### PR TITLE
fixtures: fix dojson publishers conversion (3rd time)

### DIFF
--- a/data/300.json
+++ b/data/300.json
@@ -823,7 +823,6 @@
     ],
     "title": "How to develop new ecumenical mass communication",
     "publicationYear": 1973,
-    "publishers": [],
     "is_part_of": "Japan Missionary Bulletin"
   },
   {
@@ -922,7 +921,6 @@
     },
     "title": "The Constitution of local councils of churches, The membership of local councils of churches, The organization of local councils of churches, Youth and local councils of churches",
     "publicationYear": 1969,
-    "publishers": [],
     "is_part_of": "Voyage, supplement"
   },
   {
@@ -988,7 +986,6 @@
     ],
     "title": "Le Partage de la foi : le COE a 25 ans",
     "publicationYear": 1973,
-    "publishers": [],
     "is_part_of": "R\u00e9forme : hebdomadaire protestant d'information g\u00e9n\u00e9rale"
   },
   {
@@ -2739,7 +2736,6 @@
     ],
     "title": "Paul VI on ecumenism",
     "publicationYear": 1967,
-    "publishers": [],
     "is_part_of": "Month : an illustrated magazine of literature, science and art"
   },
   {
@@ -2836,7 +2832,6 @@
     ],
     "title": "Le mouvement oecum\u00e9nique s'est approfondi",
     "publicationYear": 1967,
-    "publishers": [],
     "is_part_of": "Unitas : international ecumenical review"
   },
   {
@@ -3909,7 +3904,6 @@
     ],
     "title": "Spannung in der \u00d6kumene",
     "publicationYear": 1975,
-    "publishers": [],
     "is_part_of": "Lutherische Rundschau : Zeitschrift des Lutherischen Weltbundes"
   },
   {
@@ -4895,7 +4889,6 @@
     ],
     "title": "Healing in the local church : Oekolampad Basle, Switzerland",
     "publicationYear": 2001,
-    "publishers": [],
     "is_part_of": "International review of mission"
   },
   {
@@ -5519,7 +5512,6 @@
     ],
     "title": "Growing together towards the unity of the Church",
     "publicationYear": 1984,
-    "publishers": [],
     "is_part_of": "Mid-stream : an ecumenical journal"
   },
   {
@@ -7563,7 +7555,6 @@
     ],
     "title": "Ecclesiological aspects of the race problem",
     "publicationYear": 1970,
-    "publishers": [],
     "is_part_of": "International review of mission"
   },
   {
@@ -7775,7 +7766,6 @@
     },
     "title": "Report on the Youth Pre-conference \"Risking obedience\"",
     "publicationYear": 1989,
-    "publishers": [],
     "is_part_of": "International review of mission"
   },
   {
@@ -8522,7 +8512,6 @@
     },
     "title": "Auf dem Weg zum gemeinsamen Aussprechen des apostolischen Glaubens heute",
     "publicationYear": 1985,
-    "publishers": [],
     "is_part_of": "\u00d6kumenische Rundschau"
   },
   {
@@ -8890,7 +8879,6 @@
     ],
     "title": "\u00d6kumene gewinnt Profil (XII) : die Partnerschaft zwischen den Kirchenkreisen Koblenz und Agusan / Philippinen",
     "publicationYear": 1990,
-    "publishers": [],
     "is_part_of": "\u00d6kumenische Rundschau"
   },
   {
@@ -9315,7 +9303,6 @@
     ],
     "title": "Development service and China's modernization : the Amity Foundation in theological perspective",
     "publicationYear": 1989,
-    "publishers": [],
     "is_part_of": "Ecumenical review : a quarterly"
   },
   {
@@ -9558,7 +9545,6 @@
     },
     "title": "Central Committee of WCC Holds Annual Session at Geneva",
     "publicationYear": 1966,
-    "publishers": [],
     "is_part_of": "Unitas : international ecumenical review"
   },
   {
@@ -10459,7 +10445,6 @@
     ],
     "title": "Ursachen und Anl\u00e4sse der Walliser Auswanderung im 19. Jahrhundert",
     "publicationYear": 1991,
-    "publishers": [],
     "is_part_of": "Valais d'\u00e9migration : publication accompagnant l'exposition Ubi bene ibi patria - Valais d'\u00e9migration XVIe - XXe si\u00e8cle, Mus\u00e9e cantonal d'histoire et d'ethnographie Val\u00e8re 24 mai - 3 novembre 1991 = Auswanderungsland Wallis : Begleitpublikation zur Ausstellung Ubi bene ibi patria - Auswanderungsland Wallis 16. - 20. Jahrhundert, Kantonales Museum f\u00fcr Geschichte und Ethnographie Val\u00e8re 24. Mai - 3. November 1991"
   },
   {
@@ -10619,7 +10604,6 @@
     ],
     "title": "Gedanken zur Weltkonferenz 'Kirche und Gesellschaft', Genf 1966",
     "publicationYear": 1967,
-    "publishers": [],
     "is_part_of": "\u00d6kumenische Rundschau"
   },
   {
@@ -10678,7 +10662,6 @@
     ],
     "title": "Martin Chemnitz and the Eastern Church : A christology of the Catholic consensus of the Fathers",
     "publicationYear": 1994,
-    "publishers": [],
     "is_part_of": "St. Vladimir's theological quarterly"
   },
   {
@@ -11036,7 +11019,6 @@
     ],
     "title": "Assembly theme discussed in Bossey",
     "publicationYear": 1968,
-    "publishers": [],
     "is_part_of": "St. Vladimir's theological quarterly"
   },
   {
@@ -11140,7 +11122,6 @@
     ],
     "title": "Reflection on councils of churches",
     "publicationYear": 1967,
-    "publishers": [],
     "is_part_of": "One in Christ : a catholic ecumenical review"
   },
   {
@@ -12012,7 +11993,6 @@
     ],
     "title": "La salud de la mujer es algo mas que una cuestion medica",
     "publicationYear": 1984,
-    "publishers": [],
     "is_part_of": "Contact"
   },
   {

--- a/rero_ils/modules/documents/dojson/contrib/marc21tojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/marc21tojson/model.py
@@ -293,8 +293,10 @@ def marc21_to_publishers_publicationDate(self, key, value):
 
     if publisher:
         publishers.append(publisher)
-
-    return publishers
+    if not publishers:
+        return None
+    else:
+        return publishers
 
 
 @marc21tojson.over('formats', '^300..')

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -435,7 +435,7 @@ def test_marc21_to_publishers_publicationDate():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert not data.get('publishers')
+    assert 'publishers' not in data
     assert data.get('publicationYear') == 1984
 
 


### PR DESCRIPTION
* FIX Fixes #367.
* FIX Makes sure dojson conversion does not return an empty array for
publishers.
* FIX Asserts in the tests that there's not empty array for publishers.
Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## to test

- `./run-tests.sh`
- `./script/setup` should succeed.