### PR TITLE
RECORDS: can_delete

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -54,7 +54,8 @@ from .modules.loans.utils import get_default_extension_duration, \
     get_default_extension_max_count, get_default_loan_duration, \
     is_item_available_for_checkout, is_loan_duration_valid
 from .modules.patrons.api import Patron
-from .permissions import librarian_permission_factory
+from .permissions import librarian_delete_permission_factory, \
+    librarian_permission_factory
 
 
 def _(x):
@@ -289,7 +290,7 @@ RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY = librarian_permission_factory
 RECORDS_REST_DEFAULT_UPDATE_PERMISSION_FACTORY = librarian_permission_factory
 """Default update permission factory: reject any request."""
 
-RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY = librarian_permission_factory
+RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY = librarian_delete_permission_factory
 """Default delete permission factory: reject any request."""
 
 RECORDS_REST_ENDPOINTS = dict(
@@ -303,15 +304,18 @@ RECORDS_REST_ENDPOINTS = dict(
         indexer_class=IlsRecordIndexer,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.documents.serializers:json_doc_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers:json_v1_search'
+            ),
+            'application/rero+json': (
+                'rero_ils.modules.documents.serializers:json_doc_search'
             ),
         },
         list_route='/documents/',
@@ -333,15 +337,18 @@ RECORDS_REST_ENDPOINTS = dict(
         indexer_class=ItemsIndexer,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/items/',
@@ -361,15 +368,18 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/item_types/',
@@ -389,15 +399,18 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/patrons/',
@@ -417,15 +430,18 @@ RECORDS_REST_ENDPOINTS = dict(
         indexer_class=IlsRecordIndexer,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/patron_types/',
@@ -445,15 +461,18 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/organisations/',
@@ -476,15 +495,18 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/libraries/',
@@ -505,15 +527,18 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/locations/',
@@ -532,15 +557,18 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
+                'invenio_records_rest.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/persons/',
@@ -564,20 +592,20 @@ RECORDS_REST_ENDPOINTS = dict(
         indexer_class=IlsRecordIndexer,
         search_type=None,
         record_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
-            ),
             'application/json': (
                 'rero_ils.modules.serializers' ':json_v1_response'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
 
         },
         search_serializers={
-            'application/rero+json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
             'application/json': (
                 'invenio_records_rest.serializers' ':json_v1_search'
+            ),
+            'application/can-delete+json': (
+                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
             ),
         },
         list_route='/circ_policies/',

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -199,14 +199,17 @@ class IlsRecord(Record):
 
     def delete(self, force=False, dbcommit=False, delindex=False):
         """Delete record and persistent identifier."""
-        persistent_identifier = self.get_persistent_identifier(self.id)
-        persistent_identifier.delete()
-        self = super(IlsRecord, self).delete(force=force)
-        if dbcommit:
-            self.dbcommit()
-        if delindex:
-            self.delete_from_index()
-        return self
+        if self.can_delete:
+            persistent_identifier = self.get_persistent_identifier(self.id)
+            persistent_identifier.delete()
+            self = super(IlsRecord, self).delete(force=force)
+            if dbcommit:
+                self.dbcommit()
+            if delindex:
+                self.delete_from_index()
+            return self
+        else:
+            raise IlsRecordError.NotDeleted()
 
     def update(self, data, dbcommit=False, reindex=False):
         """Update data for record."""
@@ -291,3 +294,16 @@ class IlsRecord(Record):
     def persistent_identifier(self):
         """Get Persistent Identifier."""
         return self.get_persistent_identifier(self.id)
+
+    def get_links_to_me(self):
+        """Record links."""
+        return {}
+
+    def reasons_not_to_delete(self):
+        """Record deletion reasons."""
+        return {}
+
+    @property
+    def can_delete(self):
+        """Record can be deleted."""
+        return len(self.reasons_not_to_delete()) == 0

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -78,3 +78,30 @@ class CircPolicy(IlsRecord):
             return next(result)
         except StopIteration:
             return None
+
+    def get_non_link_reasons_to_not_delete(self):
+        """Get reasons other than links not to delete a record."""
+        others = {}
+        is_default = self.get('is_default')
+        if is_default:
+            others['is_default'] = is_default
+        has_settings = self.get('settings')
+        if has_settings:
+            others['has_settings'] = has_settings
+        return others
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        others = self.get_non_link_reasons_to_not_delete()
+        links = self.get_links_to_me()
+        if others:
+            cannot_delete['others'] = others
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -396,11 +396,6 @@ class Item(IlsRecord):
         return (self.status == ItemStatus.ON_SHELF) and \
             self.number_of_requests() == 0
 
-    @property
-    def can_delete(self):
-        """Record can be deleted."""
-        return self.available
-
     def get_item_end_date(self):
         """Get item due date a given item."""
         loan = get_loan_for_item(self.pid)
@@ -607,3 +602,31 @@ class Item(IlsRecord):
         return self, {
             LoanAction.RETURN_MISSING: None
         }
+
+    def get_number_of_loans(self):
+        """Get number of loans."""
+        search = search_by_pid(
+            item_pid=self.pid,
+            exclude_states=[
+                'CANCELLED',
+                'ITEM_RETURNED',
+            ]
+        )
+        results = search.source().count()
+        return results
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        loans = self.get_number_of_loans()
+        if loans:
+            links['loans'] = loans
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -239,3 +239,36 @@ class Library(IlsRecord):
             counting += 1
             date = self.next_open(date=date)
         return date
+
+    def get_number_of_librarians(self):
+        """Get number of librarians."""
+        from ..patrons.api import PatronsSearch
+        results = PatronsSearch().filter(
+            'term', library__pid=self.pid).filter(
+            'term', roles='librarian').source().count()
+        return results
+
+    def get_number_of_locations(self):
+        """Get number of locations."""
+        results = LocationsSearch().filter(
+            'term', library__pid=self.pid).source().count()
+        return results
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        locations = self.get_number_of_locations()
+        if locations:
+            links['locations'] = locations
+        librarians = self.get_number_of_librarians()
+        if librarians:
+            links['patrons'] = librarians
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -77,3 +77,26 @@ class Location(IlsRecord):
         from ..libraries.api import Library
         library_pid = self.replace_refs()['library']['pid']
         return Library.get_record_by_pid(library_pid)
+
+    def get_number_of_items(self):
+        """Get number of items."""
+        from ..items.api import ItemsSearch
+        results = ItemsSearch().filter(
+            'term', location__pid=self.pid).source().count()
+        return results
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        items = self.get_number_of_items()
+        if items:
+            links['items'] = items
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/organisations/api.py
+++ b/rero_ils/modules/organisations/api.py
@@ -60,3 +60,25 @@ class Organisation(IlsRecord):
             .scan()
         for library in results:
             yield Library.get_record_by_pid(library.pid)
+
+    def get_number_of_libraries(self):
+        """Get number of libraries."""
+        results = LibrariesSearch().filter(
+            'term', organisation__pid=self.pid).source().count()
+        return results
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        libraries = self.get_number_of_libraries()
+        if libraries:
+            links['libraries'] = libraries
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/serializers.py
+++ b/rero_ils/modules/serializers.py
@@ -43,6 +43,7 @@ class ReroIlsSerializer(JSONSerializer):
         """
         if request and request.args.get('resolve'):
             record = record.replace_refs()
+
         return super(
             ReroIlsSerializer, self).serialize(
                 pid, record, links_factory, **kwargs)
@@ -68,6 +69,7 @@ class ReroIlsSerializer(JSONSerializer):
             links=links or {},
             aggregations=search_result.get('aggregations', dict()),
         )
+
         with current_app.app_context():
             facet_config = current_app.config.get(
                 'RERO_ILS_APP_CONFIG_FACETS', {}
@@ -84,11 +86,82 @@ class ReroIlsSerializer(JSONSerializer):
                         results['aggregations'][aggregation]['expand'] = True
             except Exception:
                 pass
+
         return json.dumps(results, **self._format_args())
 
 
 json_v1 = ReroIlsSerializer(RecordSchemaJSONV1)
 """JSON v1 serializer."""
 
-json_v1_search = search_responsify(json_v1, 'application/rero+json')
-json_v1_response = record_responsify(json_v1, 'application/rero+json')
+json_v1_search = search_responsify(json_v1, 'application/json')
+json_v1_response = record_responsify(json_v1, 'application/json')
+
+
+class ReroIlsCanDeleteSerializer(JSONSerializer):
+    """Mixin serializing records as JSON."""
+
+    def serialize(self, pid, record, links_factory=None, **kwargs):
+        """Serialize a single record and persistent identifier.
+
+        :param pid: Persistent identifier instance.
+        :param record: Record instance.
+        :param links_factory: Factory function for record links.
+        """
+        if request and request.args.get('resolve'):
+            record = record.replace_refs()
+        if not record.can_delete:
+            record['cannot_delete'] = record.reasons_not_to_delete()
+
+        return super(
+            ReroIlsCanDeleteSerializer, self).serialize(
+                pid, record, links_factory, **kwargs)
+
+    def serialize_search(self, pid_fetcher, search_result, links=None,
+                         item_links_factory=None, **kwargs):
+        """Serialize a search result.
+
+        :param pid_fetcher: Persistent identifier fetcher.
+        :param search_result: Elasticsearch search result.
+        :param links: Dictionary of links to add to response.
+        """
+        results = dict(
+            hits=dict(
+                hits=[self.transform_search_hit(
+                    pid_fetcher(hit['_id'], hit['_source']),
+                    hit,
+                    links_factory=item_links_factory,
+                    **kwargs
+                ) for hit in search_result['hits']['hits']],
+                total=search_result['hits']['total'],
+            ),
+            links=links or {},
+            aggregations=search_result.get('aggregations', dict()),
+        )
+
+        with current_app.app_context():
+            facet_config = current_app.config.get(
+                'RERO_ILS_APP_CONFIG_FACETS', {}
+            )
+            try:
+                type = search_result['hits']['hits'][0]['_index'].split('-')[0]
+                for aggregation in results.get('aggregations'):
+                    facet_config_type = facet_config.get(type, {})
+                    facet_config_type_expand = facet_config_type.get(
+                        'expand', ''
+                    )
+                    results['aggregations'][aggregation]['expand'] = False
+                    if aggregation in facet_config_type_expand:
+                        results['aggregations'][aggregation]['expand'] = True
+            except Exception:
+                pass
+
+        return json.dumps(results, **self._format_args())
+
+
+can_delete_json_v1 = ReroIlsCanDeleteSerializer(RecordSchemaJSONV1)
+"""JSON v1 serializer."""
+
+can_delete_json_v1_search = search_responsify(
+    can_delete_json_v1, 'application/can-delete+json')
+can_delete_json_v1_response = record_responsify(
+    can_delete_json_v1, 'application/can-delete+json')

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -25,7 +25,7 @@
 """Permissions for this module."""
 
 
-from flask import abort
+from flask import abort, jsonify
 from flask_login import current_user
 from flask_principal import RoleNeed
 from invenio_access.permissions import DynamicPermission
@@ -64,6 +64,13 @@ def can_edit(user=None):
 def librarian_permission_factory(record, *args, **kwargs):
     """User has editor role."""
     return librarian_permission
+
+
+def librarian_delete_permission_factory(record, *args, **kwargs):
+    """User can delete record."""
+    if record.can_delete:
+        return librarian_permission
+    return abort(403)
 
 
 def admin_permission_factory(admin_view):

--- a/rero_ils/templates/rero_ils/_editor_button_actions.html
+++ b/rero_ils/templates/rero_ils/_editor_button_actions.html
@@ -39,5 +39,3 @@
 <div id="source-{{ json.id }}" class="card bg-light collapse mt-2">
   <pre class="mb-0 p-2 text-muted">{{ json.dumps()|tojson_pretty }}</pre>
 </div>
-
-

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -1,0 +1,121 @@
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Tests Serializers."""
+
+
+import mock
+from flask import url_for
+from utils import VerifyRecordPermissionPatch, get_json
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_circ_policies(
+    client,
+    organisation,
+    circ_policy,
+    can_delete_json_header,
+    json_header
+):
+    """Test record retrieval."""
+    item_url = url_for(
+        'invenio_records_rest.cipo_item',
+        pid_value='cipo1'
+    )
+
+    res = client.get(item_url, headers=can_delete_json_header)
+
+    assert res.status_code == 200
+    data = get_json(res)['metadata']
+    assert 'cannot_delete' in data
+    assert data.get('cannot_delete') == {'others': {'is_default': True}}
+
+    res = client.get(item_url, headers=json_header)
+
+    assert res.status_code == 200
+    assert 'cannot_delete' not in get_json(res)['metadata']
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_documents(
+    client,
+    document,
+    item_on_shelf,
+    can_delete_json_header,
+    json_header
+):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.doc_item', pid_value='doc1')
+
+    res = client.get(item_url, headers=can_delete_json_header)
+    assert res.status_code == 200
+
+    data = get_json(res)['metadata']
+    assert 'cannot_delete' in data
+    assert data.get('cannot_delete') == {'links': {'items': 1}}
+
+    res = client.get(item_url, headers=json_header)
+    assert res.status_code == 200
+    assert 'cannot_delete' not in get_json(res)['metadata']
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_item_types(
+    client,
+    item_type,
+    can_delete_json_header,
+    json_header
+):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.itty_item', pid_value='itty1')
+
+    res = client.get(item_url, headers=can_delete_json_header)
+    assert res.status_code == 200
+
+    data = get_json(res)['metadata']
+    assert 'cannot_delete' in data
+    assert data.get('cannot_delete') == {'links': {'items': 1}}
+
+    res = client.get(item_url, headers=json_header)
+    assert res.status_code == 200
+    assert 'cannot_delete' not in get_json(res)['metadata']
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_items(
+    client,
+    item_on_shelf,
+    json_header,
+    can_delete_json_header
+):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.item_item', pid_value='item2')
+
+    res = client.get(item_url, headers=can_delete_json_header)
+    assert res.status_code == 200
+
+    assert 'cannot_delete' not in get_json(res)['metadata']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -400,6 +400,15 @@ def json_header():
     ]
 
 
+@pytest.fixture(scope="session")
+def can_delete_json_header():
+    """."""
+    return [
+        ('Accept', 'application/can-delete+json'),
+        ('Content-Type', 'application/json')
+    ]
+
+
 @pytest.fixture(scope='module')
 def app_config(app_config):
     """Create temporary instance dir for each test."""

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -74,3 +74,18 @@ def test_circ_policy_exist_name_and_organisation_pid(circ_policy):
         cipo.get('name'), cipo.get('organisation', {}).get('pid'))
     assert not CircPolicy.exist_name_and_organisation_pid(
         'not exists yet', cipo.get('organisation', {}).get('pid'))
+
+
+def test_circ_policy_can_not_delete(circ_policy):
+    """Test can not delete"""
+    others = circ_policy.get_non_link_reasons_to_not_delete()
+    assert others['is_default']
+    assert not circ_policy.can_delete
+
+
+def test_circ_policy_can_delete(app, circ_policy_data_tmp):
+    """Test can delete"""
+    circ_policy_data_tmp['is_default'] = False
+    cipo = CircPolicy.create(circ_policy_data_tmp, delete_pid=True)
+    assert cipo.get_links_to_me() == {}
+    assert cipo.can_delete

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -59,3 +59,17 @@ def test_document_es_mapping(es_clear, db, organisation,
         delete_pid=True
     )
     assert mapping == get_mapping(search.Meta.index)
+
+
+def test_document_can_not_delete(document, item_on_shelf):
+    """Test can not delete"""
+    links = document.get_links_to_me()
+    assert links['items'] == 1
+    assert not document.can_delete
+
+
+def test_document_can_delete(app, document_data_tmp):
+    """Test can delete"""
+    document = Document.create(document_data_tmp, delete_pid=True)
+    assert document.get_links_to_me() == {}
+    assert document.can_delete

--- a/tests/ui/item_types/test_item_types_api.py
+++ b/tests/ui/item_types/test_item_types_api.py
@@ -74,3 +74,17 @@ def test_item_type_get_pid_by_name(item_type):
     """."""
     assert not ItemType.get_pid_by_name('no exists')
     assert ItemType.get_pid_by_name('standard') == 'itty1'
+
+
+def test_item_type_can_not_delete(item_type, item_on_shelf):
+    """Test can not delete"""
+    links = item_type.get_links_to_me()
+    assert links['items'] == 1
+    assert not item_type.can_delete
+
+
+def test_item_type_can_delete(app, item_type_data_tmp):
+    """Test can delete"""
+    itty = ItemType.create(item_type_data_tmp, delete_pid=True)
+    assert itty.get_links_to_me() == {}
+    assert itty.can_delete

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -47,6 +47,7 @@ def test_item_create(db, es_clear, item_on_loan_data_tmp):
     item = Item.create(item_on_loan_data_tmp, delete_pid=True)
     assert item == item_on_loan_data_tmp
     assert item.get('pid') == '1'
+    assert item.can_delete
 
     item = Item.get_record_by_pid('1')
     assert item == item_on_loan_data_tmp
@@ -69,3 +70,9 @@ def test_item_es_mapping(es_clear, db, document, location, item_type,
         delete_pid=True
     )
     assert mapping == get_mapping(search.Meta.index)
+
+
+def test_item_can_delete(item_on_shelf):
+    """Test can delete"""
+    assert item_on_shelf.get_links_to_me() == {}
+    assert item_on_shelf.can_delete

--- a/tests/ui/libraries/test_libraries_api.py
+++ b/tests/ui/libraries/test_libraries_api.py
@@ -87,3 +87,9 @@ def test_libraries_is_open(library):
     ) == parser.parse('2018-12-17')
 
     assert not library.is_open(date=saturday)
+
+
+def test_library_can_delete(library):
+    """Test can  delete"""
+    assert library.get_links_to_me() == {}
+    assert library.can_delete

--- a/tests/ui/locations/test_locations_api.py
+++ b/tests/ui/locations/test_locations_api.py
@@ -64,3 +64,9 @@ def test_location_get_all_pickup_locations(es, db, library, location):
     """."""
     locations = Location.get_pickup_location_pids()
     assert list(locations)[0] == location.pid
+
+
+def test_location_can_delete(location):
+    """Test can delete"""
+    assert location.get_links_to_me() == {}
+    assert location.can_delete

--- a/tests/ui/organisations/test_organisations_api.py
+++ b/tests/ui/organisations/test_organisations_api.py
@@ -36,11 +36,14 @@ def test_organisation_libararies(organisation, library):
     assert list(organisation.get_libraries()) == [library]
 
 
-def test_organisation_create(base_app, db, organisation_data):
+def test_organisation_create(app, db, organisation_data):
     """Test organisation creation."""
     org = Organisation.create(organisation_data, delete_pid=True)
     assert org == organisation_data
     assert org.get('pid') == '1'
+
+    assert org.get_links_to_me() == {}
+    assert org.can_delete
 
     org = Organisation.get_record_by_pid('1')
     assert org == organisation_data

--- a/tests/ui/organisations/test_organisations_jsonresolver.py
+++ b/tests/ui/organisations/test_organisations_jsonresolver.py
@@ -29,7 +29,7 @@ from invenio_records.api import Record
 from jsonref import JsonRefError
 
 
-def test_organisations_jsonresolver(tmp_organisation):
+def test_organisations_jsonresolver(app, tmp_organisation):
     """."""
     rec = Record.create({
         'organisation': {'$ref': 'https://ils.rero.ch/api/organisations/1'}

--- a/tests/ui/patron_types/test_patron_types_api.py
+++ b/tests/ui/patron_types/test_patron_types_api.py
@@ -68,3 +68,9 @@ def test_patron_type_exist_name_and_organisation_pid(patron_type):
         ptty.get('name'), ptty.get('organisation', {}).get('pid'))
     assert not PatronType.exist_name_and_organisation_pid(
         'not exists yet', ptty.get('organisation', {}).get('pid'))
+
+
+def test_patron_type_can_delete(patron_type):
+    """Test can delete"""
+    assert patron_type.get_links_to_me() == {}
+    assert patron_type.can_delete

--- a/tests/ui/patron_types/test_patron_types_jsonresolver.py
+++ b/tests/ui/patron_types/test_patron_types_jsonresolver.py
@@ -29,7 +29,7 @@ from invenio_records.api import Record
 from jsonref import JsonRefError
 
 
-def test_patron_types_jsonresolver(tmp_patron_type):
+def test_patron_types_jsonresolver(app, tmp_patron_type):
     """."""
     rec = Record.create({
         'patron_type': {'$ref': 'https://ils.rero.ch/api/patron_types/1'}

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -32,10 +32,10 @@ from rero_ils.modules.patrons.api import Patron, PatronsSearch, \
     patron_id_fetcher
 
 
-def test_patron_create(base_app, roles, user_librarian_data_tmp,
+def test_patron_create(app, roles, user_librarian_data_tmp,
                        mailbox):
     """Test Patron creation."""
-    ds = base_app.extensions['invenio-accounts'].datastore
+    ds = app.extensions['invenio-accounts'].datastore
     email = user_librarian_data_tmp.get('email')
     assert not ds.find_user(email=email)
     assert len(mailbox) == 0
@@ -109,3 +109,9 @@ def test_get_patron(user_librarian):
     class user:
         email = patron.get('email')
     assert Patron.get_patron_by_user(user) == patron
+
+
+def test_user_librarian_can_delete(user_librarian):
+    """Test can  delete"""
+    assert user_librarian.get_links_to_me() == {}
+    assert user_librarian.can_delete


### PR DESCRIPTION
NEW: Implement global can_delete

Signed-off-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

To Test:

get the PR branch
./run_tests.sh

- Nothing really to test because frontend implementation is planned in Taiga# 775 
- Interface, try to delete any document having items, you should get exception "IlsRecordError.NotDeleted"