### PR TITLE
CIRCULATION: link from item details to circ UI

### DIFF
--- a/rero_ils/modules/items/templates/rero_ils/detailed_view_items.html
+++ b/rero_ils/modules/items/templates/rero_ils/detailed_view_items.html
@@ -92,7 +92,7 @@
                     {% set patron_name = patron.first_name + ' ' + patron.last_name + ' - ' + patron.barcode %}
                     <tr>
                       <td>
-                        <a href="{{ url_for('circulation.index', path='checkinout?patron=' + patron.get('barcode')) }}">{{ patron_name }}</ a>
+                        <a href="{{ url_for('circulation.index') + 'checkinout?patron=' + patron.get('barcode')}}">{{ patron_name }}</a>
                       </td>
                       <td>
                         {{ holding.end_date|format_date(
@@ -137,7 +137,7 @@
                       <tr>
                         <td>
                           {% if patron %}
-                            <a href="{{ url_for('circulation.index', path='checkinout?patron=' + patron.get('barcode')) }}">{{ patron_name }}</a>
+                            <a href="{{ url_for('circulation.index') + 'checkinout?patron=' + patron.get('barcode')}}">{{ patron_name }}</a>
                           {% else %}
                             {{ _('No patron found!') }}
                           {% endif %}


### PR DESCRIPTION
* FIX Fixes link between item details view and circulation UI

closes #234

Signed-off-by: Aly Badr <aly.badr@rero.ch>

## Tests
- Go to the item detail view of a checked-out or requested item  and click on the patron name and make sure it will take you to the CIRC UI page
