### PR TITLE
circulation: patron request blocks item renewals

### DIFF
--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -399,7 +399,7 @@ class Item(IlsRecord):
                     circ_policy.get('renewal_duration'),
                     self.library_pid
                 )
-            ):
+            ) or self.number_of_requests():
                 data['action_validated'] = False
         if action == 'checkout':
             if not circ_policy.get('allow_checkout'):

--- a/tests/api/test_items_rest.py
+++ b/tests/api/test_items_rest.py
@@ -1373,7 +1373,7 @@ def test_items_in_transit(client, user_librarian_no_email,
                           location, item_type, store_location,
                           item_on_shelf, json_header,
                           circ_policy):
-    """."""
+    """Test item in-transit scenarios."""
     login_user_via_session(client, user_librarian_no_email.user)
     item = item_on_shelf
     item_pid = item.pid


### PR DESCRIPTION
* FIX Fixes #38: renewal is not possible on requested items

Signed-off-by: Aly Badr aly.badr@rero.ch

- UI: no more possible to extend a requested item.

