### PR TITLE
circulation: possibility to check-out in-transit items

### DIFF
--- a/ui/src/app/circulation/items.ts
+++ b/ui/src/app/circulation/items.ts
@@ -133,17 +133,17 @@ export class Item {
       }
       return ItemAction.no;
     }
-
+    // should rely on backend and delete this function
     public canLoan(patron) {
       if (!this.available) {
-        if (this.status === ItemStatus.AT_DESK
+        if ((this.status === ItemStatus.AT_DESK || this.status === ItemStatus.IN_TRANSIT)
             && patron
             && this.pending_loans
             && this.pending_loans.length
             && this.pending_loans[0].patron_pid === patron.pid) {
           return true;
       }
-      return false;
+      return true;
     }
     // available
     return true;


### PR DESCRIPTION
* FIX Fixes #230: allows checkout of in-transit items.

Signed-off-by: Aly Badr <aly.badr@rero.ch>

This two scenarios works:

- checkout out an item (having no requests) with loan_status= ITEM_IN_TRANSIT_TO_HOUSE to any patron.

- checkout out an item with loan_status= ITEM_IN_TRANSIT_FOR_PICKUP to any requested patron from any checkout library.