### PR TITLE
UI: adapt the patron editor for the logged user

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -329,9 +329,6 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
@@ -371,18 +368,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/items/',
         record_loaders={
@@ -409,18 +400,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/item_types/',
         record_loaders={
@@ -447,18 +432,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/patrons/',
         record_loaders={
@@ -486,18 +465,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/patron_types/',
         record_loaders={
@@ -524,18 +497,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/organisations/',
         record_loaders={
@@ -562,18 +529,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/libraries/',
         record_loaders={
@@ -584,6 +545,7 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='rero_ils.query:organisation_search_factory',
+        list_permission_factory_imp=can_access_organisation_patrons_factory,
         read_permission_factory_imp=can_access_organisation_records_factory,
         create_permission_factory_imp=can_create_organisation_records_factory,
         update_permission_factory_imp=can_update_organisation_records_factory,
@@ -600,18 +562,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/locations/',
         record_loaders={
@@ -637,18 +593,12 @@ RECORDS_REST_ENDPOINTS = dict(
         record_serializers={
             'application/json': (
                 'rero_ils.modules.serializers:json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
             )
         },
         search_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         list_route='/persons/',
         record_class='rero_ils.modules.mef_persons.api:MefPerson',
@@ -672,20 +622,13 @@ RECORDS_REST_ENDPOINTS = dict(
         search_type=None,
         record_serializers={
             'application/json': (
-                'rero_ils.modules.serializers' ':json_v1_response'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_response'
+                'rero_ils.modules.serializers:json_v1_response'
             )
-
         },
         search_serializers={
             'application/json': (
-                'invenio_records_rest.serializers' ':json_v1_search'
-            ),
-            'application/can-delete+json': (
-                'rero_ils.modules.serializers' ':can_delete_json_v1_search'
-            ),
+                'rero_ils.modules.serializers:json_v1_search'
+            )
         },
         record_loaders={
             'application/json': lambda: CircPolicy(request.get_json()),
@@ -706,7 +649,7 @@ RECORDS_REST_ENDPOINTS = dict(
 SEARCH_UI_SEARCH_INDEX = 'documents'
 
 RERO_ILS_APP_CONFIG_FACETS = {
-    'documents': {
+    'doc': {
         'order': [
             'document_type',
             'library',
@@ -720,13 +663,13 @@ RERO_ILS_APP_CONFIG_FACETS = {
         ],
         'expand': ['document_type'],
     },
-    'patrons': {
+    'ptrn': {
         'order': [
             'roles'
         ],
         'expand': ['roles']
     },
-    'persons': {
+    'pers': {
         'order': [
             'sources'
         ],

--- a/rero_ils/modules/documents/serializers.py
+++ b/rero_ils/modules/documents/serializers.py
@@ -25,57 +25,32 @@
 """Document serialization."""
 
 from flask import current_app, json
-from invenio_records_rest.schemas import RecordSchemaJSONV1
 from invenio_records_rest.serializers.response import search_responsify
 
 from ..libraries.api import Library
-from ..serializers import ReroIlsSerializer
+from ..serializers import JSONSerializer, RecordSchemaJSONV1
 
 
-class ReroIlsSerializer(ReroIlsSerializer):
+class DocumentJSONSerializer(JSONSerializer):
     """Mixin serializing records as JSON."""
 
-    def serialize_search(self, pid_fetcher, search_result, links=None,
-                         item_links_factory=None, **kwargs):
-        """Serialize a search result.
+    def post_process_serialize_search(self, results, pid_fetcher):
+        """Post process the search results.
 
-        :param pid_fetcher: Persistent identifier fetcher.
-        :param search_result: Elasticsearch search result.
-        :param links: Dictionary of links to add to response.
+        Add library names.
         """
-        results = dict(
-            hits=dict(
-                hits=[self.transform_search_hit(
-                    pid_fetcher(hit['_id'], hit['_source']),
-                    hit,
-                    links_factory=item_links_factory,
-                    **kwargs
-                ) for hit in search_result['hits']['hits']],
-                total=search_result['hits']['total'],
-            ),
-            links=links or {},
-            aggregations=search_result.get('aggregations', dict()),
-        )
-        with current_app.app_context():
-            facet_config = current_app.config.get(
-                'RERO_ILS_APP_CONFIG_FACETS', {}
-            )
-            if search_result['hits']['hits']:
-                index_name = \
-                    search_result['hits']['hits'][0]['_index'].split('-')[0]
-                facet_config = facet_config.get(index_name, {})
-                results['aggregations']['_settings'] = facet_config
-                for lib_term in results.get('aggregations', {}).get(
-                        'library', {}).get('buckets', []):
-                    pid = lib_term.get('key')
-                    name = Library.get_record_by_pid(pid).get('name')
-                    lib_term['name'] = name
+        for lib_term in results.get('aggregations', {}).get(
+                'library', {}).get('buckets', []):
+            pid = lib_term.get('key')
+            name = Library.get_record_by_pid(pid).get('name')
+            lib_term['name'] = name
 
-        return json.dumps(results, **self._format_args())
+        return super(
+            DocumentJSONSerializer, self).post_process_serialize_search(
+                results, pid_fetcher)
 
 
-json_doc = ReroIlsSerializer(RecordSchemaJSONV1)
+json_doc = DocumentJSONSerializer(RecordSchemaJSONV1)
 """JSON v1 serializer."""
 
 json_doc_search = search_responsify(json_doc, 'application/rero+json')
-# json_v1_response = record_responsify(json_v1, 'application/rero+json')

--- a/rero_ils/modules/items/jsonschemas/form_items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/form_items/item-v0.0.1.json
@@ -15,7 +15,7 @@
     "title": "Location",
     "type": "select",
     "remoteRecordType": "locations",
-    "remoteRecordFiltersByOwningLibrary": true
+    "remoteRecordFiltersByOwningLibrary": "library.pid"
   },
   {
     "key": "item_type.$ref",

--- a/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
@@ -75,7 +75,7 @@
             "key": "roles",
             "notitle": "true",
             "description": "What is/are the role(s) of the user?",
-            "type": "checkboxes",
+            "type": "rolesCheckboxes",
             "htmlClass": "d-inline-block",
             "orderable": "false",
             "titleMap": [
@@ -125,6 +125,7 @@
                 "description": "The library where the librarian works.",
                 "type": "select",
                 "remoteRecordType": "libraries",
+                "remoteRecordFiltersByOwningLibrary": "pid",
                 "condition": {
                   "functionBody": "{return model.roles? model.roles.includes('librarian'): false;}"
                 }

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -30,16 +30,6 @@ from flask import url_for
 from invenio_indexer.api import RecordIndexer
 
 
-def delete_record(record_type, record_class, pid):
-    """Remove a record from the db and the index and his corresponding pid."""
-    record = record_class.get_record_by_pid(pid)
-    record.delete(delindex=True)
-    record.dbcommit(reindex=False)
-    RecordIndexer().client.indices.flush()
-    _next = url_for('%s.index_view' % record_type)
-    return _next, record.pid
-
-
 def strtotime(strtime):
     """String to datetime."""
     splittime = strtime.split(':')

--- a/tests/api/test_circ_policies_rest.py
+++ b/tests/api/test_circ_policies_rest.py
@@ -126,7 +126,7 @@ def test_filtered_circ_policies_get(
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
 def test_circ_policies_post_put_delete(client, org_martigny,
                                        circ_policy_default_martigny_data,
-                                       json_header, can_delete_json_header):
+                                       json_header):
     """Test policy retrieval."""
     # Create policy / POST
     item_url = url_for('invenio_records_rest.cipo_item', pid_value='1')
@@ -157,7 +157,7 @@ def test_circ_policies_post_put_delete(client, org_martigny,
     res = client.put(
         item_url,
         data=json.dumps(data),
-        headers=can_delete_json_header
+        headers=json_header
     )
     assert res.status_code == 200
     # assert res.headers['ETag'] != '"{}"'.format(librarie.revision_id)
@@ -272,12 +272,12 @@ def test_circ_policy_secure_api_create(client, json_header,
     assert res.status_code == 403
 
 
-def test_circ_policy_secure_api_update(client, json_header,
+def test_circ_policy_secure_api_update(client,
                                        circ_policy_short_martigny,
                                        librarian_martigny_no_email,
                                        librarian_sion_no_email,
                                        circ_policy_short_martigny_data,
-                                       can_delete_json_header):
+                                       json_header):
     """Test circulation policies secure api update."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)
@@ -289,7 +289,7 @@ def test_circ_policy_secure_api_update(client, json_header,
     res = client.put(
         record_url,
         data=json.dumps(data),
-        headers=can_delete_json_header
+        headers=json_header
     )
     assert res.status_code == 200
 
@@ -299,17 +299,17 @@ def test_circ_policy_secure_api_update(client, json_header,
     res = client.put(
         record_url,
         data=json.dumps(data),
-        headers=can_delete_json_header
+        headers=json_header
     )
     assert res.status_code == 403
 
 
-def test_circ_policy_secure_api_delete(client, json_header,
+def test_circ_policy_secure_api_delete(client,
                                        circ_policy_short_martigny,
                                        librarian_martigny_no_email,
                                        librarian_sion_no_email,
                                        circ_policy_short_martigny_data,
-                                       can_delete_json_header):
+                                       json_header):
     """Test circulation policies secure api delete."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)

--- a/tests/api/test_item_types_rest.py
+++ b/tests/api/test_item_types_rest.py
@@ -278,12 +278,12 @@ def test_item_type_secure_api_create(client, json_header,
     assert res.status_code == 403
 
 
-def test_item_type_secure_api_update(client, json_header,
+def test_item_type_secure_api_update(client,
                                      item_type_on_site_martigny,
                                      librarian_martigny_no_email,
                                      librarian_sion_no_email,
                                      item_type_on_site_martigny_data,
-                                     can_delete_json_header):
+                                     json_header):
     """Test item type secure api update."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)
@@ -295,7 +295,7 @@ def test_item_type_secure_api_update(client, json_header,
     res = client.put(
         record_url,
         data=json.dumps(data),
-        headers=can_delete_json_header
+        headers=json_header
     )
     assert res.status_code == 200
 
@@ -305,17 +305,17 @@ def test_item_type_secure_api_update(client, json_header,
     res = client.put(
         record_url,
         data=json.dumps(data),
-        headers=can_delete_json_header
+        headers=json_header
     )
     assert res.status_code == 403
 
 
-def test_item_type_secure_api_delete(client, json_header,
+def test_item_type_secure_api_delete(client,
                                      item_type_on_site_martigny,
                                      librarian_martigny_no_email,
                                      librarian_sion_no_email,
                                      item_type_on_site_martigny_data,
-                                     can_delete_json_header):
+                                     json_header):
     """Test item type secure api delete."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)

--- a/tests/api/test_items_rest_views.py
+++ b/tests/api/test_items_rest_views.py
@@ -491,11 +491,11 @@ def test_item_secure_api_update(client, json_header, item_lib_saxon,
     assert res.status_code == 403
 
 
-def test_item_secure_api_delete(client, json_header, item_lib_saxon,
+def test_item_secure_api_delete(client, item_lib_saxon,
                                 librarian_martigny_no_email,
                                 librarian_sion_no_email,
                                 item_lib_saxon_data,
-                                can_delete_json_header):
+                                json_header):
     """Test item secure api delete."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -107,6 +107,7 @@ def test_loan_utils(client, patron_martigny_no_email,
 
     with pytest.raises(TypeError):
         assert get_loans_by_patron_pid()
+    assert get_loans_by_patron_pid(patron2_martigny_no_email.pid)
 
     with pytest.raises(TypeError):
         assert get_last_transaction_loc_for_item()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,15 @@ def json_header():
 
 
 @pytest.fixture(scope="session")
+def rero_json_header():
+    """Load json headers."""
+    return [
+        ('Accept', 'application/rero+json'),
+        ('Content-Type', 'application/json')
+    ]
+
+
+@pytest.fixture(scope="session")
 def can_delete_json_header():
     """Load can_delete json headers."""
     return [

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -22,7 +22,9 @@
 
 """Test permissions."""
 
-from utils import login_user
+from invenio_accounts.testutils import login_user_via_view
+from utils import login_user_for_view
+
 from rero_ils.permissions import can_access_item
 
 
@@ -30,11 +32,11 @@ def test_can_access_item_librarian(
         client, json_header,
         librarian_martigny_no_email, item_lib_martigny):
     """Test a librarian can access an item."""
-
-    assert not can_access_item()
-    login_user(client, librarian_martigny_no_email)
-    assert not can_access_item()
-    assert can_access_item(item=item_lib_martigny)
+    user = librarian_martigny_no_email.user
+    assert not can_access_item(user=user)
+    login_user_for_view(client, librarian_martigny_no_email)
+    assert not can_access_item(user=user)
+    assert can_access_item(user=user, item=item_lib_martigny)
 
 
 def test_can_access_item_patron(
@@ -42,7 +44,7 @@ def test_can_access_item_patron(
         patron_martigny_no_email, item_lib_martigny):
     """Test a patron can access an item."""
 
-    login_user(client, patron_martigny_no_email)
+    login_user_for_view(client, patron_martigny_no_email)
     assert not can_access_item()
     assert not can_access_item(item=item_lib_martigny)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,8 @@
 import json
 
 import mock
-from invenio_accounts.testutils import login_user_via_view
+from invenio_accounts.testutils import login_user_via_session, \
+    login_user_via_view
 from invenio_circulation.api import get_loan_for_item
 from invenio_search import current_search
 from six.moves.urllib.parse import parse_qs, urlparse
@@ -52,6 +53,12 @@ class VerifyRecordPermissionPatch(object):
 
 def login_user(client, user):
     """Sign in user."""
+    user.user.password_plaintext = user.get('email')
+    login_user_via_session(client, user=user.user)
+
+
+def login_user_for_view(client, user):
+    """Sign in user for view."""
     user.user.password_plaintext = user.get('email')
     login_user_via_view(client, user=user.user)
 

--- a/ui/src/app/records/editor/editor.component.ts
+++ b/ui/src/app/records/editor/editor.component.ts
@@ -4,6 +4,7 @@ import { RecordsService } from '../records.service';
 import { RemoteSelectComponent } from './remote-select/remote-select.component';
 import { RemoteInputComponent } from './remote-input/remote-input.component';
 import { RefAuthorityComponent } from './ref-authority/ref-authority.component';
+import {RolesCheckboxesComponent} from './roles-checkboxes/roles-checkboxes.component';
 
 import { WidgetLibraryService } from 'angular6-json-schema-form';
 import { combineLatest } from 'rxjs';
@@ -42,6 +43,7 @@ export class EditorComponent implements OnInit {
     private toastrService: ToastrService
   ) {
     this.widgetLibrary.registerWidget('select', RemoteSelectComponent);
+    this.widgetLibrary.registerWidget('rolesCheckboxes', RolesCheckboxesComponent);
     this.widgetLibrary.registerWidget('text', RemoteInputComponent);
     this.widgetLibrary.registerWidget('refAuthority', RefAuthorityComponent);
     this.currentLocale = translateService.currentLang;

--- a/ui/src/app/records/editor/remote-select/remote-select.component.ts
+++ b/ui/src/app/records/editor/remote-select/remote-select.component.ts
@@ -40,8 +40,9 @@ export class RemoteSelectComponent implements OnInit {
       this.userService.loggedUser.subscribe(user => {
         // TODO: find a cleanest way to do it
         let query = '';
-        if (this.options.remoteRecordFiltersByOwningLibrary) {
-          query = `library.pid:${user.library.pid}`;
+        const fieldToFilter = this.options.remoteRecordFiltersByOwningLibrary;
+        if (fieldToFilter && !user.roles.some(role => role === 'system_librarian')) {
+          query = `${fieldToFilter}:${user.library.pid}`;
         }
         this.recordsService.getRecords(remoteRecordType, 1, 30, query).subscribe(data => {
           data.hits.hits.map(record => {

--- a/ui/src/app/records/editor/roles-checkboxes/roles-checkboxes.component.html
+++ b/ui/src/app/records/editor/roles-checkboxes/roles-checkboxes.component.html
@@ -1,0 +1,45 @@
+<label *ngIf="options?.title"
+  [class]="options?.labelHtmlClass || ''"
+  [style.display]="options?.notitle ? 'none' : ''"
+  [innerHTML]="options?.title"></label>
+<!-- 'horizontal' = checkboxes-inline or checkboxbuttons -->
+<div *ngIf="layoutOrientation === 'horizontal'" [class]="options?.htmlClass || ''">
+  <label *ngFor="let checkboxItem of checkboxList"
+    [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+    [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+      (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+      (' ' + (options?.style?.unselected || '')))">
+    <input type="checkbox"
+      [attr.required]="options?.required"
+      [checked]="checkboxItem.checked"
+      [class]="options?.fieldHtmlClass || ''"
+      [disabled]="controlDisabled"
+      [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+      [name]="checkboxItem?.name"
+      [readonly]="options?.readonly ? 'readonly' : null"
+      [value]="checkboxItem.value"
+      (change)="updateValue($event)">
+    <span [innerHTML]="checkboxItem.name"></span>
+  </label>
+</div>
+<!-- 'vertical' = regular checkboxes -->
+<div *ngIf="layoutOrientation === 'vertical'">
+  <div *ngFor="let checkboxItem of checkboxList" [class]="options?.htmlClass || 'checkbox'">
+    <label
+      [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+      [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+        (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+        (' ' + (options?.style?.unselected || '')))">
+      <input type="checkbox"
+        [attr.required]="options?.required"
+        [checked]="checkboxItem.checked"
+        [disabled]="isDisabled(checkboxItem)"
+        [id]="options?.name + '/' + checkboxItem.value"
+        [name]="checkboxItem?.name"
+        [readonly]="options?.readonly ? 'readonly' : null"
+        [value]="checkboxItem.value"
+        (change)="updateValue($event)">
+      <span [innerHTML]="checkboxItem?.name"></span>
+    </label>
+  </div>
+</div>

--- a/ui/src/app/records/editor/roles-checkboxes/roles-checkboxes.component.spec.ts
+++ b/ui/src/app/records/editor/roles-checkboxes/roles-checkboxes.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RolesCheckboxesComponent } from './roles-checkboxes.component';
+
+describe('RolesCheckboxesComponent', () => {
+  let component: RolesCheckboxesComponent;
+  let fixture: ComponentFixture<RolesCheckboxesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RolesCheckboxesComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RolesCheckboxesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/src/app/records/editor/roles-checkboxes/roles-checkboxes.component.ts
+++ b/ui/src/app/records/editor/roles-checkboxes/roles-checkboxes.component.ts
@@ -1,0 +1,85 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService, TitleMapItem, buildTitleMap } from 'angular6-json-schema-form';
+import { UserService } from '../../../user.service';
+
+@Component({
+  // tslint:disable-next-line:component-selector
+  selector: 'app-roles-checkboxes',
+  templateUrl: './roles-checkboxes.component.html',
+  styleUrls: ['./roles-checkboxes.component.scss']
+})
+export class RolesCheckboxesComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  layoutOrientation: string;
+  formArray: AbstractControl;
+  checkboxList: TitleMapItem[] = [];
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(
+    private jsf: JsonSchemaFormService,
+    private userService: UserService
+  ) { }
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.layoutOrientation = (this.layoutNode.type === 'checkboxes-inline' ||
+      this.layoutNode.type === 'checkboxbuttons') ? 'horizontal' : 'vertical';
+    this.jsf.initializeControl(this);
+    this.checkboxList = buildTitleMap(
+      this.options.titleMap || this.options.enumNames, this.options.enum, true
+    );
+    this.userService.loggedUser.subscribe(user => {
+      if (!user.roles.some(role => role === 'system_librarian')) {
+        this.checkboxList = this.checkboxList.filter(role => role.value !== 'system_librarian');
+      }
+    });
+    if (this.boundControl) {
+      const formArray = this.jsf.getFormControl(this);
+      this.checkboxList.forEach(checkboxItem =>
+        checkboxItem.checked = formArray.value.includes(checkboxItem.value)
+      );
+    }
+  }
+
+  updateValue(event) {
+    for (const checkboxItem of this.checkboxList) {
+      if (event.target.value === checkboxItem.value) {
+        checkboxItem.checked = event.target.checked;
+      }
+      if (event.target.value === 'librarian' && !event.target.checked) {
+        this.checkboxList.map(item => {
+          if (item.value === 'system_librarian') {
+            item.checked = false;
+          }
+        });
+      }
+    }
+    if (this.boundControl) {
+      this.jsf.updateArrayCheckboxList(this, this.checkboxList);
+    }
+  }
+  isLibraryChecked(): boolean {
+    let isChecked = false;
+    this.checkboxList.map(item => {
+      if (item.value === 'librarian') {
+        isChecked = item.checked;
+      }
+    });
+    return isChecked;
+  }
+
+  isDisabled(item) {
+    if (item.value === 'system_librarian' && !this.isLibraryChecked()) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/ui/src/app/records/records.module.ts
+++ b/ui/src/app/records/records.module.ts
@@ -47,6 +47,7 @@ import { DocumentsSearchComponent } from './search/public-search/documents-searc
 import { PersonsSearchComponent } from './search/public-search/persons-search.component';
 import { RefAuthorityComponent } from './editor/ref-authority/ref-authority.component';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
+import { RolesCheckboxesComponent } from './editor/roles-checkboxes/roles-checkboxes.component';
 
 @NgModule({
   declarations: [
@@ -77,7 +78,8 @@ import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
     PublicSearchComponent,
     DocumentsSearchComponent,
     PersonsSearchComponent,
-    RefAuthorityComponent
+    RefAuthorityComponent,
+    RolesCheckboxesComponent
   ],
   imports: [
     CommonModule,
@@ -94,6 +96,7 @@ import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
   ],
   entryComponents: [
     RemoteSelectComponent,
+    RolesCheckboxesComponent,
     RemoteInputComponent,
     RefAuthorityComponent,
     JsonBriefViewComponent,

--- a/ui/src/app/records/records.service.ts
+++ b/ui/src/app/records/records.service.ts
@@ -162,9 +162,9 @@ export class RecordsService {
       recordType,
       pid,
       0,
-      'application/can-delete+json'
+      'application/json'
     ).subscribe(record => {
-      const data = record.metadata;
+      const data = record.permissions;
       const canDeleted = !('cannot_delete' in data);
       const config = {
         ignoreBackdropClick: true,

--- a/ui/src/app/records/search/brief-view/patrons-brief-view.component.ts
+++ b/ui/src/app/records/search/brief-view/patrons-brief-view.component.ts
@@ -77,26 +77,28 @@ export class PatronsBriefViewComponent implements BriefView {
   }
 
   toggleCollapse() {
-    if (this.isCollapsed) {
+    const isCollapsed = this.isCollapsed;
+    if (isCollapsed) {
       if (this.isPatron()) {
         const patronTypePid = this.record.metadata.patron_type.pid;
         this.recordsService
           .getRecord('patron_types', patronTypePid, 1)
           .subscribe(data => {
             this.record.metadata.patron_type = data.metadata;
-            this.isCollapsed = !this.isCollapsed;
+            this.isCollapsed = isCollapsed;
           });
-      } else {
+      }
+      if (this.isLibrarian()) {
         const libraryPid = this.record.metadata.library.pid;
         this.recordsService
           .getRecord('libraries', libraryPid, 1)
           .subscribe(data => {
             this.record.metadata.library = data.metadata;
-            this.isCollapsed = !this.isCollapsed;
+            this.isCollapsed = !isCollapsed;
           });
       }
     } else {
-      this.isCollapsed = !this.isCollapsed;
+      this.isCollapsed = !isCollapsed;
     }
   }
 }

--- a/ui/src/app/records/search/result/result.component.html
+++ b/ui/src/app/records/search/result/result.component.html
@@ -2,13 +2,15 @@
   <div class="flex-grow-1">
     <ng-template appBriefView></ng-template>
   </div>
-  <a *ngIf="adminMode && briefViewName !== 'persons'" class="float-right text-secondary ml-2"
+  <a *ngIf="adminMode && briefViewName !== 'persons' && hasPermissionToUpdate()"
+     class="float-right text-secondary ml-2"
      routerLinkActive="active"
      [routerLink]="['/records', briefViewName, record.metadata.pid]"
      title="{{ 'Edit' | translate }}">
     <i class="fa fa-pencil" aria-hidden="true"></i>
   </a>
-  <a *ngIf="adminMode && briefViewName !== 'persons'" (click)="deleteRecord(record.metadata.pid)"
+  <a *ngIf="adminMode && briefViewName !== 'persons' && hasPermissionToDelete()"
+     (click)="deleteRecord(record.metadata.pid)"
      class="float-right text-secondary ml-2"
      title="{{ 'Delete' | translate }}">
     <i class="fa fa-trash" aria-hidden="true"></i>

--- a/ui/src/app/records/search/result/result.component.ts
+++ b/ui/src/app/records/search/result/result.component.ts
@@ -59,6 +59,26 @@ export class ResultComponent implements OnInit {
     (<BriefView>componentRef.instance).record = this.record;
   }
 
+  hasPermissionToDelete() {
+    const record = this.record;
+    if (record.permissions
+      && record.permissions.cannot_delete
+      && record.permissions.cannot_delete.permission) {
+      return false;
+    }
+    return true;
+  }
+
+  hasPermissionToUpdate() {
+    const record = this.record;
+    if (record.permissions
+        && record.permissions.cannot_update
+        && record.permissions.cannot_update.permission) {
+      return false;
+    }
+    return true;
+  }
+
   deleteRecord(pid: string) {
     this.deletedRecord.emit(pid);
   }

--- a/ui/src/app/records/search/search.component.html
+++ b/ui/src/app/records/search/search.component.html
@@ -13,7 +13,8 @@
         <h6>
           {{total}} {{ 'results' | translate }}
         </h6>
-        <a *ngIf="adminMode && recordType !== 'persons'" class="btn btn-success btn-sm"
+        <a *ngIf="adminMode && recordType !== 'persons' && hasPermissionToCreate()"
+           class="btn btn-success btn-sm"
            routerLinkActive="active" [routerLink]="['/records', recordType, 'new']"
            translate>
           <i class="fa fa-plus" aria-hidden="true"></i> Add

--- a/ui/src/app/records/search/search.component.ts
+++ b/ui/src/app/records/search/search.component.ts
@@ -123,6 +123,7 @@ export class SearchComponent implements OnInit {
   public aggsSettings = null;
   public searchMime = 'application/json';
   public language = null;
+  public permissions = null;
   onInitDone = false;
   constructor(
     protected recordsService: RecordsService,
@@ -165,7 +166,10 @@ export class SearchComponent implements OnInit {
         this.notFound = true;
       } else {
         this.records = data.hits.hits;
-
+        this.permissions = null;
+        if (data.permissions) {
+          this.permissions = data.permissions;
+        }
         this.aggregations = [];
         this.aggsSettings = data.aggregations._settings;
         if (this.aggsSettings !== undefined) {
@@ -275,10 +279,13 @@ export class SearchComponent implements OnInit {
     }
     return false;
   }
-  // isCollapsed(title) {
-  //   return this.startOpen(title);
-  // }
-  // toggleCollapsed(title) {
-  //   return;
-  // }
+
+  hasPermissionToCreate() {
+    if (this.permissions
+        && this.permissions.cannot_create
+        && this.permissions.cannot_create.permission) {
+      return false;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
    * Limit the libraries to the affiliated library of a librarian logged
    user. All libraries are available for a system librarian.
    * A system librarian can be created only by a other system librarian.
    * remoteRecordFiltersByOwningLibrary form option is not a boolean
    anymore, but return the filter field name.