### PR TITLE
indexing: skip document indexing when indexing a holding

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -59,7 +59,6 @@ class HoldingsSearch(RecordsSearch):
     @classmethod
     def flush(cls):
         """Flush indexes."""
-        current_search.flush_and_refresh(DocumentsSearch.Meta.index)
         current_search.flush_and_refresh(cls.Meta.index)
 
 
@@ -69,10 +68,7 @@ class HoldingsIndexer(IlsRecordIndexer):
     def index(self, record):
         """Indexing a holding record."""
         return_value = super(HoldingsIndexer, self).index(record)
-        document_pid = record.replace_refs()['document']['pid']
-        document = Document.get_record_by_pid(document_pid)
-        document.reindex()
-        current_search.flush_and_refresh(DocumentsSearch.Meta.index)
+        current_search.flush_and_refresh(HoldingsSearch.Meta.index)
         return return_value
 
 


### PR DESCRIPTION
* Fixes problem when document is indexed every time a holding is indexed.

Co-Authored-by: Aly Badr aly.badr@rero.ch