### PR TITLE
search: boosting fields on resources

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -777,6 +777,18 @@ RECORDS_REST_FACETS = {
     )
 }
 
+# Elasticsearch fields boosting by index
+RERO_ILS_QUERY_BOOSTING = {
+    'documents': {
+        'title.*': 2,
+        'titlesProper.*': 2,
+        'authors.name': 2,
+        'authors.name_*': 2,
+        'publicationYearText': 2,
+        'freeFormedPublicationDate': 2,
+        'subjects.*': 2
+    }
+}
 
 # sort options
 indexes = [
@@ -797,7 +809,7 @@ RECORDS_REST_DEFAULT_SORT = dict()
 for index in indexes:
     RECORDS_REST_SORT_OPTIONS[index] = dict(
         bestmatch=dict(
-            fields=['_score'], title='Best match', default_order='asc',
+            fields=['-_score'], title='Best match', default_order='asc',
             order=1
         ),
         mostrecent=dict(

--- a/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
@@ -199,7 +199,11 @@
         },
         "publicationYear": {
           "type": "date",
-          "format": "yyyy"
+          "format": "yyyy",
+          "copy_to": "publicationYearText"
+        },
+        "publicationYearText": {
+          "type": "keyword"
         },
         "otherMaterialCharacteristics": {
           "type": "keyword"

--- a/rero_ils/modules/documents/mappings/v6/documents/ebook-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v6/documents/ebook-v0.0.1.json
@@ -168,7 +168,11 @@
         },
         "publicationYear": {
           "type": "date",
-          "format": "yyyy"
+          "format": "yyyy",
+          "copy_to": "publicationYearText"
+        },
+        "publicationYearText": {
+          "type": "keyword"
         },
         "otherMaterialCharacteristics": {
           "type": "keyword"

--- a/tests/api/test_documents_rest.py
+++ b/tests/api/test_documents_rest.py
@@ -265,3 +265,32 @@ def test_document_can_request_view(client, item_lib_fully,
 
     picks = item_library_pickup_locations(item_lib_martigny)
     assert len(picks) == 3
+
+
+def test_document_boosting(
+        client,
+        ebook_1,
+        ebook_1_data,
+        ebook_4,
+        ebook_4_data
+):
+    """Test document boosting."""
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q='maison'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total'] == 2
+    data = hits['hits'][0]['metadata']
+    assert data['pid'] == ebook_1_data.get('pid')
+
+    list_url = url_for(
+        'invenio_records_rest.doc_list',
+        q='title:maison AND authors.name:James'
+    )
+    res = client.get(list_url)
+    hits = get_json(res)['hits']
+    assert hits['total'] == 1
+    data = hits['hits'][0]['metadata']
+    assert data['pid'] == ebook_1_data.get('pid')

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1064,7 +1064,7 @@
   },
   "ebook3": {
     "$schema": "https://ils.rero.ch/schema/documents/ebook-v0.0.1.json",
-    "pid": "ebook2",
+    "pid": "ebook3",
     "type": "ebook",
     "title": "Harry Potter and the Chamber of Secrets",
     "languages": [
@@ -1092,6 +1092,42 @@
     "freeFormedPublicationDate": "December 2015",
     "abstracts": [
       "Harry Potter's summer has included the worst birthday ever, doomy warnings from a house-elf called Dobby, and rescue from the Dursleys by his friend Ron Weasley in a magical flying car! Back at Hogwarts School of Witchcraft and Wizardry for his second year, Harry hears strange whispers echo through empty corridors - and then the attacks start. Students are found as though turned to stone... Dobby's sinister predictions seem to be coming true."
+    ]
+  },
+  "ebook4": {
+    "$schema": "https://ils.rero.ch/schema/documents/ebook-v0.0.1.json",
+    "pid": "ebook4",
+    "type": "ebook",
+    "title": "Nouveau titre",
+    "languages": [
+      {
+        "language": "fre"
+      }
+    ],
+    "authors": [
+      {
+        "name": "Peter James",
+        "type": "person"
+      }
+    ],
+    "publishers": [
+      {
+        "name": [
+          "12-21"
+        ],
+        "place": [
+          "Paris"
+        ]
+      }
+    ],
+    "publicationYear": 2019,
+    "freeFormedPublicationDate": "Mars 2019",
+    "subjects": [
+      "thriller",
+      "suspense"
+    ],
+    "notes": [
+      "La maison des oubli\u00e9s"
     ]
   },
   "item1": {

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -72,7 +72,7 @@ def ebook_2_data(data):
 
 @pytest.fixture(scope="module")
 def ebook_2(app, ebook_2_data):
-    """Load document record."""
+    """Load ebook 2 record."""
     doc = Document.create(
         data=ebook_2_data,
         delete_pid=False,
@@ -90,9 +90,27 @@ def ebook_3_data(data):
 
 @pytest.fixture(scope="module")
 def ebook_3(app, ebook_3_data):
-    """Load document record."""
+    """Load ebook 3 record."""
     doc = Document.create(
         data=ebook_3_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(DocumentsSearch.Meta.index)
+    return doc
+
+
+@pytest.fixture(scope="module")
+def ebook_4_data(data):
+    """Load ebook 4 data."""
+    return deepcopy(data.get('ebook4'))
+
+
+@pytest.fixture(scope="module")
+def ebook_4(app, ebook_4_data):
+    """Load ebook 4 record."""
+    doc = Document.create(
+        data=ebook_4_data,
         delete_pid=False,
         dbcommit=True,
         reindex=True)


### PR DESCRIPTION
* Adds fields boosting configuration.
* Improves query parser to use the boosting configuration.

How to test:
* Upgrade Elasticsearch to version 6.6.0 (show in docker-services.yml)
* `script/setup`
* http://localhost:5000
* Find some terms and check if the result is correct (show boosting in config.py)

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>