### PR TITLE
#1011 fix unittest fixtures

### DIFF
--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -302,36 +302,6 @@ def patron_martigny(
     return ptrn
 
 
-# ------------ Org: Martigny Patron 1 ----------
-@pytest.fixture(scope="module")
-def patron_martigny_data(data):
-    """Load Martigny patron data."""
-    return deepcopy(data.get('ptrn6'))
-
-
-@pytest.fixture(scope="function")
-def patron_martigny_data_tmp(data):
-    """Load Martigny patron data scope function."""
-    return deepcopy(data.get('ptrn6'))
-
-
-@pytest.fixture(scope="module")
-def patron_martigny(
-        app,
-        roles,
-        lib_martigny,
-        patron_type_children_martigny,
-        patron_martigny_data):
-    """Create Martigny patron record."""
-    ptrn = Patron.create(
-        data=patron_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
 @pytest.fixture(scope="module")
 @mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
 def patron_martigny_no_email(
@@ -447,93 +417,6 @@ def patron_martigny_no_email(
     """Create Martigny patron without sending reset password instruction."""
     ptrn = Patron.create(
         data=patron_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-# ------------ Org: Martigny Patron 2 ----------
-@pytest.fixture(scope="module")
-def patron2_martigny_data(data):
-    """Load Martigny patron data."""
-    return deepcopy(data.get('ptrn7'))
-
-
-@pytest.fixture(scope="module")
-def patron2_martigny(
-        app,
-        roles,
-        lib_martigny,
-        patron_type_adults_martigny,
-        patron2_martigny_data):
-    """Create Martigny patron record."""
-    ptrn = Patron.create(
-        data=patron2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron2_martigny_no_email(
-        app,
-        roles,
-        patron_type_adults_martigny,
-        patron2_martigny_data):
-    """Create Martigny patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron2_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-# ------------ Org: Sion, Lib: Sion, System Librarian ----------
-@pytest.fixture(scope="module")
-def system_librarian_sion_data(data):
-    """Load Sion system librarian data."""
-    return deepcopy(data.get('ptrn8'))
-
-
-@pytest.fixture(scope="function")
-def system_librarian_sion_data_tmp(data):
-    """Load Sion system librarian data scope function."""
-    return deepcopy(data.get('ptrn8'))
-
-
-@pytest.fixture(scope="module")
-def system_librarian_sion(
-        app,
-        roles,
-        lib_sion,
-        system_librarian_sion_data):
-    """Create Sion system librarian record."""
-    ptrn = Patron.create(
-        data=system_librarian_sion_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-@pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def system_librarian_sion_no_email(
-        app,
-        roles,
-        lib_sion,
-        system_librarian_sion_data):
-    """Create Sion system librarian without sending reset password."""
-    ptrn = Patron.create(
-        data=system_librarian_sion_data,
         delete_pid=False,
         dbcommit=True,
         reindex=True)

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -339,21 +339,21 @@ def item_lib_sion(
 
 
 @pytest.fixture(scope="module")
-def item_lib_sion_org2_data(data):
+def item2_lib_sion_data(data):
     """Load item of sion library."""
     return deepcopy(data.get('item6'))
 
 
 @pytest.fixture(scope="module")
-def item_lib_sion_org2(
+def item2_lib_sion(
         app,
         document,
-        item_lib_sion_org2_data,
+        item2_lib_sion_data,
         loc_restricted_sion,
         item_type_regular_sion):
     """Create item of sion library."""
     item = Item.create(
-        data=item_lib_sion_org2_data,
+        data=item2_lib_sion_data,
         delete_pid=False,
         dbcommit=True,
         reindex=True)
@@ -436,7 +436,7 @@ def holding_lib_sion_data(data):
 @pytest.fixture(scope="module")
 def holding_lib_sion(app, document, holding_lib_sion_data,
                      loc_public_sion, item_type_internal_sion):
-    """Create holding of saxon library."""
+    """Create holding of sion library."""
     holding = Holding.create(
         data=holding_lib_sion_data,
         delete_pid=False,


### PR DESCRIPTION
  * delete duplicates from patron6, 7 and 8
  * fix a typo in Sion Library description
  * rename item_lib_sion_org2 to item2_lib_sion

@BadrAly: I checked with existing fixtures. No "org" was used. Perhaps it would be better to rename it `item2_lib_sion` than `item2_lib_sion_org`?
Moreover, no `item_lib_sion_org` exists. That's why I prefer to rename it `item2_lib_sion` :wink: 