### PR TITLE
circulation: improve circulation dates

### DIFF
--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -177,8 +177,8 @@ def can_request(item):
                 item_status = item.get('status')
                 if item_status != 'missing':
                     loaned_to_patron = item.is_loaned_to_patron(patron_barcode)
-                    request = item.is_requested_by_patron(patron_barcode)
-                    if not (request or loaned_to_patron):
+                    requested = item.is_requested_by_patron(patron_barcode)
+                    if not (requested or loaned_to_patron):
                         return True
     return False
 
@@ -190,8 +190,8 @@ def requested_this_item(item):
         patron = Patron.get_patron_by_user(current_user)
         if patron and 'patron' in patron.get('roles'):
             patron_barcode = patron.get('barcode')
-            request = item.is_requested_by_patron(patron_barcode)
-            if request:
+            requested = item.is_requested_by_patron(patron_barcode)
+            if requested:
                 return True
     return False
 

--- a/tests/api/test_libraries_rest.py
+++ b/tests/api/test_libraries_rest.py
@@ -94,8 +94,7 @@ def test_libraries_get(client, lib_martigny):
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
-def test_libraries_post_put_delete(client, org_martigny, lib_martigny_data,
-                                   json_header):
+def test_libraries_post_put_delete(client, lib_martigny_data, json_header):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.lib_item', pid_value='1')
     post_url = url_for('invenio_records_rest.lib_list')
@@ -155,12 +154,12 @@ def test_libraries_post_put_delete(client, org_martigny, lib_martigny_data,
     assert res.status_code == 410
 
 
-def test_library_no_pickup(client, lib_sion, loc_restricted_sion):
+def test_library_no_pickup(lib_sion):
     """Test library with no pick_up location."""
     assert not lib_sion.get_pickup_location_pid()
 
 
-def test_library_never_open(client, lib_sion, lib_martigny):
+def test_library_never_open(lib_sion):
     """Test library with no opening hours."""
     assert lib_sion._has_is_open()
     assert lib_sion.next_open()
@@ -177,40 +176,40 @@ def test_library_never_open(client, lib_sion, lib_martigny):
         assert lib_sion.next_open()
 
 
-def test_library_exceptions(client, lib_martigny):
+def test_library_exceptions(lib_martigny):
     """Test library exceptions."""
     assert lib_martigny._has_is_open()
     assert lib_martigny.next_open()
-    assert not lib_martigny.is_open(date=parser.parse('2018-12-15'))
-    assert not lib_martigny.is_open(date=parser.parse('2019-01-06'))
+    assert lib_martigny.is_open(date=parser.parse('2018-12-15'))
+    assert lib_martigny.is_open(date=parser.parse('2019-01-05'))
+    assert not lib_martigny.is_open(date=parser.parse('2019-08-01'))
 
     exception_dates = lib_martigny.get('exception_dates')
     exception_open_false = lib_martigny._has_exception(
-            _open=False,
-            date=parser.parse('2019-01-06'),
-            exception_dates=exception_dates,
-            day_only=False
+        _open=False,
+        date=parser.parse('2019-01-06'),
+        exception_dates=exception_dates,
+        day_only=False
     )
     exception_open_true = lib_martigny._has_exception(
-            _open=True,
-            date=parser.parse('2019-01-06'),
-            exception_dates=exception_dates,
-            day_only=False
+        _open=True,
+        date=parser.parse('2019-01-06'),
+        exception_dates=exception_dates,
+        day_only=False
     )
-    # One of these asserts should fail, this to demonstrate the bug documented
-    # in https://github.com/rero/rero-ils/issues/263
-    assert not exception_open_false
+
+    assert exception_open_false
     assert not exception_open_true
 
     assert not lib_martigny._has_exception(
-            _open=True,
-            date=parser.parse('2019-08-01'),
-            exception_dates=exception_dates,
-            day_only=False
+        _open=True,
+        date=parser.parse('2019-08-01'),
+        exception_dates=exception_dates,
+        day_only=False
     )
 
 
-def test_library_can_delete(client, lib_martigny, librarian_martigny_no_email,
+def test_library_can_delete(lib_martigny, librarian_martigny_no_email,
                             loc_public_martigny):
     """Test can delete a library."""
     links = lib_martigny.get_links_to_me()
@@ -245,7 +244,7 @@ def test_filtered_libraries_get(
     assert data['hits']['total'] == 1
 
 
-def test_library_secure_api(client, json_header, lib_martigny,
+def test_library_secure_api(client, lib_martigny,
                             librarian_martigny_no_email,
                             librarian_sion_no_email):
     """Test library secure api access."""
@@ -327,9 +326,7 @@ def test_library_secure_api_update(client, lib_fully,
 
 def test_library_secure_api_delete(client, lib_fully,
                                    librarian_martigny_no_email,
-                                   librarian_sion_no_email,
-                                   lib_fully_data,
-                                   json_header):
+                                   librarian_sion_no_email):
     """Test library secure api delete."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)

--- a/tests/ui/libraries/test_libraries_api.py
+++ b/tests/ui/libraries/test_libraries_api.py
@@ -53,8 +53,8 @@ def test_libraries_is_open(lib_martigny):
     library = lib_martigny
     assert library.is_open(date=saturday)
 
-    assert not library.is_open(date='2018-8-1')
-    assert not library.is_open(date='2222-8-1')
+    assert not library.is_open(date=parser.parse('2019-08-01'))
+    assert not library.is_open(date=parser.parse('2222-8-1'))
 
     del library['exception_dates']
     library.replace(library.dumps(), dbcommit=True)

--- a/tests/ui/loans/test_loans_api.py
+++ b/tests/ui/loans/test_loans_api.py
@@ -26,16 +26,30 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_circulation.pidstore.fetchers import loan_pid_fetcher
+from copy import deepcopy
 from invenio_circulation.proxies import current_circulation
 from utils import get_mapping
 
-from rero_ils.modules.loans.api import Loan
+from rero_ils.modules.loans.api import get_loans_by_patron_pid
+from rero_ils.modules.loans.utils import get_default_loan_duration
 
 
-def test_loans_create(db, loan_pending_martigny):
+def test_loans_create(loan_pending_martigny):
     """Test loan creation."""
     assert loan_pending_martigny.get('state') == 'PENDING'
+
+
+def test_loans_elemnts(loan_pending_martigny, item_lib_fully):
+    """Test loan elements."""
+    assert loan_pending_martigny.item_pid == item_lib_fully.pid
+
+    loan = list(get_loans_by_patron_pid(loan_pending_martigny.patron_pid))[0]
+    assert loan.get('loan_pid') == loan_pending_martigny.get('loan_pid')
+
+    new_loan = deepcopy(loan_pending_martigny)
+    del new_loan['transaction_location_pid']
+    assert get_default_loan_duration(new_loan) == \
+        get_default_loan_duration(loan_pending_martigny)
 
 
 def test_loan_es_mapping(es_clear, db):


### PR DESCRIPTION
* Fixes issue when a library exception opening day is considered as closed.
* Fixes closes #263.
* Improves the calculation of the due date of a circulation transaction. Now it is based on the transaction library instead of item owning library.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>