### PR TITLE
indexing: update item types mapping

### DIFF
--- a/rero_ils/modules/item_types/mappings/v6/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/mappings/v6/item_types/item_type-v0.0.1.json
@@ -17,13 +17,15 @@
         },
         "name": {
           "type": "text",
-          "copy_to": "item_type_name"
+          "copy_to": "item_type_name",
+          "analyzer": "global_lowercase_asciifolding"
         },
         "item_type_name": {
           "type": "keyword"
         },
         "description": {
-          "type": "keyword"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding"
         },
         "organisation": {
           "properties": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,9 @@ from os.path import dirname, join
 
 import mock
 import pytest
+from elasticsearch.exceptions import RequestError
 from invenio_circulation.proxies import current_circulation
+from invenio_search import current_search, current_search_client
 from utils import flush_index, mock_response
 
 from rero_ils.modules.circ_policies.api import CircPoliciesSearch, CircPolicy
@@ -50,6 +52,36 @@ pytest_plugins = [
     'fixtures.metadata',
     'fixtures.organisations'
 ]
+
+
+@pytest.fixture(scope='module')
+def es(appctx):
+    """Setup and teardown all registered Elasticsearch indices.
+
+    Scope: module
+    This fixture will create all registered indexes in Elasticsearch and remove
+    once done. Fixtures that perform changes (e.g. index or remove documents),
+    should used the function-scoped :py:data:`es_clear` fixture to leave the
+    indexes clean for the following tests.
+    """
+    try:
+        list(current_search.put_templates())
+    except RequestError:
+        current_search_client.indices.delete_template('*')
+        list(current_search.put_templates())
+
+    try:
+        list(current_search.create())
+    except RequestError:
+        list(current_search.delete(ignore=[404]))
+        list(current_search.create())
+    current_search_client.indices.refresh()
+
+    try:
+        yield current_search_client
+    finally:
+        current_search_client.indices.delete(index='*')
+        current_search_client.indices.delete_template('*')
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -26,7 +26,7 @@
 
 
 import pytest
-from invenio_search import current_search_client
+from invenio_search import current_search, current_search_client
 
 from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patron_types.api import PatronType

--- a/tests/ui/item_types/conftest.py
+++ b/tests/ui/item_types/conftest.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Common pytest item_types."""
+
+import pytest
+
+from invenio_search import current_search, current_search_client
+
+
+@pytest.yield_fixture(scope='module')
+def item_types_records(
+    item_type_standard_martigny,
+    item_type_on_site_martigny,
+    item_type_specific_martigny,
+    item_type_regular_sion
+):
+    """Item types for test mapping."""
+    pass

--- a/tests/ui/item_types/test_item_types_api.py
+++ b/tests/ui/item_types/test_item_types_api.py
@@ -47,20 +47,6 @@ def test_item_type_create(db, item_type_data_tmp):
     assert not ItemType.get_pid_by_name('no exists')
 
 
-def test_item_type_es_mapping(es_clear, db, org_martigny, item_type_data_tmp):
-    """Test item type elasticsearch mapping."""
-    search = ItemTypesSearch()
-    mapping = get_mapping(search.Meta.index)
-    assert mapping
-    ItemType.create(
-        item_type_data_tmp,
-        dbcommit=True,
-        reindex=True,
-        delete_pid=True
-    )
-    assert mapping == get_mapping(search.Meta.index)
-
-
 def test_item_type_exist_name_and_organisation_pid(
         item_type_standard_martigny):
     """Test item type name uniquness."""

--- a/tests/ui/item_types/test_item_types_mapping.py
+++ b/tests/ui/item_types/test_item_types_mapping.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Item type elasticsearch mapping tests."""
+
+from __future__ import absolute_import, print_function
+
+from utils import get_mapping
+
+from rero_ils.modules.item_types.api import ItemType, ItemTypesSearch
+
+
+def test_item_type_es_mapping(es_clear, db, org_martigny, item_type_data_tmp):
+    """Test item type elasticsearch mapping."""
+    search = ItemTypesSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    ItemType.create(
+        item_type_data_tmp,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)
+
+
+def test_item_types_search_mapping(
+    app, item_types_records
+):
+    """Test item type search mapping."""
+    search = ItemTypesSearch()
+
+    c = search.query('query_string', query='checkout').count()
+    assert c == 2
+
+    c = search.query('match', name='checkout').count()
+    assert c == 0
+
+    c = search.query('match', name='specific').count()
+    assert c == 1
+
+    pids = [r.pid for r in search.query(
+         'match', name='specific').source(['pid']).scan()]
+    assert 'itty3' in pids


### PR DESCRIPTION
* Adds analyzer on name and description fields.
* Adds es config on test to support templates.
* Fixes type on description field.

How to test:
- `script/setup`
- `http://localhost:5000/admin/records/item_types`
- Find a term and check if the result is correct (value in fields name or description)

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>