### PR TITLE
[spike] holdings: introduce holding level

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -56,6 +56,7 @@ from rero_ils.utils import get_agg_config
 
 from .modules.circ_policies.api import CircPolicy
 from .modules.documents.api import Document
+from .modules.holdings.api import Holding, HoldingsIndexer
 from .modules.item_types.api import ItemType
 from .modules.items.api import Item, ItemsIndexer
 from .modules.libraries.api import Library
@@ -392,6 +393,38 @@ RECORDS_REST_ENDPOINTS = dict(
         },
         record_class='rero_ils.modules.items.api:Item',
         item_route='/items/<pid(item, record_class="rero_ils.modules.items.api:Item"):pid_value>',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp='rero_ils.query:organisation_search_factory',
+        read_permission_factory_imp=can_access_organisation_records_factory,
+        create_permission_factory_imp=can_create_organisation_records_factory,
+        update_permission_factory_imp=can_update_organisation_records_factory,
+        delete_permission_factory_imp=can_delete_organisation_records_factory,
+    ),
+    hold=dict(
+        pid_type='hold',
+        pid_minter='holding_id',
+        pid_fetcher='holding_id',
+        search_class=RecordsSearch,
+        search_index='holdings',
+        search_type=None,
+        indexer_class=HoldingsIndexer,
+        record_serializers={
+            'application/json': (
+                'rero_ils.modules.serializers:json_v1_response'
+            )
+        },
+        search_serializers={
+            'application/json': (
+                'rero_ils.modules.serializers:json_v1_search'
+            )
+        },
+        list_route='/holdings/',
+        record_loaders={
+            'application/json': lambda: Holding(request.get_json()),
+        },
+        record_class='rero_ils.modules.holdings.api:Holding',
+        item_route='/holdings/<pid(hold, record_class="rero_ils.modules.holdings.api:Holding"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='rero_ils.query:organisation_search_factory',
@@ -885,6 +918,15 @@ RECORDS_UI_ENDPOINTS = {
         permission_factory_imp='rero_ils.permissions.'
                                'librarian_permission_factory',
     ),
+    'hold': dict(
+        pid_type='hold',
+        route='/holdings/<pid_value>',
+        template='rero_ils/detailed_view_holdings.html',
+        view_imp='rero_ils.modules.holdings.views.holding_view_method',
+        record_class='rero_ils.modules.holdings.api:Holding',
+        permission_factory_imp='rero_ils.permissions.'
+                               'librarian_permission_factory',
+    ),
 }
 
 RECORDS_UI_EXPORT_FORMATS = {
@@ -908,6 +950,7 @@ RECORDS_JSON_SCHEMA = {
     'ptrn': '/patrons/patron-v0.0.1.json',
     'ptty': '/patron_types/patron_type-v0.0.1.json',
     'notif': '/notifications/notification-v0.0.1.json',
+    'hold': '/holdings/holding-v0.0.1.json',
 }
 
 # Login Configuration

--- a/rero_ils/modules/admin.py
+++ b/rero_ils/modules/admin.py
@@ -204,3 +204,14 @@ items = {
         menu_icon_value='fa-barcode'
     )
 }
+
+holdings = {
+    'view_class': LibraryManager,
+    'kwargs': dict(
+        name='Holdings',
+        category='Resources',
+        endpoint='records/holdings',
+        menu_icon_type='fa',
+        menu_icon_value='fa-barcode'
+    )
+}

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -106,6 +106,7 @@ class IlsRecord(Record):
     fetcher = None
     provider = None
     object_type = 'rec'
+    indexer = IlsRecordIndexer
 
     @classmethod
     def create(cls, data, id_=None, delete_pid=False,
@@ -274,9 +275,9 @@ class IlsRecord(Record):
     def reindex(self, forceindex=False):
         """Reindex record."""
         if forceindex:
-            RecordIndexer(version_type="external_gte").index(self)
+            self.indexer(version_type="external_gte").index(self)
         else:
-            RecordIndexer().index(self)
+            self.indexer().index(self)
 
     def delete_from_index(self):
         """Delete record from index."""

--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -39,6 +39,7 @@ from flask_security.confirmable import confirm_user
 from invenio_accounts.cli import commit, users
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records.api import Record
+from invenio_records_rest.utils import obj_or_import_string
 from invenio_search.cli import es_version_check
 from invenio_search.proxies import current_search, current_search_client
 from werkzeug.local import LocalProxy
@@ -59,6 +60,32 @@ fixtures.add_command(import_users)
 fixtures.add_command(create_items)
 fixtures.add_command(reindex_items)
 fixtures.add_command(create_loans)
+
+
+@click.command('create')
+@click.option('-v', '--verbose', 'verbose', is_flag=True, default=False)
+@click.option('--pid_type', default=None)
+@click.argument('infile', type=click.File('r'), default=sys.stdin)
+@with_appcontext
+def create(infile, pid_type, verbose):
+    """Load REROILS record.
+
+    infile: Json file
+    """
+    click.secho('Loading "%s" records.' % pid_type, fg='green')
+    record_class = obj_or_import_string(
+        current_app.config
+        .get('RECORDS_REST_ENDPOINTS')
+        .get(pid_type).get('record_class', Record))
+    data = json.load(infile)
+    for record in data:
+        rec = record_class.create(record, dbcommit=True, reindex=True)
+        click.echo(
+            '{pid_type} created {id}'.format(pid_type=pid_type, id=rec.id)
+        )
+
+
+fixtures.add_command(create)
 
 
 @users.command('confirm')

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -75,6 +75,19 @@ class Document(IlsRecord):
         # TODO: Make this condition on data
         return not self.harvested
 
+    def item_organisations(self, view_code):
+        """Returns organisations of items attached to document."""
+        from ..items.api import Item
+        from ..organisations.api import Organisation
+
+        organisations = []
+        for item_pid in Item.get_items_pid_by_document_pid(self.pid):
+            item = Item.get_record_by_pid(item_pid)
+            org = Organisation.get_record_by_pid(item.ogranisation_pid)
+            if org.get('view_code') == view_code:
+                organisations.append(item.ogranisation_pid)
+        return organisations
+
     def get_number_of_items(self):
         """Get number of items for document."""
         from ..items.api import ItemsSearch

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -37,6 +37,7 @@ from .apiharvester.signals import apiharvest_part
 from .documents.listener import enrich_document_data, mef_person_delete, \
     mef_person_insert, mef_person_revert, mef_person_update
 from .ebooks.receivers import publish_harvested_records
+from .holdings.listener import enrich_holding_data
 from .items.listener import enrich_item_data
 from .items.signals import item_at_desk
 from .loans.listener import enrich_loan_data, listener_loan_state_changed
@@ -102,6 +103,7 @@ class REROILSAPP(object):
         before_record_index.connect(enrich_item_data)
         before_record_index.connect(enrich_patron_data)
         before_record_index.connect(enrich_location_data)
+        before_record_index.connect(enrich_holding_data)
         before_record_index.connect(enrich_notification_data)
 
         item_at_desk.connect(listener_item_at_desk)

--- a/rero_ils/modules/holdings/__init__.py
+++ b/rero_ils/modules/holdings/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2019 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holdings Records."""

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2019 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""API for manipulating holdings."""
+
+from __future__ import absolute_import, print_function
+
+from functools import partial
+
+from flask import current_app
+from invenio_search import current_search
+from invenio_search.api import RecordsSearch
+from elasticsearch.exceptions import NotFoundError
+
+from .models import HoldingIdentifier, HoldingMetadata
+from ..api import IlsRecord, IlsRecordIndexer, IlsRecordError
+from ..documents.api import Document, DocumentsSearch
+from ..fetchers import id_fetcher
+from ..items.api import ItemsSearch
+from ..locations.api import Location
+from ..minters import id_minter
+from ..providers import Provider
+
+# notif provider
+HoldingProvider = type(
+    'HoldingProvider',
+    (Provider,),
+    dict(identifier=HoldingIdentifier, pid_type='hold')
+)
+# notif minter
+holding_id_minter = partial(id_minter, provider=HoldingProvider)
+# notif fetcher
+holding_id_fetcher = partial(id_fetcher, provider=HoldingProvider)
+
+
+class HoldingsSearch(RecordsSearch):
+    """RecordsSearch for holdings."""
+
+    class Meta:
+        """Search only on holdings index."""
+
+        index = 'holdings'
+
+    @classmethod
+    def flush(cls):
+        """Flush indexes."""
+        current_search.flush_and_refresh(DocumentsSearch.Meta.index)
+        current_search.flush_and_refresh(cls.Meta.index)
+
+
+class HoldingsIndexer(IlsRecordIndexer):
+    """Holdings indexing class."""
+
+    def index(self, record):
+        """Indexing a holding record."""
+        return_value = super(HoldingsIndexer, self).index(record)
+        document_pid = record.replace_refs()['document']['pid']
+        document = Document.get_record_by_pid(document_pid)
+        document.reindex()
+        current_search.flush_and_refresh(DocumentsSearch.Meta.index)
+        return return_value
+
+
+class Holding(IlsRecord):
+    """Holding class."""
+
+    minter = holding_id_minter
+    fetcher = holding_id_fetcher
+    provider = HoldingProvider
+    model_cls = HoldingMetadata
+    indexer = HoldingsIndexer
+
+    def delete_from_index(self):
+        """Delete record from index."""
+        try:
+            HoldingsIndexer().delete(self)
+        except NotFoundError:
+            pass
+
+    @property
+    def document_pid(self):
+        """Shortcut for document pid of the holding."""
+        return self.replace_refs()['document']['pid']
+
+    @property
+    def circulation_type_pid(self):
+        """Shortcut for circulation type pid of the holding."""
+        return self.replace_refs()['circulation_type']['pid']
+
+    @property
+    def location_pid(self):
+        """Shortcut for location pid of the holding."""
+        return self.replace_refs()['location']['pid']
+
+    @property
+    def organisation_pid(self):
+        """Get organisation pid for holding."""
+        location = Location.get_record_by_pid(self.location_pid)
+        return location.organisation_pid
+
+    @classmethod
+    def get_document_pid_by_holding_pid(cls, holding_pid):
+        """Returns document pid for a holding pid."""
+        holding = cls.get_record_by_pid(holding_pid).replace_refs()
+        return holding.get('document', {}).get('pid')
+
+    @classmethod
+    def get_holdings_pid_by_document_pid(cls, document_pid):
+        """Returns holding pids attached for a given document pid."""
+        results = HoldingsSearch()\
+            .filter('term', document__pid=document_pid)\
+            .source(['pid']).scan()
+        for holding in results:
+            yield holding.pid
+
+    def get_number_of_items(self):
+        """Get holding number of items."""
+        results = ItemsSearch().filter(
+            'term', holding__pid=self.pid).source().count()
+        return results
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        items = self.get_number_of_items()
+        if items:
+            links['items'] = items
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete
+
+
+def get_holding_pid_for_item(document_pid, location_pid, item_type_pid):
+    """Returns holding pid for document/location/item type."""
+    result = HoldingsSearch().filter(
+        'term',
+        document__pid=document_pid
+    ).filter(
+        'term',
+        circulation_type__pid=item_type_pid
+    ).filter(
+        'term',
+        location__pid=location_pid
+    ).source().scan()
+    try:
+        return next(result).pid
+    except StopIteration:
+        return None
+
+
+def create_holding_for_item(document_pid, location_pid,
+                            item_type_pid):
+    """Create a new holding to link an item."""
+    data = {}
+    schemas = current_app.config.get('RECORDS_JSON_SCHEMA')
+    data_schema = {
+        'base_url': current_app.config.get(
+            'RERO_ILS_APP_BASE_URL'
+        ),
+        'schema_endpoint': current_app.config.get(
+            'JSONSCHEMAS_ENDPOINT'
+        ),
+        'schema': schemas['hold']
+    }
+    data['$schema'] = '{base_url}{schema_endpoint}{schema}'\
+        .format(**data_schema)
+
+    base_url = current_app.config.get('RERO_ILS_APP_BASE_URL')
+    url_api = '{base_url}/api/{doc_type}/{pid}'
+    data['location'] = {
+        '$ref': url_api.format(
+            base_url=base_url,
+            doc_type='locations',
+            pid=location_pid)
+    }
+    data['circulation_type'] = {
+        '$ref': url_api.format(
+            base_url=base_url,
+            doc_type='item_types',
+            pid=item_type_pid)
+    }
+    data['document'] = {
+        '$ref': url_api.format(
+            base_url=base_url,
+            doc_type='documents',
+            pid=document_pid)
+    }
+
+    record = Holding.create(
+        data, dbcommit=True, reindex=True, delete_pid=True)
+    return record.get('pid')

--- a/rero_ils/modules/holdings/api_views.py
+++ b/rero_ils/modules/holdings/api_views.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Blueprint used for loading templates."""
+
+from __future__ import absolute_import, print_function
+
+from functools import wraps
+
+from flask import Blueprint, jsonify
+from flask_login import current_user
+from werkzeug.exceptions import NotFound
+
+from ...permissions import librarian_permission
+
+api_blueprint = Blueprint(
+    'api_holding',
+    __name__,
+    url_prefix='/holding'
+)

--- a/rero_ils/modules/holdings/jsonresolver.py
+++ b/rero_ils/modules/holdings/jsonresolver.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holding resolver."""
+
+
+import jsonresolver
+from flask import current_app
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+
+
+@jsonresolver.route('/api/holdings/<pid>', host='ils.rero.ch')
+def holding_resolver(pid):
+    """."""
+    persistent_id = PersistentIdentifier.get('hold', pid)
+    if persistent_id.status == PIDStatus.REGISTERED:
+        return dict(pid=persistent_id.pid_value)
+    current_app.logger.error(
+        'Doc resolver error: /api/holdings/{pid} {persistent_id}'.format(
+            pid=pid,
+            persistent_id=persistent_id
+        )
+    )
+    raise Exception('unable to resolve')

--- a/rero_ils/modules/holdings/jsonschemas/__init__.py
+++ b/rero_ils/modules/holdings/jsonschemas/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 RERO.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holdings JSON schemas."""

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Holding",
+  "description": "JSON schema for holdings.",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "pid"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "Schema to validate holdings records against.",
+      "type": "string",
+      "minLength": 9,
+      "default": "https://ils.rero.ch/schema/holdings/holding-v0.0.1.json"
+    },
+    "pid": {
+      "title": "Holding ID",
+      "type": "string",
+      "minLength": 1
+    },
+    "call_number": {
+      "type": "string",
+      "minLength": 4,
+      "title": "Holding call number.",
+      "description": "Call number of the holding."
+    },
+    "circulation_type": {
+      "title": "Circulation type",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "circulation type URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/item_types/.*?$"
+        }
+      }
+    },
+    "location": {
+      "title": "Location",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Location URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/locations/.*?$"
+        }
+      }
+    },
+    "document": {
+      "title": "Document",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Document URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/documents/.*?$"
+        }
+      }
+    }
+  }
+}

--- a/rero_ils/modules/holdings/listener.py
+++ b/rero_ils/modules/holdings/listener.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Signals connector for Holding."""
+
+from .api import Holding, HoldingsSearch
+
+
+def enrich_holding_data(sender, json=None, record=None, index=None,
+                        **dummy_kwargs):
+    """Signal sent before a record is indexed.
+
+    :params json: The dumped record dictionary which can be modified.
+    :params record: The record being indexed.
+    :params index: The index in which the record will be indexed.
+    :params doc_type: The doc_type for the record.
+    """
+    holding_index_name = HoldingsSearch.Meta.index
+    if index.startswith(holding_index_name):
+        holding = record
+        if not isinstance(record, Holding):
+            holding = Holding.get_record_by_pid(record.get('pid'))
+        org_pid = holding.organisation_pid
+        json['organisation'] = {
+            'pid': org_pid
+        }

--- a/rero_ils/modules/holdings/mappings/__init__.py
+++ b/rero_ils/modules/holdings/mappings/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 RERO.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holdings Elasticsearch mappings."""

--- a/rero_ils/modules/holdings/mappings/v6/__init__.py
+++ b/rero_ils/modules/holdings/mappings/v6/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 RERO.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holdings elasticsearch mappings."""

--- a/rero_ils/modules/holdings/mappings/v6/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v6/holdings/holding-v0.0.1.json
@@ -5,7 +5,7 @@
     "max_result_window": 20000
   },
   "mappings": {
-    "item-v0.0.1": {
+    "holding-v0.0.1": {
       "date_detection": false,
       "numeric_detection": false,
       "properties": {
@@ -15,11 +15,15 @@
         "pid": {
           "type": "keyword"
         },
-        "barcode": {
-          "type": "keyword"
-        },
         "call_number": {
           "type": "keyword"
+        },
+        "circulation_type": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
         },
         "location": {
           "properties": {
@@ -29,33 +33,6 @@
           }
         },
         "document": {
-          "properties": {
-            "pid": {
-              "type": "keyword"
-            }
-          }
-        },
-        "item_type": {
-          "properties": {
-            "pid": {
-              "type": "keyword"
-            }
-          }
-        },
-        "holding": {
-          "properties": {
-            "pid": {
-              "type": "keyword"
-            }
-          }
-        },
-        "status": {
-          "type": "keyword"
-        },
-        "available": {
-          "type": "boolean"
-        },
-        "organisation": {
           "properties": {
             "pid": {
               "type": "keyword"

--- a/rero_ils/modules/holdings/models.py
+++ b/rero_ils/modules/holdings/models.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2019 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Define relation between records and buckets."""
+
+from __future__ import absolute_import
+
+from invenio_db import db
+from invenio_pidstore.models import RecordIdentifier
+from invenio_records.models import RecordMetadataBase
+
+
+class HoldingIdentifier(RecordIdentifier):
+    """Sequence generator for holdings identifiers."""
+
+    __tablename__ = 'holding_id'
+    __mapper_args__ = {'concrete': True}
+
+    recid = db.Column(
+        db.BigInteger().with_variant(db.Integer, 'sqlite'),
+        primary_key=True, autoincrement=True,
+    )
+
+
+class HoldingMetadata(db.Model, RecordMetadataBase):
+    """Holding record metadata."""
+
+    __tablename__ = 'holdings_metadata'

--- a/rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html
+++ b/rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html
@@ -1,0 +1,52 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of RERO ILS.
+  Copyright (C) 2018 RERO.
+
+  RERO ILS is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License License; see LICENSE file for more details.
+
+#}
+{% from 'rero_ils/macros/macro.html' import dl %}
+{%- extends 'rero_ils/page.html' %}
+{%- block body %}
+  <header class="row">
+    <!-- TODO: Add cover -->
+    <div id="thumbnail" class="col-sm-2 col-md-1 d-flex justify-content-start">
+      <div class="thumb">
+        <figure class="mb-0">
+          <img class="img-responsive border border-light" src="{{ url_for('static', filename='images/icon_') }}{{ document.type }}.png">
+          <figcaption class="text-center">{{ _(document.type) }}</figcaption>
+        </figure>
+      </div>
+    </div>
+   <h1 class="col-sm-11 col-md-11">{{ _('Barcode') }} {{ record.barcode }}</h1>
+  </header>
+  <section>
+    <!-- Holding data -->
+    <section class="py-4">
+      <article>
+        <dl class="row mb-0">
+          {{ dl(_('Call number'), record.call_number) }}
+          {{ dl(
+            _('Document'),
+            '<a href="'+ url_for('invenio_records_ui.doc', pid_value=document.pid) +'">' + document.title +'</a>')
+          }}
+        </dl>
+      </article>
+      <footer class="d-flex flex-column pt-2">
+          <!-- TODO: delete button -->
+        {% with
+          href_update=url_for('records/holdings.index', path=record.pid + '?document=' + document.pid),
+          href_delete='/api/holdings/' + record.pid,
+          json=record,
+          message=_("Holding cannot be deleted: there are still transactions linked to this holding.")
+        %}
+          {% include 'rero_ils/_editor_button_actions.html' %}
+        {% endwith %}
+      </footer>
+    </section>
+    <!-- Transactions data -->
+  </section>
+
+{%- endblock body %}

--- a/rero_ils/modules/holdings/views.py
+++ b/rero_ils/modules/holdings/views.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Blueprint used for loading templates."""
+
+from __future__ import absolute_import, print_function
+
+from functools import wraps
+
+from flask import Blueprint, current_app, flash, jsonify, redirect, \
+    render_template, url_for
+from flask_babelex import gettext as _
+from flask_login import current_user
+from invenio_records_ui.signals import record_viewed
+
+from .api import Holding
+from ..documents.api import Document
+from ...permissions import request_item_permission
+
+
+def holding_view_method(pid, record, template=None, **kwargs):
+    r"""Display default view.
+
+    Sends record_viewed signal and renders template.
+    :param pid: PID object.
+    :param record: Record object.
+    :param template: Template to render.
+    :param \*\*kwargs: Additional view arguments based on URL rule.
+    :returns: The rendered template.
+    """
+    record_viewed.send(
+        current_app._get_current_object(), pid=pid, record=record
+    )
+    document = Document.get_record_by_pid(
+        record.replace_refs()['document']['pid'])
+    holding = record.replace_refs()
+    return render_template(
+        template, pid=pid, record=record, document=document)
+
+
+blueprint = Blueprint(
+    'holding',
+    __name__,
+    url_prefix='/holding',
+    template_folder='templates',
+    static_folder='static',
+)

--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -183,6 +183,7 @@ class Item(IlsRecord):
     minter = item_id_minter
     fetcher = item_id_fetcher
     provider = ItemProvider
+    indexer = ItemsIndexer
 
     statuses = {
         'ITEM_ON_LOAN': 'on_loan',
@@ -481,13 +482,6 @@ class Item(IlsRecord):
         # else:
         #     actions.add('lose')
         return actions
-
-    def reindex(self, forceindex=False):
-        """Reindex record."""
-        if forceindex:
-            ItemsIndexer(version_type="external_gte").index(self)
-        else:
-            ItemsIndexer().index(self)
 
     def status_update(self, dbcommit=False, reindex=False, forceindex=False):
         """Update item status."""

--- a/rero_ils/modules/items/cli.py
+++ b/rero_ils/modules/items/cli.py
@@ -31,7 +31,10 @@ import random
 from random import randint
 
 import click
+from flask import current_app
 from flask.cli import with_appcontext
+from invenio_records.api import Record
+from invenio_records_rest.utils import obj_or_import_string
 
 from .models import ItemIdentifier, ItemStatus
 from ..documents.api import Document

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -74,6 +74,18 @@
         }
       }
     },
+    "holding": {
+      "title": "Holding",
+      "description": "Holding record for the item.",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Holding URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/holdings/.+?$"
+        }
+      }
+    },
     "status": {
       "type": "string",
       "default": "on_shelf",

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -76,7 +76,7 @@ def can_access_organisation_records_factory(record, *args, **kwargs):
         patron = staffer_is_authenticated()
         if patron and patron.organisation_pid == record.organisation_pid:
             if patron.is_librarian or patron.is_system_librarian:
-                    return True
+                return True
         return False
     return type('Check', (), {'can': can})()
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -77,22 +77,22 @@ pipenv run invenio roles add admin@rero.ch admins
 pipenv run invenio roles add admin@rero.ch superusers
 
 echo -e ${GREEN}Organisations:${NC}
-pipenv run invenio records create --pid-minter organisation_id ${DATA_PATH}/organisations.json
+pipenv run invenio fixtures create --pid_type org ${DATA_PATH}/organisations.json
 pipenv run invenio index reindex -t org --yes-i-know
 echo -e ${GREEN}Libraries:${NC}
-pipenv run invenio records create --pid-minter library_id ${DATA_PATH}/libraries.json
+pipenv run invenio fixtures create --pid_type lib ${DATA_PATH}/libraries.json
 pipenv run invenio index reindex -t lib --yes-i-know
 echo -e ${GREEN}Locations:${NC}
-pipenv run invenio records create --pid-minter location_id ${DATA_PATH}/locations.json
+pipenv run invenio fixtures create --pid_type loc ${DATA_PATH}/locations.json
 pipenv run invenio index reindex -t loc --yes-i-know
 echo -e ${GREEN}Item types:${NC}
-pipenv run invenio records create --pid-minter item_type_id ${DATA_PATH}/item_types.json
+pipenv run invenio fixtures create --pid_type itty ${DATA_PATH}/item_types.json
 pipenv run invenio index reindex -t itty --yes-i-know
 echo -e ${GREEN}Patron types:${NC}
-pipenv run invenio records create --pid-minter patron_type_id ${DATA_PATH}/patron_types.json
+pipenv run invenio fixtures create --pid_type ptty ${DATA_PATH}/patron_types.json
 pipenv run invenio index reindex -t ptty --yes-i-know
 echo -e ${GREEN}Circulation policies:${NC}
-pipenv run invenio records create --pid-minter circ_policy_id ${DATA_PATH}/circulation_policies.json
+pipenv run invenio fixtures create --pid_type cipo ${DATA_PATH}/circulation_policies.json
 pipenv run invenio index reindex -t cipo --yes-i-know
 pipenv run invenio index run --raise-on-error
 
@@ -116,7 +116,7 @@ else
 fi
 
 echo -e ${GREEN}Documents:${NC} ${DOCUMENTS}
-pipenv run dojson -i ${DOCUMENTS} schema 'http://ils.rero.ch/schema/documents/document-v0.0.1.json' | pipenv run invenio records create --pid-minter document_id
+pipenv run dojson -i ${DOCUMENTS} schema 'http://ils.rero.ch/schema/documents/document-v0.0.1.json' | pipenv run invenio fixtures create --pid_type doc
 
 # create items
 # NEEDS item type !!!
@@ -124,13 +124,14 @@ pipenv run dojson -i ${DOCUMENTS} schema 'http://ils.rero.ch/schema/documents/do
 # pipenv run invenio fixtures create_items -c 10000 -i 5 ${DATA_PATH}/items10k.json
 # pipenv run invenio fixtures create_items -c 300 -i 5 ${DATA_PATH}/items300.json
 echo -e ${GREEN}Items:${NC} ${ITEMS}
-pipenv run dojson -i ${ITEMS} schema 'http://ils.rero.ch/schema/items/item-v0.0.1.json' | pipenv run invenio records create --pid-minter item_id
+pipenv run dojson -i ${ITEMS} schema 'http://ils.rero.ch/schema/items/item-v0.0.1.json' | pipenv run invenio fixtures create --pid_type item
 
 
 pipenv run invenio index reindex -t item --yes-i-know
 pipenv run invenio index run -c 4 --raise-on-error
 pipenv run invenio index reindex -t doc --yes-i-know
 pipenv run invenio index run -c 4 --raise-on-error
+
 
 # # create circulation transactions
 echo -e ${GREEN}Circulation transactions:${NC}

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
             'documents = rero_ils.modules.documents.views:blueprint',
             'items = rero_ils.modules.items.views:blueprint',
             'notifications = rero_ils.modules.notifications.views:blueprint',
+            'holdings = rero_ils.modules.holdings.views:blueprint',
         ],
         'invenio_base.api_blueprints': [
             'circ_policies = rero_ils.modules.circ_policies.views:blueprint',
@@ -109,6 +110,7 @@ setup(
             'api_documents = rero_ils.modules.documents.views:api_blueprint',
             'items = rero_ils.modules.items.api_views:api_blueprint',
             'mef_persons = rero_ils.modules.mef_persons.views:api_blueprint',
+            'holdings = rero_ils.modules.holdings.api_views:api_blueprint',
         ],
         'invenio_config.module': [
             'rero_ils = rero_ils.config',
@@ -190,6 +192,7 @@ setup(
             'apiharvester = rero_ils.modules.apiharvester.models',
             'circ_policies = rero_ils.modules.circ_policies.models',
             'notifications = rero_ils.modules.notifications.models',
+            'holdings = rero_ils.modules.holdings.models',
         ],
         'invenio_pidstore.minters': [
             'organisation_id = \
@@ -212,6 +215,7 @@ setup(
             ':circ_policy_id_minter',
             'notification_id = rero_ils.modules.notifications.api'
             ':notification_id_minter',
+            'holding_id = rero_ils.modules.holdings.api:holding_id_minter',
         ],
         'invenio_pidstore.fetchers': [
             'organisation_id = rero_ils.modules.organisations'
@@ -236,6 +240,8 @@ setup(
             ':circ_policy_id_fetcher',
             'notification_id = rero_ils.modules.notifications.api'
             ':notification_id_fetcher',
+            'holding_id = \
+                            rero_ils.modules.holdings.api:holding_id_fetcher',
         ],
         'invenio_jsonschemas.schemas': [
             'organisations = rero_ils.modules.organisations.jsonschemas',
@@ -249,7 +255,8 @@ setup(
             'persons = rero_ils.modules.mef_persons.jsonschemas',
             'circ_policies = rero_ils.modules.circ_policies.jsonschemas',
             'loans = rero_ils.modules.loans.jsonschemas',
-            'notifications = rero_ils.modules.notifications.jsonschemas'
+            'notifications = rero_ils.modules.notifications.jsonschemas',
+            'holdings = rero_ils.modules.holdings.jsonschemas'
         ],
         'invenio_search.mappings': [
             'organisations = rero_ils.modules.organisations.mappings',
@@ -264,9 +271,10 @@ setup(
             'circ_policies = rero_ils.modules.circ_policies.mappings',
             'loans = rero_ils.modules.loans.mappings',
             'notifications = rero_ils.modules.notifications.mappings',
+            'holdings = rero_ils.modules.holdings.mappings',
         ],
         'invenio_search.templates': [
-            'base-record = rero_ils.es_templates:list_es_templates'
+            'base-record = rero_ils.es_templates:list_es_templates',
         ],
         'invenio_celery.tasks': [
             'rero_ils_oaiharvest = rero_ils.modules.ebooks.tasks',
@@ -284,7 +292,8 @@ setup(
             'documents = rero_ils.modules.documents.jsonresolver',
             'loans = rero_ils.modules.loans.jsonresolver',
             'documents_mef_person = \
-                rero_ils.modules.documents.jsonresolver_mef_person'
+                rero_ils.modules.documents.jsonresolver_mef_person',
+            'holdings = rero_ils.modules.holdings.jsonresolver',
         ]
     },
     classifiers=[

--- a/tests/api/test_holdings_rest.py
+++ b/tests/api/test_holdings_rest.py
@@ -1,0 +1,303 @@
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Tests REST API holdings."""
+
+import json
+from copy import deepcopy
+
+import mock
+import pytest
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+
+from rero_ils.modules.api import IlsRecordError
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
+
+
+def test_holdings_permissions(client, holding_lib_martigny, json_header):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.hold_item', pid_value='holding1')
+    post_url = url_for('invenio_records_rest.hold_list')
+
+    res = client.get(item_url)
+    assert res.status_code == 401
+
+    res = client.post(
+        post_url,
+        data={},
+        headers=json_header
+    )
+    assert res.status_code == 401
+
+    res = client.put(
+        item_url,
+        data={},
+        headers=json_header
+    )
+
+    res = client.delete(item_url)
+    assert res.status_code == 401
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_holdings_get(client, holding_lib_martigny):
+    """Test record retrieval."""
+    holding = holding_lib_martigny
+    item_url = url_for('invenio_records_rest.hold_item', pid_value=holding.pid)
+    list_url = url_for(
+        'invenio_records_rest.hold_list', q='pid:' + holding.pid)
+    item_url_with_resolve = url_for(
+        'invenio_records_rest.hold_item',
+        pid_value=holding.pid,
+        resolve=1,
+        sources=1
+    )
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    assert res.headers['ETag'] == '"{}"'.format(holding.revision_id)
+
+    data = get_json(res)
+    assert holding.dumps() == data['metadata']
+
+    # Check metadata
+    for k in ['created', 'updated', 'metadata', 'links']:
+        assert k in data
+
+    # Check self links
+    res = client.get(to_relative_url(data['links']['self']))
+    assert res.status_code == 200
+    assert data == get_json(res)
+    assert holding.dumps() == data['metadata']
+
+    # check resolve
+    res = client.get(item_url_with_resolve)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert holding.replace_refs().dumps() == data['metadata']
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    result = data['hits']['hits'][0]['metadata']
+    # organisation has been added during the indexing
+    del result['organisation']
+    assert result == holding.replace_refs()
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_holdings_post_put_delete(client, holding_lib_martigny_data_tmp,
+                                  json_header, holding_lib_martigny):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.hold_item', pid_value='1')
+    post_url = url_for('invenio_records_rest.hold_list')
+    list_url = url_for('invenio_records_rest.hold_list', q='pid:1')
+    holding_data = holding_lib_martigny_data_tmp
+    # Create record / POST
+    holding_data['pid'] = '1'
+    res = client.post(
+        post_url,
+        data=json.dumps(holding_data),
+        headers=json_header
+    )
+    assert res.status_code == 201
+
+    # Check that the returned record matches the given data
+    data = get_json(res)
+    assert data['metadata'] == holding_data
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert holding_data == data['metadata']
+
+    # Update record/PUT
+    data = holding_data
+    data['call_number'] = 'call number'
+    res = client.put(
+        item_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+    # Check that the returned record matches the given data
+    data = get_json(res)
+    assert data['metadata']['call_number'] == 'call number'
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    data = get_json(res)
+    assert data['metadata']['call_number'] == 'call number'
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    data = get_json(res)['hits']['hits'][0]
+    assert data['metadata']['call_number'] == 'call number'
+
+    # Delete record/DELETE
+    res = client.delete(item_url)
+    assert res.status_code == 204
+
+    res = client.get(item_url)
+    assert res.status_code == 410
+
+
+def test_holding_can_delete(client, holding_lib_martigny):
+    """Test can delete a holding."""
+    links = holding_lib_martigny.get_links_to_me()
+    assert 'items' not in links
+
+    assert holding_lib_martigny.can_delete
+
+    reasons = holding_lib_martigny.reasons_not_to_delete()
+    assert 'links' not in reasons
+
+
+def test_filtered_holdings_get(
+        client, librarian_martigny_no_email, holding_lib_martigny,
+        holding_lib_fully, holding_lib_saxon, holding_lib_sion,
+        librarian_sion_no_email):
+    """Test holding filter by organisation."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    list_url = url_for('invenio_records_rest.hold_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 3
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.hold_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+
+def test_holding_secure_api(client, json_header, holding_lib_martigny,
+                            librarian_martigny_no_email,
+                            librarian_sion_no_email):
+    """Test holding secure api access."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.hold_item',
+                         pid_value=holding_lib_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for('invenio_records_rest.hold_item',
+                         pid_value=holding_lib_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 403
+
+
+def test_holding_secure_api_create(client, json_header, holding_lib_martigny,
+                                   librarian_martigny_no_email,
+                                   librarian_sion_no_email,
+                                   holding_lib_martigny_data):
+    """Test holding secure api create."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    post_url = url_for('invenio_records_rest.hold_list')
+
+    del holding_lib_martigny_data['pid']
+    res = client.post(
+        post_url,
+        data=json.dumps(holding_lib_martigny_data),
+        headers=json_header
+    )
+    assert res.status_code == 201
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.post(
+        post_url,
+        data=json.dumps(holding_lib_martigny_data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_holding_secure_api_update(client, holding_lib_sion,
+                                   librarian_martigny_no_email,
+                                   librarian_sion_no_email,
+                                   holding_lib_sion_data,
+                                   json_header):
+    """Test holding secure api update."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.hold_item',
+                         pid_value=holding_lib_sion.pid)
+
+    data = holding_lib_sion_data
+    data['call_number'] = 'call_number'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+
+def test_holding_secure_api_delete(client, holding_lib_saxon,
+                                   librarian_martigny_no_email,
+                                   librarian_sion_no_email):
+    """Test holding secure api delete."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.hold_item',
+                         pid_value=holding_lib_saxon.pid)
+    # Martigny
+    res = client.delete(record_url)
+    assert res.status_code == 204
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.delete(record_url)
+    assert res.status_code == 410

--- a/tests/api/test_items_rest.py
+++ b/tests/api/test_items_rest.py
@@ -122,11 +122,13 @@ def test_items_post_put_delete(client, document, loc_public_martigny,
 
     # Check that the returned record matches the given data
     data = get_json(res)
+    del data['metadata']['holding']
     assert data['metadata'] == item_lib_martigny_data
 
     res = client.get(item_url)
     assert res.status_code == 200
     data = get_json(res)
+    del data['metadata']['holding']
     assert item_lib_martigny_data == data['metadata']
 
     # Update record/PUT

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1425,5 +1425,61 @@
     "loan": {
       "$ref": "https://ils.rero.ch/api/loans/x"
     }
+  },
+  "holding1": {
+    "$schema": "https://ils.rero.ch/schema/holdings/holding-v0.0.1.json",
+    "pid": "holding1",
+    "call_number": "h00001",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "circulation_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty1"
+    },
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc1"
+    }
+  },
+  "holding2": {
+    "$schema": "https://ils.rero.ch/schema/holdings/holding-v0.0.1.json",
+    "pid": "holding2",
+    "call_number": "h00002",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "circulation_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty1"
+    },
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc3"
+    }
+  },
+  "holding3": {
+    "$schema": "https://ils.rero.ch/schema/holdings/holding-v0.0.1.json",
+    "pid": "holding3",
+    "call_number": "h00003",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "circulation_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty1"
+    },
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc5"
+    }
+  },
+  "holding4": {
+    "$schema": "https://ils.rero.ch/schema/holdings/holding-v0.0.1.json",
+    "pid": "holding4",
+    "call_number": "h00004",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "circulation_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty5"
+    },
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc7"
+    }
   }
 }

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -32,6 +32,7 @@ import pytest
 from utils import flush_index, mock_response
 
 from rero_ils.modules.documents.api import Document, DocumentsSearch
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 from rero_ils.modules.items.api import Item, ItemsSearch
 from rero_ils.modules.mef_persons.api import MefPerson, MefPersonsSearch
 
@@ -342,3 +343,87 @@ def item_lib_sion(
         reindex=True)
     flush_index(ItemsSearch.Meta.index)
     return item
+
+# --------- Holdings records -----------
+
+
+@pytest.fixture(scope="module")
+def holding_lib_martigny_data(data):
+    """Load holding of martigny library."""
+    return deepcopy(data.get('holding1'))
+
+
+@pytest.fixture(scope="function")
+def holding_lib_martigny_data_tmp(data):
+    """Load holding of martigny library scope function."""
+    return deepcopy(data.get('holding1'))
+
+
+@pytest.fixture(scope="module")
+def holding_lib_martigny(app, document, holding_lib_martigny_data,
+                         loc_public_martigny, item_type_standard_martigny):
+    """Create holding of martigny library."""
+    holding = Holding.create(
+        data=holding_lib_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    return holding
+
+
+@pytest.fixture(scope="module")
+def holding_lib_saxon_data(data):
+    """Load holding of saxon library."""
+    return deepcopy(data.get('holding2'))
+
+
+@pytest.fixture(scope="module")
+def holding_lib_saxon(app, document, holding_lib_saxon_data,
+                      loc_public_saxon, item_type_standard_martigny):
+    """Create holding of saxon library."""
+    holding = Holding.create(
+        data=holding_lib_saxon_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    return holding
+
+
+@pytest.fixture(scope="module")
+def holding_lib_fully_data(data):
+    """Load holding of fully library."""
+    return deepcopy(data.get('holding3'))
+
+
+@pytest.fixture(scope="module")
+def holding_lib_fully(app, document, holding_lib_fully_data,
+                      loc_public_fully, item_type_standard_martigny):
+    """Create holding of fully library."""
+    holding = Holding.create(
+        data=holding_lib_fully_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    return holding
+
+
+@pytest.fixture(scope="module")
+def holding_lib_sion_data(data):
+    """Load holding of sion library."""
+    return deepcopy(data.get('holding4'))
+
+
+@pytest.fixture(scope="module")
+def holding_lib_sion(app, document, holding_lib_sion_data,
+                     loc_public_sion, item_type_internal_sion):
+    """Create holding of saxon library."""
+    holding = Holding.create(
+        data=holding_lib_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    return holding

--- a/tests/ui/holdings/test_holdings_api.py
+++ b/tests/ui/holdings/test_holdings_api.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holding Record tests."""
+
+from __future__ import absolute_import, print_function
+
+from utils import get_mapping
+
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
+from rero_ils.modules.holdings.api import holding_id_fetcher as fetcher
+
+
+def test_holding_create(db, es_clear, holding_lib_martigny_data):
+    """Test holding creation."""
+    holding = Holding.create(holding_lib_martigny_data, delete_pid=True)
+    assert holding == holding_lib_martigny_data
+    assert holding.get('pid') == '1'
+
+    holding = Holding.get_record_by_pid('1')
+    assert holding == holding_lib_martigny_data
+
+    fetched_pid = fetcher(holding.id, holding)
+    assert fetched_pid.pid_value == '1'
+    assert fetched_pid.pid_type == 'hold'
+
+
+def test_holding_organisation_pid(org_martigny, holding_lib_martigny):
+    """Test organisation pid has been added during the indexing."""
+    search = HoldingsSearch()
+    holding = next(search.filter('term', pid=holding_lib_martigny.pid).scan())
+    holding_record = Holding.get_record_by_pid(holding.pid)
+    assert holding_record.organisation_pid == org_martigny.pid
+
+
+def test_holding_es_mapping(es, db, holding_lib_martigny,
+                            holding_lib_martigny_data):
+    """Test holding elasticsearch mapping."""
+    search = HoldingsSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    Holding.create(
+        holding_lib_martigny_data,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)

--- a/tests/ui/holdings/test_holdings_item.py
+++ b/tests/ui/holdings/test_holdings_item.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holding Record tests."""
+
+from __future__ import absolute_import, print_function
+
+from copy import deepcopy
+
+from utils import flush_index
+
+from rero_ils.modules.holdings.api import Holding, HoldingsSearch
+from rero_ils.modules.items.api import Item, ItemsSearch
+
+
+def test_holding_item_links(client, holding_lib_martigny, item_lib_martigny,
+                            item_lib_martigny_data, document,
+                            item_type_on_site_martigny, loc_public_martigny,
+                            item_lib_saxon_data, loc_public_saxon,
+                            item_type_standard_martigny):
+    """Test holding and item links."""
+    item = deepcopy(item_lib_martigny_data)
+    del item['pid']
+    item['barcode'] = 'barcode'
+    item = Item.create(item, dbcommit=True, reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    assert item.holding_pid == holding_lib_martigny.pid
+
+    item2 = deepcopy(item_lib_saxon_data)
+    del item2['pid']
+    item2 = Item.create(item2, dbcommit=True, reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    assert item2.holding_pid != holding_lib_martigny.pid
+
+    holding = Holding.get_record_by_pid(item2.holding_pid)
+    assert holding.document_pid == document.pid
+    assert holding.circulation_type_pid == item_type_standard_martigny.pid
+
+    assert Holding.get_document_pid_by_holding_pid(item2.holding_pid) == \
+        document.pid
+
+    holdings = list(Holding.get_holdings_pid_by_document_pid(document.pid))
+    assert holding_lib_martigny.pid in holdings
+    assert item2.holding_pid in holdings
+
+    assert holding_lib_martigny.get_links_to_me().get('items')
+    assert not holding_lib_martigny.can_delete
+
+
+def test_holding_delete_after_item_deletion(
+        client, holding_lib_martigny, item_lib_martigny):
+    """Test automatic holding delete after deleting last item."""
+    for pid in Item.get_all_pids():
+        if pid != item_lib_martigny.pid:
+            item = Item.get_record_by_pid(pid)
+            Item.delete(item, dbcommit=True, delindex=True)
+            flush_index(ItemsSearch.Meta.index)
+
+    pid = holding_lib_martigny.pid
+    holding = Holding.get_record_by_pid(pid)
+    assert not holding.can_delete
+
+    item_lib_martigny.delete(dbcommit=True, delindex=True)
+    flush_index(ItemsSearch.Meta.index)
+
+    pid = holding_lib_martigny.pid
+    holding = Holding.get_record_by_pid(pid)
+    assert not holding

--- a/tests/ui/holdings/test_holdings_jsonresolver.py
+++ b/tests/ui/holdings/test_holdings_jsonresolver.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holding JSON Resolver tests."""
+
+import pytest
+from invenio_records.api import Record
+from jsonref import JsonRefError
+
+
+def test_holdings_jsonresolver(holding_lib_martigny):
+    """Test holding json resolver."""
+    rec = Record.create({
+        'holding': {'$ref': 'https://ils.rero.ch/api/holdings/holding1'}
+    })
+    assert rec.replace_refs().get('holding') == {'pid': 'holding1'}
+
+    # deleted record
+    holding_lib_martigny.delete()
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()
+
+    # non existing record
+    rec = Record.create({
+        'holding': {'$ref': 'https://ils.rero.ch/api/holdings/n_e'}
+    })
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()

--- a/tests/ui/items/test_items_api.py
+++ b/tests/ui/items/test_items_api.py
@@ -31,7 +31,15 @@ from utils import get_mapping
 from rero_ils.modules.items.api import Item, ItemsSearch, item_id_fetcher
 
 
-def test_item_item_location_retriever(item_lib_martigny, loc_public_martigny,
+def test_item_organisation_pid(client, org_martigny, item_lib_martigny):
+    """Test organisation pid has been added during the indexing."""
+    search = ItemsSearch()
+    item = next(search.filter('term', pid=item_lib_martigny.pid).scan())
+    assert item.organisation.pid == org_martigny.pid
+
+
+def test_item_item_location_retriever(client, item_lib_martigny,
+                                      loc_public_martigny,
                                       loc_restricted_martigny):
     """Test location retriever for invenio-circulation."""
     assert item_lib_martigny.item_location_retriever(
@@ -43,38 +51,23 @@ def test_item_get_items_pid_by_document_pid(document, item_lib_martigny):
     assert len(list(Item.get_items_pid_by_document_pid(document.pid))) == 1
 
 
-def test_item_create(db, es_clear, item_lib_martigny_data_tmp):
+def test_item_create(db, es_clear, item_lib_martigny_data_tmp,
+                     item_lib_martigny):
     """Test itemanisation creation."""
     item = Item.create(item_lib_martigny_data_tmp, delete_pid=True)
+
+    del item['holding']
     assert item == item_lib_martigny_data_tmp
     assert item.get('pid') == '1'
     assert item.can_delete
 
     item = Item.get_record_by_pid('1')
+    del item['holding']
     assert item == item_lib_martigny_data_tmp
 
     fetched_pid = item_id_fetcher(item.id, item)
     assert fetched_pid.pid_value == '1'
     assert fetched_pid.pid_type == 'item'
-
-
-def test_item_organisation_pid(org_martigny, item_lib_martigny):
-    """Test organisation pid has been added during the indexing."""
-    search = ItemsSearch()
-    item = next(search.filter('term', pid=item_lib_martigny.pid).scan())
-    assert item.organisation.pid == org_martigny.pid
-
-
-def test_item_item_location_retriever(item_lib_martigny, loc_public_martigny,
-                                      loc_restricted_martigny):
-    """Test location retriever for invenio-circulation."""
-    assert item_lib_martigny.item_location_retriever(
-        item_lib_martigny.pid) == loc_public_martigny.pid
-
-
-def test_item_get_items_pid_by_document_pid(document, item_lib_martigny):
-    """."""
-    assert len(list(Item.get_items_pid_by_document_pid(document.pid))) == 1
 
 
 def test_item_can_delete(item_lib_martigny):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -148,3 +148,14 @@ def item_schema():
     )
     schema = loads(schema_in_bytes.decode('utf8'))
     return schema
+
+
+@pytest.fixture()
+def holding_schema():
+    """Holdings Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.holdings.jsonschemas',
+        '/holdings/holding-v0.0.1.json'
+    )
+    schema = loads(schema_in_bytes.decode('utf8'))
+    return schema

--- a/tests/unit/test_holdings_jsonschema.py
+++ b/tests/unit/test_holdings_jsonschema.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO ILS.
+# Copyright (C) 2017 RERO.
+#
+# RERO ILS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO ILS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO ILS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Holdings JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import copy
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_required(holding_schema, holding_lib_martigny_data):
+    """Test required for library jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, holding_schema)
+        validate(holding_lib_martigny_data, holding_schema)
+
+
+def test_pid(holding_schema, holding_lib_martigny_data):
+    """Test pid for holding jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(holding_lib_martigny_data)
+        data['pid'] = 25
+        validate(data, holding_schema)
+
+
+def test_call_number(holding_schema, holding_lib_martigny_data):
+    """Test call_number for holding jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(holding_lib_martigny_data)
+        data['call_number'] = 25
+        validate(data, holding_schema)
+
+
+def test_document(holding_schema, holding_lib_martigny_data):
+    """Test document for holding jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(holding_lib_martigny_data)
+        data['document'] = 25
+        validate(data, holding_schema)
+
+
+def test_circulation_type(holding_schema, holding_lib_martigny_data):
+    """Test circulation_type for holding jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(holding_lib_martigny_data)
+        data['circulation_type'] = 25
+        validate(data, holding_schema)
+
+
+def test_location(holding_schema, holding_lib_martigny_data):
+    """Test location for holding jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(holding_lib_martigny_data)
+        data['location'] = 25
+        validate(data, holding_schema)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,6 +35,7 @@ from six.moves.urllib.parse import parse_qs, urlparse
 
 from rero_ils.modules.circ_policies.api import CircPolicy
 from rero_ils.modules.documents.api import Document
+from rero_ils.modules.holdings.api import Holding
 from rero_ils.modules.item_types.api import ItemType
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.libraries.api import Library
@@ -102,7 +103,8 @@ def loaded_resources_report():
         'patron_types': PatronType,
         'patrons': Patron,
         'documents': Document,
-        'items': Item
+        'items': Item,
+        'holdings': Holding
     }
     report = {}
     for object in objects:


### PR DESCRIPTION
* Adds holdings level between documents and items.
* Adds automatic holding creation for new items based on item type and item location.
* Adds automatic attaching of new items to a holding record if a valid holding record exists.
* Adds automatic holding deletion once last item is deleted.
* Adds automatic relinking if necessary to a new holding with item is updated.
* Adds loading fixtures is now using reroils class instead of invenio record class.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

# How to Test:
bootstrap
setup

1. create an item then check the json of the item to see if there is a holding field is added.
2. you can display the holding record via '/api/holdings/XX'
3. delete the  item and make sure the holding is also deleted by checking   '/api/holdings/XX'