### PR TITLE
indexing: update document and ebooks mapping

### DIFF
--- a/rero_ils/es_templates/v6/record.json
+++ b/rero_ils/es_templates/v6/record.json
@@ -1,33 +1,33 @@
 {
   "index_patterns": "*",
   "settings": {
-      "analysis": {
-          "tokenizer": {
-              "char_group_tokenizer": {
-                  "type": "char_group",
-                  "tokenize_on_chars": [
-                      "whitespace",
-                      "punctuation"
-                  ]
-              }
-          },
-          "analyzer": {
-              "global_lowercase_asciifolding": {
-                  "type": "custom",
-                  "tokenizer": "char_group_tokenizer",
-                  "filter": [
-                      "lowercase",
-                      "asciifolding",
-                      "length_min_3"
-                  ]
-              }
-          },
-          "filter": {
-              "length_min_3": {
-                  "type": "length",
-                  "min": 3
-              }
-          }
+    "analysis": {
+      "tokenizer": {
+        "char_group_tokenizer": {
+          "type": "char_group",
+          "tokenize_on_chars": [
+            "whitespace",
+            "punctuation"
+          ]
+        }
+      },
+      "analyzer": {
+        "global_lowercase_asciifolding": {
+          "type": "custom",
+          "tokenizer": "char_group_tokenizer",
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "length_min_3"
+          ]
+        }
+      },
+      "filter": {
+        "length_min_3": {
+          "type": "length",
+          "min": 3
+        }
       }
+    }
   }
 }

--- a/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
@@ -36,7 +36,26 @@
         },
         "title": {
           "type": "text",
-          "copy_to": "autocomplete_title"
+          "analyzer": "global_lowercase_asciifolding",
+          "copy_to": "autocomplete_title",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "autocomplete_title": {
           "type": "text",
@@ -44,7 +63,26 @@
           "search_analyzer": "standard"
         },
         "titlesProper": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "type": {
           "type": "keyword"
@@ -58,7 +96,26 @@
           }
         },
         "is_part_of": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "translatedFrom": {
           "type": "keyword"
@@ -68,6 +125,7 @@
           "properties": {
             "name": {
               "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
               "copy_to": [
                 "facet_authors_en",
                 "facet_authors_fr",
@@ -77,18 +135,22 @@
             },
             "name_en": {
               "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
               "copy_to": "facet_authors_en"
             },
             "name_fr": {
               "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
               "copy_to": "facet_authors_fr"
             },
             "name_de": {
               "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
               "copy_to": "facet_authors_de"
             },
             "name_it": {
               "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
               "copy_to": "facet_authors_it"
             },
             "type": {
@@ -121,7 +183,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "global_lowercase_asciifolding"
             },
             "place": {
               "type": "text"
@@ -151,7 +214,26 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
+              "fields": {
+                "eng": {
+                  "type": "text",
+                  "analyzer": "english"
+                },
+                "fre": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "ger": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "ita": {
+                  "type": "text",
+                  "analyzer": "italian"
+                }
+              }
             },
             "number": {
               "type": "keyword"
@@ -159,10 +241,48 @@
           }
         },
         "notes": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "abstracts": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "identifiers": {
           "type": "object",
@@ -180,7 +300,26 @@
         },
         "subjects": {
           "type": "text",
-          "copy_to": "facet_subjects"
+          "analyzer": "global_lowercase_asciifolding",
+          "copy_to": "facet_subjects",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "facet_subjects": {
           "type": "keyword"

--- a/rero_ils/modules/documents/mappings/v6/documents/ebook-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v6/documents/ebook-v0.0.1.json
@@ -16,10 +16,48 @@
           "type": "keyword"
         },
         "title": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "titlesProper": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "type": {
           "type": "keyword"
@@ -33,7 +71,26 @@
           }
         },
         "is_part_of": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "translatedFrom": {
           "type": "keyword"
@@ -41,9 +98,29 @@
         "authors": {
           "type": "object",
           "properties": {
-            "name": {
-              "type": "text",
-              "copy_to": "facet_authors"
+            "authors": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "text",
+                  "analyzer": "global_lowercase_asciifolding",
+                  "copy_to": [
+                    "facet_authors_en",
+                    "facet_authors_fr",
+                    "facet_authors_de",
+                    "facet_authors_it"
+                  ]
+                },
+                "type": {
+                  "type": "keyword"
+                },
+                "date": {
+                  "type": "keyword"
+                },
+                "qualifier": {
+                  "type": "keyword"
+                }
+              }
             },
             "type": {
               "type": "keyword"
@@ -59,14 +136,24 @@
         "item_status": {
           "type": "keyword"
         },
-        "facet_authors": {
+        "facet_authors_en": {
+          "type": "keyword"
+        },
+        "facet_authors_fr": {
+          "type": "keyword"
+        },
+        "facet_authors_de": {
+          "type": "keyword"
+        },
+        "facet_authors_it": {
           "type": "keyword"
         },
         "publishers": {
           "type": "object",
           "properties": {
             "name": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "global_lowercase_asciifolding"
             },
             "place": {
               "type": "text"
@@ -103,7 +190,26 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "global_lowercase_asciifolding",
+              "fields": {
+                "eng": {
+                  "type": "text",
+                  "analyzer": "english"
+                },
+                "fre": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "ger": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "ita": {
+                  "type": "text",
+                  "analyzer": "italian"
+                }
+              }
             },
             "number": {
               "type": "keyword"
@@ -114,7 +220,26 @@
           "type": "text"
         },
         "abstracts": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "global_lowercase_asciifolding",
+          "fields": {
+            "eng": {
+              "type": "text",
+              "analyzer": "english"
+            },
+            "fre": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "ger": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "ita": {
+              "type": "text",
+              "analyzer": "italian"
+            }
+          }
         },
         "identifiers": {
           "type": "object",

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -991,6 +991,109 @@
     "publicationYear": 1889,
     "freeFormedPublicationDate": "[ca 1889]"
   },
+  "ebook1": {
+    "$schema": "https://ils.rero.ch/schema/documents/ebook-v0.0.1.json",
+    "pid": "ebook1",
+    "type": "ebook",
+    "title": "La maison des oubli\u00e9s",
+    "languages": [
+      {
+        "language": "fre"
+      }
+    ],
+    "authors": [
+      {
+        "name": "Peter James",
+        "type": "person"
+      }
+    ],
+    "publishers": [
+      {
+        "name": [
+          "12-21"
+        ],
+        "place": [
+          "Paris"
+        ]
+      }
+    ],
+    "publicationYear": 2019,
+    "freeFormedPublicationDate": "Mars 2019",
+    "abstracts": [
+      "Le d\u00e9m\u00e9nagement dans ce manoir charmant, en haut de la colline, devait \u00eatre le point de d\u00e9part pour une nouvelle vie. Apr\u00e8s des ann\u00e9es pass\u00e9es dans la banlieue de Brighton, Ollie Harcourt ne pouvait r\u00eaver mieux qu'une existence paisible \u00e0 la campagne. Le reste de la famille suit d'un pas h\u00e9sitant, mais ne rechigne pas pour autant \u00e0 cette nouvelle aventure. Cependant, peu apr\u00e8s leur installation, des sc\u00e8nes \u00e9tranges se d\u00e9roulent dans la maison. Des ombres apparaissent, les animaux domestiques se comportent de mani\u00e8re bizarre et plusieurs accidents, plus d\u00e9routants les uns que les autres, ont lieu. Bient\u00f4t, Ollie n'a plus de doute : leur pr\u00e9sence n'est pas vraiment souhait\u00e9e. Quelqu'un semble m\u00eame pr\u00eat \u00e0 tout pour les expulser de l\u00e0... \u00e0 n'importe quel prix."
+    ],
+    "identifiers": {
+      "isbn": "9782823855890"
+    },
+    "subjects": [
+      "thriller",
+      "suspense"
+    ]
+  },
+  "ebook2": {
+    "$schema": "https://ils.rero.ch/schema/documents/ebook-v0.0.1.json",
+    "pid": "ebook2",
+    "type": "ebook",
+    "title": "Kurkuma: Effekte auf den menschlichen K\u00f6rper-Der aktuelle Stand der Wissenschaft",
+    "languages": [
+      {
+        "language": "ger"
+      }
+    ],
+    "authors": [
+      {
+        "name": "Christopher Sch\u00fctze",
+        "type": "person"
+      }
+    ],
+    "publishers": [
+      {
+        "name": [
+          "Amazon Media EU S.\u00e0 r.l."
+        ],
+        "place": [
+          "Paris"
+        ]
+      }
+    ],
+    "publicationYear": 2010,
+    "freeFormedPublicationDate": "Mars 2010",
+    "abstracts": [
+      "Das Gew\u00fcrz Kurkuma spielt in der Welt der Kulinarik, als auch in der Wissenschaft und Medizin eine wichtige Rolle. Es konnte gezeigt werden, dass Kurkuma bei der Behandlung von metabolischem Syndrom, entz\u00fcndlichen Erkrankungen wie Arthritis, aber auch Hyperlipid\u00e4mie (erh\u00f6hte Blutfette) positive Effekte aufweist. Ebenso wird dieser Pflanze zugeschrieben, die Leistungsf\u00e4higkeit aktiver Menschen zu verbessern. Obwohl gezeigt werden konnte, dass die Einnahme von Curcumin alleine, aufgrund von geringer Resorbtion bzw. einer schnellen Verstoffwechslung und rascher Elimination nicht zu den damit verbundenen gesundheitlichen Vorteilen f\u00fchrt, f\u00fchren Inhaltsstoffe wie der Tr\u00e4ger des schwarzen Pfeffergeschmacks zu einer verbesserten Bioverf\u00fcgbarkeit. Nicht zuletzt wurden vorteilhafte Effekte in Hinblick auf die Tumorgenese (Krebsentstehung) und entz\u00fcndlicher Erkrankungen wie der Psoriasis im Mausmodell nachgewiesen. Ziel dieses Buches ist es, einen \u00dcberblick \u00fcber die Effekte von Kurkuma auf den menschlichen K\u00f6rper zu geben, mit Verweisen auf aktuelle wissenschaftliche Literatur."
+    ]
+  },
+  "ebook3": {
+    "$schema": "https://ils.rero.ch/schema/documents/ebook-v0.0.1.json",
+    "pid": "ebook2",
+    "type": "ebook",
+    "title": "Harry Potter and the Chamber of Secrets",
+    "languages": [
+      {
+        "language": "eng"
+      }
+    ],
+    "authors": [
+      {
+        "name": "J.K. Rowling",
+        "type": "person"
+      }
+    ],
+    "publishers": [
+      {
+        "name": [
+          "Pottermore Publishing"
+        ],
+        "place": [
+          "USA"
+        ]
+      }
+    ],
+    "publicationYear": 2015,
+    "freeFormedPublicationDate": "December 2015",
+    "abstracts": [
+      "Harry Potter's summer has included the worst birthday ever, doomy warnings from a house-elf called Dobby, and rescue from the Dursleys by his friend Ron Weasley in a magical flying car! Back at Hogwarts School of Witchcraft and Wizardry for his second year, Harry hears strange whispers echo through empty corridors - and then the attacks start. Students are found as though turned to stone... Dobby's sinister predictions seem to be coming true."
+    ]
+  },
   "item1": {
     "$schema": "https://ils.rero.ch/schema/items/item-v0.0.1.json",
     "pid": "item1",

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -47,6 +47,60 @@ from rero_ils.modules.patrons.api import Patron, PatronsSearch
 
 
 @pytest.fixture(scope="module")
+def ebook_1_data(data):
+    """Load ebook 1 data."""
+    return deepcopy(data.get('ebook1'))
+
+
+@pytest.fixture(scope="module")
+def ebook_1(app, ebook_1_data):
+    """Load ebook 1 record."""
+    doc = Document.create(
+        data=ebook_1_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(DocumentsSearch.Meta.index)
+    return doc
+
+
+@pytest.fixture(scope="module")
+def ebook_2_data(data):
+    """Load ebook 2 data."""
+    return deepcopy(data.get('ebook2'))
+
+
+@pytest.fixture(scope="module")
+def ebook_2(app, ebook_2_data):
+    """Load document record."""
+    doc = Document.create(
+        data=ebook_2_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(DocumentsSearch.Meta.index)
+    return doc
+
+
+@pytest.fixture(scope="module")
+def ebook_3_data(data):
+    """Load ebook 3 data."""
+    return deepcopy(data.get('ebook3'))
+
+
+@pytest.fixture(scope="module")
+def ebook_3(app, ebook_3_data):
+    """Load document record."""
+    doc = Document.create(
+        data=ebook_3_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(DocumentsSearch.Meta.index)
+    return doc
+
+
+@pytest.fixture(scope="module")
 def document_data(data):
     """Load document data."""
     return deepcopy(data.get('doc1'))

--- a/tests/ui/documents/conftest.py
+++ b/tests/ui/documents/conftest.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Common pytest item_types."""
+
+import pytest
+
+
+@pytest.yield_fixture(scope='module')
+def document_records(
+    document,
+    document_ref,
+    document_sion_items,
+    ebook_1,
+    ebook_2,
+    ebook_3
+):
+    """Documents for test mapping."""
+    pass

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -30,7 +30,7 @@ import mock
 import pytest
 from utils import get_mapping, mock_response
 
-from rero_ils.modules.documents.api import Document, DocumentsSearch, \
+from rero_ils.modules.documents.api import Document, \
     document_id_fetcher
 from rero_ils.modules.mef_persons.api import MefPersonsSearch
 
@@ -47,21 +47,6 @@ def test_document_create(db, document_data_tmp):
     fetched_pid = document_id_fetcher(ptty.id, ptty)
     assert fetched_pid.pid_value == '1'
     assert fetched_pid.pid_type == 'doc'
-
-
-def test_document_es_mapping(db, org_martigny,
-                             document_data_tmp, item_lib_martigny):
-    """Test document elasticsearch mapping."""
-    search = DocumentsSearch()
-    mapping = get_mapping(search.Meta.index)
-    assert mapping
-    Document.create(
-        document_data_tmp,
-        dbcommit=True,
-        reindex=True,
-        delete_pid=True
-    )
-    assert mapping == get_mapping(search.Meta.index)
 
 
 def test_document_can_not_delete(document, item_lib_martigny):

--- a/tests/ui/documents/test_documents_mapping.py
+++ b/tests/ui/documents/test_documents_mapping.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Document mapping tests."""
+
+from elasticsearch_dsl.query import MultiMatch
+from utils import get_mapping
+
+from rero_ils.modules.documents.api import Document, DocumentsSearch
+
+
+def test_document_search_mapping(
+    app, document_records
+):
+    """Test document search mapping."""
+    search = DocumentsSearch()
+
+    c = search.query('query_string', query='reine Berthe').count()
+    assert c == 2
+
+    c = search.query('query_string', query='maison').count()
+    assert c == 1
+
+    c = search.query('query_string', query='scene').count()
+    assert c == 1
+
+    query = MultiMatch(query='scène', fields=['abstracts.fre'])
+    c = search.query(query).count()
+    assert c == 1
+
+    c = search.query('query_string', query='Körper').count()
+    assert c == 1
+
+    query = MultiMatch(query='Körper', fields=['abstracts.ger'])
+    c = search.query(query).count()
+    assert c == 1
+
+    c = search.query('query_string', query='Chamber Secrets').count()
+    assert c == 1
+
+    query = MultiMatch(query='Chamber of Secrets', fields=['title.eng'])
+    c = search.query(query).count()
+    assert c == 1
+
+
+def test_document_es_mapping(db, org_martigny,
+                             document_data_tmp, item_lib_martigny):
+    """Test document elasticsearch mapping."""
+    search = DocumentsSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    Document.create(
+        document_data_tmp,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)


### PR DESCRIPTION
* Adds specific languages analyzers to the template.
* Adds analyzer on documents: title, titlesProper, is_part_of, authors.name, publishers.name, series.name, notes.name, subjects
* Adds analyzer on ebooks: title, titlesProper, is_part_of, authors.name, publishers.name, series.name, abstracts
* Improves facet authors (languages)

How to test:

* `script/bootstrap`
* `script/setup`
* http://localhost:5000
* Find some terms and check if the result is correct

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>