### PR TITLE
notifications: create recall notification

### DIFF
--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 from invenio_admin import current_admin
+from invenio_circulation.signals import loan_state_changed
 from invenio_indexer.signals import before_record_index
 from invenio_oaiharvester.signals import oaiharvest_finished
 from invenio_records.signals import after_record_delete, after_record_insert, \
@@ -38,7 +39,7 @@ from .documents.listener import enrich_document_data, mef_person_delete, \
 from .ebooks.receivers import publish_harvested_records
 from .items.listener import enrich_item_data
 from .items.signals import item_at_desk
-from .loans.listener import enrich_loan_data
+from .loans.listener import enrich_loan_data, listener_loan_state_changed
 from .locations.listener import enrich_location_data
 from .mef_persons.receivers import publish_api_harvested_records
 from .notifications.listener import enrich_notification_data
@@ -104,6 +105,8 @@ class REROILSAPP(object):
         before_record_index.connect(enrich_notification_data)
 
         item_at_desk.connect(listener_item_at_desk)
+
+        loan_state_changed.connect(listener_loan_state_changed, weak=False)
 
         oaiharvest_finished.connect(publish_harvested_records, weak=False)
 

--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -602,7 +602,7 @@ class Item(IlsRecord):
 
     @add_loans_parameters_and_flush_indexes
     def request(self, current_loan, **kwargs):
-        """Request item for the user."""
+        """Request item for the user and create notifications."""
         loan = current_circulation.circulation.trigger(
             current_loan, **dict(kwargs, trigger='request')
         )

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -25,6 +25,8 @@
 """API for manipulating Loans."""
 
 
+from datetime import datetime, timedelta, timezone
+
 from flask import current_app, url_for
 from invenio_circulation.errors import CirculationException
 from invenio_circulation.pidstore.fetchers import loan_pid_fetcher
@@ -36,6 +38,7 @@ from invenio_jsonschemas import current_jsonschemas
 
 from ..api import IlsRecord
 from ..locations.api import Location
+from ..notifications.api import Notification, NotificationsSearch
 from ..patrons.api import Patron
 
 
@@ -127,6 +130,35 @@ class Loan(IlsRecord):
             data['pickup_location'] = {}
             data['pickup_location']['name'] = loc_data['name']
             data['pickup_location']['library_name'] = library.get('name')
+        return data
+
+    def is_recalled(self):
+        """Check if a recall notification exist already for the given loan."""
+        results = NotificationsSearch().filter(
+            'term', loan__pid=self.get('loan_pid')
+            ).filter('term', notification_type='recall').source().count()
+        return results > 0
+
+    def create_notification(self, notification_type=None):
+        """Creates a recall notification from a checked-out loan."""
+        data = {}
+        if notification_type == 'recall':
+            if self.get('state') == 'ITEM_ON_LOAN' and not self.is_recalled():
+                record = {}
+                creation_date = datetime.now(timezone.utc).isoformat()
+                record['creation_date'] = creation_date
+                record['notification_type'] = 'recall'
+
+                base_url = current_app.config.get('RERO_ILS_APP_BASE_URL')
+                url_api = '{base_url}/api/{doc_type}/{pid}'
+                record['loan'] = {
+                    '$ref': url_api.format(
+                        base_url=base_url,
+                        doc_type='loans',
+                        pid=self.get('loan_pid'))
+                }
+                data = Notification.create(
+                    data=record, dbcommit=True, reindex=True)
         return data
 
 

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -99,8 +99,20 @@ class Notification(IlsRecord):
 def get_availability_notification(loan):
     """Returns availability notification from loan."""
     results = NotificationsSearch().filter(
-        'term', loan_pid=loan.get('loan_pid')
+        'term', loan__pid=loan.get('loan_pid')
         ).filter('term', notification_type='availability').source().scan()
+    try:
+        pid = next(results).pid
+        return Notification.get_record_by_pid(pid)
+    except StopIteration:
+        return None
+
+
+def get_recall_notification(loan):
+    """Returns availability notification from loan."""
+    results = NotificationsSearch().filter(
+        'term', loan__pid=loan.get('loan_pid')
+        ).filter('term', notification_type='recall').source().scan()
     try:
         pid = next(results).pid
         return Notification.get_record_by_pid(pid)

--- a/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
+++ b/rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "Notification",
   "description": "JSON schema for notifications.",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": [
     "$schema",
     "pid",
@@ -23,7 +23,7 @@
       "type": "string",
       "minLength": 1
     },
-    "notification_date": {
+    "creation_date": {
       "type": "string",
       "format": "date-time",
       "title": "Notification creation date"
@@ -38,6 +38,11 @@
           "pattern": "^https://ils.rero.ch/api/loans/.*?$"
         }
       }
+    },
+    "process_date": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Notification processing date"
     },
     "reminder_counter": {
       "type": "integer",

--- a/rero_ils/modules/notifications/mappings/v6/notifications/notification-v0.0.1.json
+++ b/rero_ils/modules/notifications/mappings/v6/notifications/notification-v0.0.1.json
@@ -15,11 +15,14 @@
         "pid": {
           "type": "keyword"
         },
-        "notification_date": {
+        "creation_date": {
+          "type": "date"
+        },
+        "process_date": {
           "type": "date"
         },
         "reminder_counter": {
-          "type": "keyword"
+          "type": "integer"
         },
         "notification_type": {
           "type": "keyword"

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1179,7 +1179,7 @@
   "dummy_notif": {
     "$schema": "https://ils.rero.ch/schema/notifications/notification-v0.0.1.json",
     "pid": "notif1",
-    "notification_date": "2019-01-09T08:18:22.576291+00:00",
+    "creation_date": "2019-01-09T08:18:22.576291+00:00",
     "notification_type": "availability",
     "loan": {
       "$ref": "https://ils.rero.ch/api/loans/x"


### PR DESCRIPTION
* Adds automatically a recall notification when a checked-out item is requested.

Co-Authored-by: Gianni Pante <gianni.pante@rero.ch>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

# To test:
* `./scripts/boostrap`
* `./scripts/setup`
* checkout an item to patron A, request the same item by patron B
* go to `http://localhost:5000/api/notifications/` and make sure a new notification is created for Patron A