### PR TITLE
Circulation UI: Checkout possible according to circ policy

### DIFF
--- a/ui/src/app/circulation/main-checkin-checkout/main-checkin-checkout.component.ts
+++ b/ui/src/app/circulation/main-checkin-checkout/main-checkin-checkout.component.ts
@@ -136,8 +136,7 @@ export class MainCheckinCheckoutComponent implements OnInit, NoPendingChange {
             if (newItem.canLoan(this.patron) === false) {
               this.alertsService.addAlert('info', _('item is unavailable!'));
             } else {
-
-              if (newItem.actions === ['no']) {
+              if (newItem.actions.length === 1 && newItem.actions.indexOf('no') > -1) {
                 this.alertsService.addAlert('info', _('no action possible on this item!'));
               } else {
                 newItem.currentAction = ItemAction.checkout;


### PR DESCRIPTION
* FIX Fixes error when scanning a no-checkout item in CIRC UI
* closes #233

Signed-off-by: Aly Badr <aly.badr@rero.ch>

** TESTS

- re deploy angular app
- login as a librarian and visit http://localhost:5000/admin/circulation/checkinout?patron=2050124311
- scan an item barcode with item type "No Checkout"
- you will receive the following message "no action possible on this item!"

