### PR TITLE
indexing: update patron types mapping

### DIFF
--- a/rero_ils/modules/patron_types/mappings/v6/patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/mappings/v6/patron_types/patron_type-v0.0.1.json
@@ -17,13 +17,15 @@
         },
         "name": {
           "type": "text",
-          "copy_to": "patron_type_name"
+          "copy_to": "patron_type_name",
+          "analyzer": "global_lowercase_asciifolding"
         },
         "patron_type_name": {
           "type": "keyword"
         },
         "description": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding"
         },
         "organisation": {
           "properties": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,9 @@ def es(appctx):
     should used the function-scoped :py:data:`es_clear` fixture to leave the
     indexes clean for the following tests.
     """
+    from elasticsearch.exceptions import RequestError
+    from invenio_search import current_search, current_search_client
+
     try:
         list(current_search.put_templates())
     except RequestError:

--- a/tests/ui/patron_types/conftest.py
+++ b/tests/ui/patron_types/conftest.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Common pytest patron_types."""
+
+import pytest
+
+
+@pytest.yield_fixture(scope='module')
+def patron_types_records(
+    patron_type_children_martigny,
+    patron_type_adults_martigny,
+    patron_type_youngsters_sion,
+    patron_type_grown_sion
+):
+    """Patron types for test mapping."""
+    pass

--- a/tests/ui/patron_types/test_patron_types_api.py
+++ b/tests/ui/patron_types/test_patron_types_api.py
@@ -47,21 +47,6 @@ def test_patron_type_create(db, patron_type_children_martigny_data):
     assert fetched_pid.pid_type == 'ptty'
 
 
-def test_patron_type_es_mapping(es_clear, db, org_martigny,
-                                patron_type_children_martigny_data):
-    """Test patron types es mapping."""
-    search = PatronTypesSearch()
-    mapping = get_mapping(search.Meta.index)
-    assert mapping
-    PatronType.create(
-        patron_type_children_martigny_data,
-        dbcommit=True,
-        reindex=True,
-        delete_pid=True
-    )
-    assert mapping == get_mapping(search.Meta.index)
-
-
 def test_patron_type_exist_name_and_organisation_pid(
         patron_type_children_martigny):
     """Test patron type name uniquness."""

--- a/tests/ui/patron_types/test_patron_types_mapping.py
+++ b/tests/ui/patron_types/test_patron_types_mapping.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Patron type elasticsearch mapping tests."""
+
+from utils import get_mapping
+
+from rero_ils.modules.patron_types.api import PatronType, PatronTypesSearch
+
+
+def test_patron_types_search_mapping(
+    app, patron_types_records
+):
+    """Test patron type search mapping."""
+    search = PatronTypesSearch()
+
+    c = search.query('query_string', query='patrons').count()
+    assert c == 4
+
+    c = search.query('match', name='patrons').count()
+    assert c == 0
+
+    c = search.query('match', name='children').count()
+    assert c == 1
+
+    pids = [r.pid for r in search.query(
+         'match', name='children').source(['pid']).scan()]
+    assert 'ptty1' in pids
+
+
+def test_patron_type_es_mapping(es_clear, db, org_martigny,
+                                patron_type_children_martigny_data):
+    """Test patron types es mapping."""
+    search = PatronTypesSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    PatronType.create(
+        patron_type_children_martigny_data,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)


### PR DESCRIPTION
* Adds analyzer on name and description fields.

How to test:
* `script/setup`
* http://localhost:5000/admin/records/patron_types
* Find a term and check if the result is correct (value in fields name or description)

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>