### PR TITLE
interface: display record availability in document detailed view

### DIFF
--- a/rero_ils/modules/documents/listener.py
+++ b/rero_ils/modules/documents/listener.py
@@ -24,7 +24,7 @@ from invenio_search import current_search
 from requests import codes as requests_codes
 from requests import get as requests_get
 
-from ..documents.api import DocumentsSearch
+from ..documents.api import Document, DocumentsSearch
 from ..holdings.api import Holding
 from ..item_types.api import ItemType
 from ..items.api import Item
@@ -46,9 +46,9 @@ def enrich_document_data(sender, json=None, record=None, index=None,
     if index.startswith(document_index_name):
         # HOLDINGS
         holdings = []
-        available = False
+        document_pid = record['pid']
         for holding_pid in Holding.get_holdings_pid_by_document_pid(
-            record['pid']
+                document_pid
         ):
             holding = Holding.get_record_by_pid(holding_pid)
             location = Location.get_record_by_pid(
@@ -60,6 +60,7 @@ def enrich_document_data(sender, json=None, record=None, index=None,
                 holding.circulation_category_pid).replace_refs()
             data = {
                 'pid': holding.pid,
+                'available': holding.available,
                 'call_number': holding.get('call_number'),
                 'location': {
                     'pid': location.pid,
@@ -82,7 +83,7 @@ def enrich_document_data(sender, json=None, record=None, index=None,
             items = []
             for item_pid in Item.get_items_pid_by_holding_pid(holding_pid):
                 item = Item.get_record_by_pid(item_pid)
-                available = available or item.available
+                available = item.available
                 items.append({
                     'pid': item.pid,
                     'barcode': item['barcode'],
@@ -98,7 +99,7 @@ def enrich_document_data(sender, json=None, record=None, index=None,
         if holdings:
             json['holdings'] = holdings
 
-        json['available'] = available
+        json['available'] = Document.get_record_by_pid(document_pid).available
 
 
 def mef_person_insert(sender, *args, **kwargs):

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -153,6 +153,7 @@
             <dd class="col-sm-7 col-md-8">
               {{ url_for('invenio_records_ui.doc', viewcode=viewcode, pid_value=record.pid, _external=True) }}
             </dd>
+            {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('success' if record.available else 'danger') +'"></i> ') }}
             </dl>
         </article>
         <footer class="d-flex flex-column pt-2">
@@ -223,7 +224,12 @@
                     {% endif %}
                   {% endif %}
                   {% if item.status %}
-                    {{ dl(_('Status'),'<i class="fa fa-circle text-'+ ('success' if item.available else 'danger') +'"></i> ' + item|item_status_text(format='short_date', locale=current_i18n.locale.language)) }}
+                    {{ dl(_('Status'), item.status) }}
+                  {% endif %}
+                  {% if item.available %}
+                      {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('success') +'"></i> ') }}
+                    {% else %}
+                      {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('danger') +'"></i> ' + item|not_available_reasons) }}
                   {% endif %}
                 </dl>
               </article>

--- a/rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html
+++ b/rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html
@@ -46,6 +46,12 @@
             {{ dl(_('Library'), library.name) }}
             {{ dl(_('Location'), location.name) }}
             {{ dl(_('Circulation category'), circulation_category.name) }}
+            {% if record.available %}
+                {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('success') +'"></i> ') }}
+              {% else %}
+                {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('danger') +'"></i> ' + record.pid|holding_loan_condition_filter) }}
+            {% endif %}
+
           </dl>
         </article>
       </section>
@@ -62,6 +68,14 @@
                   {{ dl(_('ID'), item.pid) }}
                   {{ dl(_('Call number'), item.call_number) }}
                   {{ dl(_('Barcode'), item.barcode) }}
+                  {% if item.status %}
+                    {{ dl(_('Status'), item.status) }}
+                  {% endif %}
+                  {% if item.available %}
+                      {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('success') +'"></i> ') }}
+                    {% else %}
+                      {{ dl(_('Availability'),'<i class="fa fa-circle text-'+ ('danger') +'"></i> ' + item|not_available_reasons) }}
+                  {% endif %}
                 </dl>
               </article>
               {% endfor %}

--- a/rero_ils/modules/holdings/views.py
+++ b/rero_ils/modules/holdings/views.py
@@ -20,9 +20,10 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import Blueprint, current_app, render_template
+from flask import Blueprint, abort, current_app, render_template
 from invenio_records_ui.signals import record_viewed
 
+from .api import Holding
 from ..documents.api import Document
 from ..item_types.api import ItemType
 from ..libraries.api import Library
@@ -64,3 +65,12 @@ blueprint = Blueprint(
     template_folder='templates',
     static_folder='static',
 )
+
+
+@blueprint.app_template_filter()
+def holding_loan_condition_filter(holding_pid):
+    """HTTP GET request for holding loan condition."""
+    holding = Holding.get_record_by_pid(holding_pid)
+    if not holding:
+        abort(404)
+    return holding.get_holding_loan_conditions()

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -31,7 +31,6 @@ from werkzeug.exceptions import NotFound
 from .api import Item
 from ..circ_policies.api import CircPolicy
 from ..loans.api import Loan
-from ..loans.utils import extend_loan_data_is_valid
 from ..patrons.api import Patron
 from ...permissions import librarian_permission
 


### PR DESCRIPTION
(This is a temporary display of availabilities until US963 is implemented)

* Displays document and item availabilities in document detailed view.
* Displays holding availability in holding detailed view.
* Closes #445

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

To test:
* Display a document detailed view to see document and items availabilities 
http://localhost:5000/aoste/documents/xxx
* Display a holding detailed view to see document and items availabilities 
http://localhost:5000/aoste/holdings/xx

