### PR TITLE
admin: field description not mandatory

### DIFF
--- a/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
+++ b/rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json
@@ -8,7 +8,6 @@
     "$schema",
     "pid",
     "name",
-    "description",
     "organisation",
     "is_default"
   ],

--- a/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
@@ -8,7 +8,6 @@
     "$schema",
     "pid",
     "name",
-    "description",
     "organisation"
   ],
   "properties": {

--- a/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json
@@ -8,7 +8,6 @@
     "$schema",
     "pid",
     "name",
-    "description",
     "organisation"
   ],
   "properties": {

--- a/ui/src/app/records/custom-editor/circulation-settings/circulation-policy-form.service.ts
+++ b/ui/src/app/records/custom-editor/circulation-settings/circulation-policy-form.service.ts
@@ -49,9 +49,7 @@ export class CirculationPolicyFormService {
         Validators.required,
         Validators.minLength(2)
       ]],
-      description: [null, [
-        Validators.required
-      ]],
+      description: [],
       allow_requests: [true],
       allow_checkout: [true],
       checkout_duration: [7],

--- a/ui/src/app/records/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.html
+++ b/ui/src/app/records/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.html
@@ -29,19 +29,13 @@
     </div>
   </div>
   <div class="form-group row">
-    <label for="description" class="col-sm-2 col-form-label required" translate>Description</label>
+    <label for="description" class="col-sm-2 col-form-label" translate>Description</label>
     <div class="col-sm-10">
       <input
         class="form-control"
         id="description"
         formControlName="description"
-        required
       >
-      <div *ngIf="description.invalid && (description.dirty || description.touched)" class="text-danger pt-1">
-        <div *ngIf="description.errors.required" translate>
-          Description is required.
-        </div>
-      </div>
     </div>
   </div>
   <div class="form-group row">


### PR DESCRIPTION
* BETTER Makes description fields for patron types, item types and circulation policies not required.
* FIX Closes #224

Signed-off-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>