### PR TITLE
Delete add item button in the document search view

### DIFF
--- a/ui/src/app/records/search/brief-view/documents-brief-view.component.ts
+++ b/ui/src/app/records/search/brief-view/documents-brief-view.component.ts
@@ -50,10 +50,6 @@ import { _, AlertsService } from '@app/core';
       <i class="fa fa-caret-down" aria-hidden="true"></i> <span translate> items</span>
     </a>
     <span *ngIf="!(record.metadata.items && record.metadata.items.length)" translate>no item</span>
-     <a class="ml-2 text-secondary" routerLinkActive="active"
-        [queryParams]="{document: record.metadata.pid}" [routerLink]="['/records/items/new']">
-      <i class="fa fa-plus" aria-hidden="true"></i> {{ 'Add' | translate }}
-    </a>
   </section>
   <ul *ngIf="record.metadata.items"
       class="collapse list-group list-group-flush"


### PR DESCRIPTION
* FIX removes button add item.

Signed-off-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

How to test:
- go to document brief view (admin) and note the deletion of the button