### PR TITLE
rest API: access restriction by organisation read, write, delete, update

### DIFF
--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -307,3 +307,10 @@ class IlsRecord(Record):
     def can_delete(self):
         """Record can be deleted."""
         return len(self.reasons_not_to_delete()) == 0
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for circulation policy."""
+        if self.get('organisation'):
+            return self.replace_refs()['organisation']['pid']
+        return None

--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -754,3 +754,9 @@ class Item(IlsRecord):
         if links:
             cannot_delete['links'] = links
         return cannot_delete
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for item."""
+        library = Library.get_record_by_pid(self.library_pid)
+        return library.organisation_pid

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -98,6 +98,16 @@ class Loan(IlsRecord):
             return True
         return False
 
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for loan."""
+        from ..items.api import Item
+
+        if self.get('item_pid'):
+            item = Item.get_record_by_pid(self.get('item_pid'))
+            return item.organisation_pid
+        return None
+
     def dumps_for_circulation(self):
         """Dumps for circulation."""
         loan = self.replace_refs()

--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -100,3 +100,16 @@ class Location(IlsRecord):
         if links:
             cannot_delete['links'] = links
         return cannot_delete
+
+    @property
+    def library_pid(self):
+        """Get library pid for location."""
+        return self.replace_refs()['library']['pid']
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for location."""
+        from ..libraries.api import Library
+
+        library = Library.get_record_by_pid(self.library_pid)
+        return library.organisation_pid

--- a/rero_ils/modules/organisations/api.py
+++ b/rero_ils/modules/organisations/api.py
@@ -82,3 +82,8 @@ class Organisation(IlsRecord):
         if links:
             cannot_delete['links'] = links
         return cannot_delete
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid ."""
+        return self.pid

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -256,3 +256,25 @@ class Patron(IlsRecord):
             return Organisation.get_record_by_pid(
                 ptty.replace_refs()['organisation']['pid'])
         return None
+
+    @property
+    def library_pid(self):
+        """Shortcut for patron library pid."""
+        if self.get('library'):
+            library_pid = self.replace_refs().get('library').get('pid')
+            return library_pid
+        return None
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for patron."""
+        from ..patron_types.api import PatronType
+
+        if self.library_pid:
+            library = Library.get_record_by_pid(self.library_pid)
+            return library.organisation_pid
+
+        if self.patron_type_pid:
+            patron_type = PatronType.get_record_by_pid(self.patron_type_pid)
+            return patron_type.organisation_pid
+        return None

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -23,6 +23,8 @@
 
 """Tests REST API item_types."""
 
+from copy import deepcopy
+
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
@@ -111,3 +113,10 @@ def test_loan_utils(client, librarian_martigny_no_email, lib_martigny,
 
     with pytest.raises(TypeError):
         assert get_last_transaction_loc_for_item()
+
+    assert loan_pending.organisation_pid
+
+    new_loan = deepcopy(loan_pending)
+    assert new_loan.organisation_pid
+    del new_loan['item_pid']
+    assert not new_loan.organisation_pid

--- a/tests/api/test_organisations_rest_api.py
+++ b/tests/api/test_organisations_rest_api.py
@@ -13,6 +13,13 @@
 
 """Tests REST API organisations."""
 
+import json
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+
 
 def test_location_can_delete(client, org_martigny, lib_martigny):
     """Test can delete an organisation."""
@@ -23,3 +30,97 @@ def test_location_can_delete(client, org_martigny, lib_martigny):
 
     reasons = org_martigny.reasons_not_to_delete()
     assert 'links' in reasons
+
+
+def test_organisation_secure_api(client, json_header, org_martigny,
+                                 librarian_martigny_no_email,
+                                 librarian_sion_no_email):
+    """Test organisation secure api access."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.org_item',
+                         pid_value=org_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for('invenio_records_rest.org_item',
+                         pid_value=org_martigny.pid)
+
+
+def test_organisation_secure_api_create(client, json_header, org_martigny,
+                                        librarian_martigny_no_email,
+                                        librarian_sion_no_email,
+                                        org_martigny_data):
+    """Test organisation secure api create."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    post_url = url_for('invenio_records_rest.org_list')
+
+    del org_martigny_data['pid']
+    res = client.post(
+        post_url,
+        data=json.dumps(org_martigny_data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.post(
+        post_url,
+        data=json.dumps(org_martigny_data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_organisation_secure_api_update(client, json_header, org_martigny,
+                                        librarian_martigny_no_email,
+                                        librarian_sion_no_email,
+                                        org_martigny_data):
+    """Test organisation secure api create."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.org_item',
+                         pid_value=org_martigny.pid)
+
+    data = org_martigny_data
+    data['name'] = 'New Name'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_organisation_secure_api_delete(client, json_header, org_martigny,
+                                        librarian_martigny_no_email,
+                                        librarian_sion_no_email,
+                                        org_martigny_data):
+    """Test organisation secure api delete."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.org_item',
+                         pid_value=org_martigny.pid)
+
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.delete(record_url)
+    assert res.status_code == 403

--- a/tests/api/test_patrons_views.py
+++ b/tests/api/test_patrons_views.py
@@ -24,6 +24,7 @@
 """Tests Views for patrons."""
 
 import json
+from copy import deepcopy
 
 import mock
 import pytest
@@ -48,6 +49,16 @@ def test_patron_can_delete(client, librarian_martigny_no_email,
     item = item_lib_martigny
     patron = patron_martigny_no_email
     location = loc_public_martigny
+
+    assert librarian_martigny_no_email.patron_type_pid == 'ptty1'
+    assert patron_martigny_no_email.patron_type_pid == 'ptty1'
+
+    assert patron_martigny_no_email.organisation_pid == 'org1'
+
+    data = deepcopy(patron_martigny_no_email)
+    del data['patron_type']
+    assert not data.get_organisation()
+
     # request
     res = client.post(
         url_for('api_item.librarian_request'),

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -91,6 +91,7 @@ def patron_martigny_no_email(
         patron_type_children_martigny,
         patron_martigny_data):
     """Create Martigny patron without sending reset password instruction."""
+    patron_martigny_data['roles'] == ['patron']
     ptrn = Patron.create(
         data=patron_martigny_data,
         delete_pid=False,
@@ -109,6 +110,7 @@ def librarian_martigny_no_email(
         patron_type_children_martigny,
         librarian_martigny_data):
     """Create Martigny librarian without sending reset password instruction."""
+    librarian_martigny_data['roles'] == ['librarian']
     ptrn = Patron.create(
         data=librarian_martigny_data,
         delete_pid=False,


### PR DESCRIPTION
* NEW Restricts access to APIs for users of same organisation.

Signed-off-by: Aly Badr <aly.badr@rero.ch>

* ./run_tests.sh
* localhost:5000/api/< record_type >/ < pid > 
read/write/delete/update is now available only for records of logged users organisation