### PR TITLE
indexing: add a custom text analyzer in ES template

### DIFF
--- a/rero_ils/es_templates/__init__.py
+++ b/rero_ils/es_templates/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 RERO.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Records Templates Elasticsearch."""
+
+
+def list_es_templates():
+    """Elasticsearch Templates path."""
+    return [
+        'rero_ils.es_templates'
+    ]

--- a/rero_ils/es_templates/v6/record.json
+++ b/rero_ils/es_templates/v6/record.json
@@ -1,0 +1,17 @@
+{
+  "index_patterns": "*",
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "global_lowercase_asciifolding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/setup
+++ b/scripts/setup
@@ -38,7 +38,9 @@ pipenv run invenio db init create
 pipenv run invenio index queue purge delete
 set -e
 pipenv run invenio index destroy --force --yes-i-know
-pipenv run invenio index init --force
+# Override index init to load templates before mapping
+pipenv run invenio utils init --force
+# pipenv run invenio index init --force
 pipenv run invenio index queue init
 # Delete invenio_circulations index
 pipenv run invenio index delete loans-loan-v1.0.0 --force --yes-i-know

--- a/setup.py
+++ b/setup.py
@@ -256,6 +256,9 @@ setup(
             'circ_policies = rero_ils.modules.circ_policies.mappings',
             'loans = rero_ils.modules.loans.mappings',
         ],
+        'invenio_search.templates': [
+            'base-record = rero_ils.es_templates:list_es_templates'
+        ],
         'invenio_celery.tasks': [
             'rero_ils_oaiharvest = rero_ils.modules.ebooks.tasks',
             'rero_ils_mefharvest = rero_ils.modules.apiharvester.tasks',


### PR DESCRIPTION
Adds a sharded lowercase and asciifolding analzer using ES templates to be used in several indexes.

How to test:
- `script/bootstrap`
- `script/setup`
-  Kibana console: `GET /_template` to show custom analyzer 

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>