### PR TITLE
fixtures: users following personas templates

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -2,17 +2,17 @@
   {
     "$schema": "https://ils.test.rero.ch/schema/patrons/patron-v0.0.1.json",
     "birth_date": "1989-05-14",
-    "city": "Schaffhausen",
+    "city": "Aosta",
     "email": "reroilstest@gmail.com",
     "first_name": "Astrid",
     "is_patron": false,
     "is_staff": true,
     "last_name": "M\u00fcller",
-    "member_pid": "1",
+    "member_pid": "4",
     "password": "123456",
-    "phone": "+41324993597",
-    "postal_code": "8200",
-    "street": "Spitalstrasse, 112"
+    "phone": "+39324993597",
+    "postal_code": "11100",
+    "street": "Viale Rue Gran Paradiso, 44"
   },
   {
     "$schema": "https://ils.test.rero.ch/schema/patrons/patron-v0.0.1.json",
@@ -48,7 +48,7 @@
     "$schema": "https://ils.test.rero.ch/schema/patrons/patron-v0.0.1.json",
     "barcode": "2050124311",
     "birth_date": "1969-06-07",
-    "city": "La Chaux-de-Fonds",
+    "city": "Aosta",
     "email": "reroilstest+simonetta@gmail.com",
     "first_name": "Simonetta",
     "is_patron": true,
@@ -56,15 +56,15 @@
     "last_name": "Casalini",
     "password": "123456",
     "patron_type": "standard_user",
-    "phone": "+41324993585",
-    "postal_code": "2300",
-    "street": "Avenue Leopold-Robert, 132"
+    "phone": "+39324993585",
+    "postal_code": "11100",
+    "street": "Via Croix Noire 3"
   },
   {
     "$schema": "https://ils.test.rero.ch/schema/patrons/patron-v0.0.1.json",
     "barcode": "2030124287",
     "birth_date": "2004-10-11",
-    "city": "Sion",
+    "city": "Aosta",
     "email": "reroilstest+helder@gmail.com",
     "first_name": "Helder",
     "is_patron": true,
@@ -72,24 +72,23 @@
     "last_name": "de Figueiredo Santos",
     "password": "123456",
     "patron_type": "standard_user",
-    "postal_code": "1950",
-    "street": "Rue des Aub\u00e9pines, 15"
+    "postal_code": "11100",
+    "street": "Panoramica Collinare, 47"
   },
   {
     "$schema": "https://ils.test.rero.ch/schema/patrons/patron-v0.0.1.json",
-    "barcode": "2030155308",
     "birth_date": "1969-02-01",
-    "city": "V\u00e9rossaz",
+    "city": "Avise",
     "email": "reroilstest+virgile@gmail.com",
     "first_name": "Virgile",
-    "is_patron": true,
-    "is_staff": false,
     "last_name": "Charbonnet",
+    "is_patron": false,
+    "is_staff": true,
+    "member_pid": "4",
     "password": "123456",
-    "patron_type": "standard_user",
-    "phone": "+41244857275",
-    "postal_code": "1891",
-    "street": "Chemin Vers-Chez-Borr\u00e9, 172"
+    "phone": "+39244857275",
+    "postal_code": "11010",
+    "street": "Frazione Plan"
   },
   {
     "$schema": "https://ils.test.rero.ch/schema/patrons/patron-v0.0.1.json",


### PR DESCRIPTION
* FIX: correct users with personas data
* BETTER: adapt users data to the organization fixture (Aoste)

Signed-off-by: Igor Milhit <igor.milhit@rero.ch>
Co-authored-by: Nicolas Prongué <nicolas.prongue@rero.ch>

-----------------------------------------------------------------
## To test

- `pipenv run invenio fixtures importusers data/users.json -v`
- verify that
   - the address of Astrid, Virgile, Simonetta, Helder are  in "Canton Aoste"
   - that Astrid and Virgile are librarian, and Simonetta and Helder are patrons
