### PR TITLE
fixture: fix transformation with no publishers

### DIFF
--- a/data/300.json
+++ b/data/300.json
@@ -825,9 +825,6 @@
     ],
     "title": "How to develop new ecumenical mass communication",
     "publicationYear": 1973,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Japan Missionary Bulletin"
   },
   {
@@ -927,9 +924,6 @@
     },
     "title": "The Constitution of local councils of churches, The membership of local councils of churches, The organization of local councils of churches, Youth and local councils of churches",
     "publicationYear": 1969,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Voyage, supplement"
   },
   {
@@ -996,9 +990,6 @@
     ],
     "title": "Le Partage de la foi : le COE a 25 ans",
     "publicationYear": 1973,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "R\u00e9forme : hebdomadaire protestant d'information g\u00e9n\u00e9rale"
   },
   {
@@ -2752,9 +2743,6 @@
     ],
     "title": "Paul VI on ecumenism",
     "publicationYear": 1967,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Month : an illustrated magazine of literature, science and art"
   },
   {
@@ -2852,9 +2840,6 @@
     ],
     "title": "Le mouvement oecum\u00e9nique s'est approfondi",
     "publicationYear": 1967,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Unitas : international ecumenical review"
   },
   {
@@ -3933,9 +3918,6 @@
     ],
     "title": "Spannung in der \u00d6kumene",
     "publicationYear": 1975,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Lutherische Rundschau : Zeitschrift des Lutherischen Weltbundes"
   },
   {
@@ -4925,9 +4907,6 @@
     ],
     "title": "Healing in the local church : Oekolampad Basle, Switzerland",
     "publicationYear": 2001,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "International review of mission"
   },
   {
@@ -5553,9 +5532,6 @@
     ],
     "title": "Growing together towards the unity of the Church",
     "publicationYear": 1984,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Mid-stream : an ecumenical journal"
   },
   {
@@ -7607,9 +7583,6 @@
     ],
     "title": "Ecclesiological aspects of the race problem",
     "publicationYear": 1970,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "International review of mission"
   },
   {
@@ -7821,9 +7794,6 @@
     },
     "title": "Report on the Youth Pre-conference \"Risking obedience\"",
     "publicationYear": 1989,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "International review of mission"
   },
   {
@@ -8571,9 +8541,6 @@
     },
     "title": "Auf dem Weg zum gemeinsamen Aussprechen des apostolischen Glaubens heute",
     "publicationYear": 1985,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "\u00d6kumenische Rundschau"
   },
   {
@@ -8941,9 +8908,6 @@
     ],
     "title": "\u00d6kumene gewinnt Profil (XII) : die Partnerschaft zwischen den Kirchenkreisen Koblenz und Agusan / Philippinen",
     "publicationYear": 1990,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "\u00d6kumenische Rundschau"
   },
   {
@@ -9371,9 +9335,6 @@
     ],
     "title": "Development service and China's modernization : the Amity Foundation in theological perspective",
     "publicationYear": 1989,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Ecumenical review : a quarterly"
   },
   {
@@ -9616,9 +9577,6 @@
     },
     "title": "Central Committee of WCC Holds Annual Session at Geneva",
     "publicationYear": 1966,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Unitas : international ecumenical review"
   },
   {
@@ -10522,9 +10480,6 @@
     ],
     "title": "Ursachen und Anl\u00e4sse der Walliser Auswanderung im 19. Jahrhundert",
     "publicationYear": 1991,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Valais d'\u00e9migration : publication accompagnant l'exposition Ubi bene ibi patria - Valais d'\u00e9migration XVIe - XXe si\u00e8cle, Mus\u00e9e cantonal d'histoire et d'ethnographie Val\u00e8re 24 mai - 3 novembre 1991 = Auswanderungsland Wallis : Begleitpublikation zur Ausstellung Ubi bene ibi patria - Auswanderungsland Wallis 16. - 20. Jahrhundert, Kantonales Museum f\u00fcr Geschichte und Ethnographie Val\u00e8re 24. Mai - 3. November 1991"
   },
   {
@@ -10684,9 +10639,6 @@
     ],
     "title": "Gedanken zur Weltkonferenz 'Kirche und Gesellschaft', Genf 1966",
     "publicationYear": 1967,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "\u00d6kumenische Rundschau"
   },
   {
@@ -10745,9 +10697,6 @@
     ],
     "title": "Martin Chemnitz and the Eastern Church : A christology of the Catholic consensus of the Fathers",
     "publicationYear": 1994,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "St. Vladimir's theological quarterly"
   },
   {
@@ -11109,9 +11058,6 @@
     ],
     "title": "Assembly theme discussed in Bossey",
     "publicationYear": 1968,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "St. Vladimir's theological quarterly"
   },
   {
@@ -11215,9 +11161,6 @@
     ],
     "title": "Reflection on councils of churches",
     "publicationYear": 1967,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "One in Christ : a catholic ecumenical review"
   },
   {
@@ -12093,9 +12036,6 @@
     ],
     "title": "La salud de la mujer es algo mas que una cuestion medica",
     "publicationYear": 1984,
-    "publishers": [
-      {}
-    ],
     "is_part_of": "Contact"
   },
   {

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/model.py
@@ -291,7 +291,10 @@ def marc21_to_publishers_publicationDate(self, key, value):
         indexes[tag] = index + 1
         lasttag = tag
     publishers.append(publisher)
-    return publishers
+    if publishers == [{}]:
+        return None
+    else:
+        return publishers
 
 
 @marc21tojson.over('formats', '^300..')

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -38,12 +38,12 @@
         <article class="">
             <dl class="row mb-0">
             <!-- AUTHORS -->
-            {% if record.authors|length > 0 %}
+            {% if record.authors %}
               {{ dl(_('Author'), record.pid | authors_format(current_i18n.language)) }}
             {% endif %}
 
             <!-- PUBLISHERS -->
-            {% if record.publishers|length > 0 %}
+            {% if record.publishers %}
               {{ dl(_('Publisher'), record.publishers|publishers_format) }}
             {% endif %}
 

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -404,6 +404,18 @@ def test_marc21_to_publishers_publicationDate():
     assert data.get('freeFormedPublicationDate') == '1912-1955'
     assert data.get('publicationYear') == 1912
 
+    marc21xml = """
+    <record>
+      <datafield tag="264" ind1=" " ind2="1">
+        <subfield code="c">1984</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('publishers')
+    assert data.get('publicationYear') == 1984
+
 
 # extent: 300$a (the first one if many)
 # otherMaterialCharacteristics: 300$b (the first one if many)


### PR DESCRIPTION
* FIX Fixes #367.
* FIX Updates documents fixtures files.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## To test.

- `./scripts/setup`.
- display detailed view of documents without publishers data (such as *La salud de la mujer es algo mas que una cuestion medica*).