### PR TITLE
user interface: pickup library instead of pickup location

### DIFF
--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -104,9 +104,11 @@ class Loan(IlsRecord):
 
         if loan.get('pickup_location_pid'):
             location = Location.get_record_by_pid(loan['pickup_location_pid'])
+            library = location.get_library()
             loc_data = location.dumps()
             data['pickup_location'] = {}
             data['pickup_location']['name'] = loc_data['name']
+            data['pickup_location']['library_name'] = library.get('name')
         return data
 
     def build_url_action_for_pid(self, action):

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -21,7 +21,7 @@
           <a class="nav-link active" href="#checkouts" data-toggle="tab"
              id="checkouts-tab" title="{{ _('Checkouts') }}" role="tab"
              aria-controls="checkouts" aria-selected="true">
-            {{ _('Checkouts') }} ({{ loans|length }})
+            {{ _('Checkouts') }} ({{ checkouts|length }})
           </a>
         </li>
         <li class="nav-item">
@@ -43,8 +43,8 @@
     </header>
     <article class="tab-content">
       <section class="tab-pane show active py-2" id="checkouts" role="tabpanel" aria-labelledby="checkouts-tab">
-        {% if loans|length > 0 %}
-            {{ build_table('checkouts', loans) }}
+        {% if checkouts|length > 0 %}
+            {{ build_table('checkouts', checkouts) }}
         {% else %}
             <p>{{ _('No loan') }}</p>
         {% endif %}
@@ -63,28 +63,26 @@
   </article>
 {%- endblock body %}
 
-{% macro build_table(type, documents) %}
+{% macro build_table(type, loans) %}
 <div class="table-responsive">
     <table class="table table-striped table-sm">
         <thead>
             <tr>
                 <th class="col-md-6 border-top-0" scope="col">{{ _('Title') }}</th>
                 <th class="col-md-2 border-top-0" scope="col">{{ _('Call Number') }}</th>
+                {% if type != 'checkouts' %}
                 <th class="col-md-2 border-top-0" scope="col">
-                  {% if 'checkout' == type %}
-                    {{ _('Belongs to') }}
-                  {% else %}
                     {{ _('Pickup library') }}
-                  {% endif %}
                 </th>
+                {% endif %}
                 <th class="col-md-2 border-top-0" scope="col">
-                    {% if 'checkouts' == type %}
+                    {% if type == 'checkouts' %}
                         {{ _('Due date') }}
                     {% else %}
                         {{ _('Reservation date') }}
                     {% endif %}
                 </th>
-                {% if 'checkouts' == type %}
+                {% if type == 'checkouts' %}
                 <th class="col-md-1 border-top-0" scope="col">
                         {{ _('Renewals') }}
                 </th>
@@ -92,33 +90,31 @@
             </tr>
         </thead>
         <tbody>
-            {% for document in documents %}
+            {% for loan in loans %}
             <tr>
-                <td>{{ document.title }}</td>
-                <td>{{ document.call_number }}</td>
+                <td>{{ loan.document_title }}</td>
+                <td>{{ loan.item_call_number }}</td>
+                {% if type != 'checkouts' %}
                 <td>
-                    {% if 'checkouts' == type %}
-                      {{ document.library_name}}
-                    {% else %}
-                        {{ document.library }}
-                    {% endif %}
+                  {{ loan.pickup_library_name }}
                 </td>
+                {% endif %}
                 <td>
-                    {% if 'checkouts' == type %}
-                      {{ document.end_date|format_date(
+                    {% if type == 'checkouts' %}
+                      {{ loan.end_date|format_date(
                           format='short_date',
                           locale=current_i18n.locale.language
                       )}}
                     {% else %}
-                        {{ document.transaction_date|format_date(
+                        {{ loan.transaction_date|format_date(
                           format='short_date',
                           locale=current_i18n.locale.language
                       )}}
                     {% endif %}
                 </td>
-                {% if 'checkouts' == type %}
+                {% if type == 'checkouts' %}
                 <td>
-                    {{ document.extension_count }}
+                    {{ loan.extension_count }}
                 </td>
                 {% endif %}
             </tr>

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -128,13 +128,9 @@ def profile():
         for loan in loans:
             item_pid = loan.get('item_pid')
             item = Item.get_record_by_pid(item_pid).replace_refs()
-            location = Location.get_record_by_pid(
-                item['location']['pid']).replace_refs()
-            library = Library.get_record_by_pid(location['library']['pid'])
             document = Document.get_record_by_pid(item['document']['pid'])
-            loan['title'] = document['title']
-            loan['call_number'] = item['call_number']
-            loan['library'] = library['name']
+            loan['document_title'] = document['title']
+            loan['item_call_number'] = item['call_number']
             if loan['state'] == 'ITEM_ON_LOAN':
                 checkouts.append(loan)
             elif loan['state'] in (
@@ -144,12 +140,13 @@ def profile():
             ):
                 pickup_loc = Location.get_record_by_pid(
                     loan['pickup_location_pid'])
-                loan['pickup_location_name'] = pickup_loc.get('name', '')
+                loan['pickup_library_name'] = \
+                    pickup_loc.get_library().get('name')
                 requests.append(loan)
     return render_template(
         'rero_ils/patron_profile.html',
         record=patron,
-        loans=checkouts,
+        checkouts=checkouts,
         pendings=requests
     )
 

--- a/ui/src/app/circulation/requested-items-list/requested-items-list.component.html
+++ b/ui/src/app/circulation/requested-items-list/requested-items-list.component.html
@@ -36,7 +36,7 @@
         </span>
       </td>
       <td class="text-right">
-        {{ item.loan.pickup_location.name }}
+        {{ item.loan.pickup_location.library_name }}
       </td>
       <td class="text-right">
         {{ item.loan.transaction_date | date :'medium' }}


### PR DESCRIPTION
* BETTER Replace pickup location by pickup library in the patron profile and circulation ui.
* BETTER Remove useless column in the patron profile.
* Changed name variable to be more clear.

Signed-off-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

### To Test
- boostrap