### PR TITLE
circulation: due date hours set to end of day

### DIFF
--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -55,6 +55,8 @@ def get_default_loan_duration(loan):
     policy = get_circ_policy(loan)
     # TODO: case when start_date is not sysdate.
     start_date = datetime.now()
+    time_to_end_of_day = timedelta(hours=23, minutes=59) - \
+        timedelta(hours=start_date.hour, minutes=start_date.minute)
     transaction_location_pid = loan.get('transaction_location_pid')
     if not transaction_location_pid:
         library_pid = Item.get_record_by_pid(loan.item_pid).library_pid
@@ -68,10 +70,9 @@ def get_default_loan_duration(loan):
     # rero_ils due_date, considering library opening_hours and exception_dates.
     # next_open: -1 to check first the due date not the days.
     open_after_due_date = library.next_open(date=due_date - timedelta(days=1))
-
     new_duration = open_after_due_date - start_date
 
-    return timedelta(days=new_duration.days)
+    return timedelta(days=new_duration.days) + time_to_end_of_day
 
 
 def get_extension_params(loan=None, parameter_name=None):
@@ -83,6 +84,8 @@ def get_extension_params(loan=None, parameter_name=None):
         'duration_default': policy.get('renewal_duration')
     }
     current_date = datetime.now()
+    time_to_end_of_day = timedelta(hours=23, minutes=59) - \
+        timedelta(hours=current_date.hour, minutes=current_date.minute)
 
     transaction_location_pid = loan.get('transaction_location_pid')
     if not transaction_location_pid:
@@ -102,7 +105,8 @@ def get_extension_params(loan=None, parameter_name=None):
         params['max_count'] = 0
 
     new_duration = first_open_date - current_date
-    params['duration_default'] = timedelta(days=new_duration.days)
+    params['duration_default'] = \
+        timedelta(days=new_duration.days) + time_to_end_of_day
 
     return params.get(parameter_name)
 

--- a/tests/api/test_items_rest.py
+++ b/tests/api/test_items_rest.py
@@ -692,6 +692,12 @@ def test_items_extend(client, librarian_martigny_no_email,
     assert actions.get(LoanAction.EXTEND)
     assert item.get_extension_count() == 1
 
+    # test renewal due date hour
+    extended_loan = Loan.get_record_by_pid(loan_pid)
+    end_date = ciso8601.parse_datetime(
+        extended_loan.get('end_date')).astimezone()
+    assert end_date.minute == 59 and end_date.hour == 23
+
     # second extenion
     res = client.post(
         url_for('api_item.extend_loan'),

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -21,6 +21,7 @@ import json
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
+import ciso8601
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
@@ -166,6 +167,12 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
     loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
     due_soon_loans = get_due_soon_loans()
     assert due_soon_loans[0].get('pid') == loan_pid
+
+    # test due date hour
+    checkout_loan = Loan.get_record_by_pid(loan_pid)
+    end_date = ciso8601.parse_datetime(
+        checkout_loan.get('end_date')).astimezone()
+    assert end_date.minute == 59 and end_date.hour == 23
 
     # checkin the item to put it back to it's original state
     res = client.post(


### PR DESCRIPTION
* Fixes issue #417
* Improves hours of due date of checkout and renewals to the end of the day.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>