### PR TITLE
fix: patron persistent identifiers

### DIFF
--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -78,7 +78,7 @@ class Patron(IlsRecord):
     available_roles = ['librarian', 'patron']
 
     @classmethod
-    def create(cls, data, id_=None, delete_pid=True,
+    def create(cls, data, id_=None, delete_pid=False,
                dbcommit=False, reindex=False, **kwargs):
         """Patron record creation."""
         record = super(Patron, cls).create(

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -13,7 +13,8 @@
     "email",
     "street",
     "postal_code",
-    "city"
+    "city",
+    "roles"
   ],
   "properties": {
     "$schema": {

--- a/tests/api/test_patrons_rest.py
+++ b/tests/api/test_patrons_rest.py
@@ -35,6 +35,7 @@ from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.api import ItemStatus
 from rero_ils.modules.loans.api import Loan, LoanAction
+from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.patrons.utils import user_has_patron
 
 
@@ -139,12 +140,16 @@ def test_patrons_get(client, librarian_martigny_no_email):
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def test_patrons_post_put_delete(client, lib_martigny,
                                  patron_type_children_martigny,
-                                 librarian_martigny_data, json_header):
+                                 librarian_martigny_data, json_header,
+                                 roles):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.ptrn_item', pid_value='1')
     post_url = url_for('invenio_records_rest.ptrn_list')
     list_url = url_for('invenio_records_rest.ptrn_list', q='pid:1')
     patron_data = librarian_martigny_data
+
+    pids = len(Patron.get_all_pids())
+    uuids = len(Patron.get_all_ids())
 
     # Create record / POST
     patron_data['pid'] = '1'
@@ -159,6 +164,8 @@ def test_patrons_post_put_delete(client, lib_martigny,
         )
 
     assert res.status_code == 201
+    assert len(Patron.get_all_pids()) == pids + 1
+    assert len(Patron.get_all_ids()) == uuids + 1
 
     # Check that the returned record matches the given data
     data = get_json(res)

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -64,9 +64,6 @@ def test_patron_create(app, roles, librarian_martigny_data_tmp,
     ptrn.update({'roles': roles}, dbcommit=True)
     user_roles = [r.name for r in user.roles]
     assert set(user_roles) == set(roles)
-    del ptrn['roles']
-    ptrn.update({}, dbcommit=True)
-    assert not user.roles
     roles = Patron.available_roles
     ptrn.update({'roles': Patron.available_roles}, dbcommit=True)
     user_roles = [r.name for r in user.roles]

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -137,3 +137,12 @@ def test_patron_type(patron_schema, librarian_martigny_data_tmp):
     with pytest.raises(ValidationError):
         librarian_martigny_data_tmp['patron_type_pid'] = 25
         validate(librarian_martigny_data_tmp, patron_schema)
+
+
+def test_roles(patron_schema, librarian_martigny_data_tmp):
+    """Test roles for patron jsonschemas."""
+    validate(librarian_martigny_data_tmp, patron_schema)
+
+    with pytest.raises(ValidationError):
+        librarian_martigny_data_tmp['roles'] = 25
+        validate(librarian_martigny_data_tmp, patron_schema)


### PR DESCRIPTION
* FIX Fixes problem when patron ids are created twice.
* FIX Fixes problem when users are created with no roles.

Signed-off-by: Aly Badr <aly.badr@rero.ch>