### PR TITLE
views: disabling edit/delete buttons for items of other organisation

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -210,7 +210,7 @@
                 {% endif %}
               </div>
               <div class="col-12 col-sm-9 d-flex flex-column">
-                {% if current_user|can_edit %}
+                {% if current_user |can_access_item(item) %}
                   {% with
                     href_update=url_for('records/items.index', path=item.pid, document=record.pid),
                     href_delete='/api/items/' + item.pid,

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -44,7 +44,7 @@ from .mef_persons.receivers import publish_api_harvested_records
 from .patrons.listener import enrich_patron_data, listener_item_at_desk
 from ..filter import admin_menu_is_visible, format_date_filter, jsondumps, \
     resource_can_create, text_to_id, to_pretty_json
-from ..permissions import can_edit
+from ..permissions import can_access_item, can_edit
 
 
 class REROILSAPP(object):
@@ -57,6 +57,10 @@ class REROILSAPP(object):
             app.add_template_filter(format_date_filter, name='format_date')
             app.add_template_filter(to_pretty_json, name='tojson_pretty')
             app.add_template_filter(can_edit, name='can_edit')
+            app.add_template_filter(
+                can_access_item,
+                name='can_access_item'
+            )
             app.add_template_filter(text_to_id, name='text_to_id')
             app.add_template_filter(jsondumps, name='jsondumps')
             app.add_template_filter(

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -48,6 +48,17 @@ def login_and_librarian():
 librarian_permission = DynamicPermission(RoleNeed('librarian'))
 
 
+def can_access_item(user=None, item=None):
+    """User has librarian role and logged in and in same item organisation."""
+    if not user:
+        user = current_user
+    if item:
+        patron = Patron.get_patron_by_user(user)
+        if patron.organisation_pid == item.organisation_pid:
+            return user.is_authenticated and librarian_permission.can()
+    return False
+
+
 def can_edit(user=None):
     """User has editor role."""
     if not user:

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -91,7 +91,6 @@ def patron_martigny_no_email(
         patron_type_children_martigny,
         patron_martigny_data):
     """Create Martigny patron without sending reset password instruction."""
-    patron_martigny_data['roles'] == ['patron']
     ptrn = Patron.create(
         data=patron_martigny_data,
         delete_pid=False,
@@ -110,7 +109,6 @@ def librarian_martigny_no_email(
         patron_type_children_martigny,
         librarian_martigny_data):
     """Create Martigny librarian without sending reset password instruction."""
-    librarian_martigny_data['roles'] == ['librarian']
     ptrn = Patron.create(
         data=librarian_martigny_data,
         delete_pid=False,

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -1,0 +1,47 @@
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test permissions."""
+
+from utils import login_user
+from rero_ils.permissions import can_access_item
+
+
+def test_can_access_item_librarian(
+        client, json_header,
+        librarian_martigny_no_email, item_lib_martigny):
+    """Test a librarian can access an item."""
+
+    assert not can_access_item()
+    login_user(client, librarian_martigny_no_email)
+    assert not can_access_item()
+    assert can_access_item(item=item_lib_martigny)
+
+
+def test_can_access_item_patron(
+        client, json_header,
+        patron_martigny_no_email, item_lib_martigny):
+    """Test a patron can access an item."""
+
+    login_user(client, patron_martigny_no_email)
+    assert not can_access_item()
+    assert not can_access_item(item=item_lib_martigny)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,6 +27,7 @@
 import json
 
 import mock
+from invenio_accounts.testutils import login_user_via_view
 from invenio_circulation.api import get_loan_for_item
 from invenio_search import current_search
 from six.moves.urllib.parse import parse_qs, urlparse
@@ -47,6 +48,12 @@ class VerifyRecordPermissionPatch(object):
     """Verify record permissions."""
 
     status_code = 200
+
+
+def login_user(client, user):
+    """Sign in user."""
+    user.user.password_plaintext = user.get('email')
+    login_user_via_view(client, user=user.user)
 
 
 def get_json(response):


### PR DESCRIPTION
* NEW Fixes issue when edit/delete buttons are displayed for users of other organisations.

Signed-off-by: Aly Badr <aly.badr@rero.ch>

* Display a document having items from two organisations (possibly http://localhost:5000/documents/299)
* The edit/delete buttons are only displayed for items of your organisation