### PR TITLE
#1019 - Refactoring units testing api calls

### DIFF
--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -22,7 +22,7 @@ import pytz
 from dateutil import parser
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import get_json
+from utils import get_json, postdata
 
 from rero_ils.filter import format_date_filter
 from rero_ils.modules.holdings.api import Holding
@@ -63,19 +63,16 @@ def test_item_holding_document_availability(
     # request
     login_user_via_session(client, librarian_martigny_no_email.user)
 
-    res = client.post(
-        url_for('api_item.librarian_request'),
-        data=json.dumps(
-            dict(
-                item_pid=item_lib_martigny.pid,
-                pickup_location_pid=loc_public_saxon.pid,
-                patron_pid=patron_martigny_no_email.pid
-            )
-        ),
-        content_type='application/json',
+    res, data = postdata(
+        client,
+        'api_item.librarian_request',
+        dict(
+            item_pid=item_lib_martigny.pid,
+            pickup_location_pid=loc_public_saxon.pid,
+            patron_pid=patron_martigny_no_email.pid
+        )
     )
     assert res.status_code == 200
-    data = get_json(res)
     actions = data.get('action_applied')
     loan_pid = actions[LoanAction.REQUEST].get('pid')
     assert not item_lib_martigny.available
@@ -91,15 +88,13 @@ def test_item_holding_document_availability(
     assert document_availablity_status(
         client, document.pid, librarian_martigny_no_email.user)
     # validate request
-    res = client.post(
-        url_for('api_item.validate_request'),
-        data=json.dumps(
-            dict(
-                item_pid=item_lib_martigny.pid,
-                pid=loan_pid
-            )
-        ),
-        content_type='application/json',
+    res, _ = postdata(
+        client,
+        'api_item.validate_request',
+        dict(
+            item_pid=item_lib_martigny.pid,
+            pid=loan_pid
+        )
     )
     assert res.status_code == 200
     assert not item_lib_martigny.available
@@ -118,15 +113,13 @@ def test_item_holding_document_availability(
         client, document.pid, librarian_martigny_no_email.user)
     login_user_via_session(client, librarian_saxon_no_email.user)
     # receive
-    res = client.post(
-        url_for('api_item.receive'),
-        data=json.dumps(
-            dict(
-                item_pid=item_lib_martigny.pid,
-                pid=loan_pid
-            )
-        ),
-        content_type='application/json',
+    res, _ = postdata(
+        client,
+        'api_item.receive',
+        dict(
+            item_pid=item_lib_martigny.pid,
+            pid=loan_pid
+        )
     )
     assert res.status_code == 200
     assert not item_lib_martigny.available
@@ -144,15 +137,13 @@ def test_item_holding_document_availability(
     assert document_availablity_status(
         client, document.pid, librarian_martigny_no_email.user)
     # checkout
-    res = client.post(
-        url_for('api_item.checkout'),
-        data=json.dumps(
-            dict(
-                item_pid=item_lib_martigny.pid,
-                patron_pid=patron_martigny_no_email.pid
-            )
-        ),
-        content_type='application/json',
+    res, _ = postdata(
+        client,
+        'api_item.checkout',
+        dict(
+            item_pid=item_lib_martigny.pid,
+            patron_pid=patron_martigny_no_email.pid
+        )
     )
     assert res.status_code == 200
 
@@ -196,19 +187,16 @@ def test_item_holding_document_availability(
     # request second item
     login_user_via_session(client, librarian_martigny_no_email.user)
 
-    res = client.post(
-        url_for('api_item.librarian_request'),
-        data=json.dumps(
-            dict(
-                item_pid=item2_lib_martigny.pid,
-                pickup_location_pid=loc_public_saxon.pid,
-                patron_pid=patron2_martigny_no_email.pid
-            )
-        ),
-        content_type='application/json',
+    res, data = postdata(
+        client,
+        'api_item.librarian_request',
+        dict(
+            item_pid=item2_lib_martigny.pid,
+            pickup_location_pid=loc_public_saxon.pid,
+            patron_pid=patron2_martigny_no_email.pid
+        )
     )
     assert res.status_code == 200
-    data = get_json(res)
     actions = data.get('action_applied')
     loan_pid = actions[LoanAction.REQUEST].get('pid')
     assert not item2_lib_martigny.available

--- a/tests/api/test_documents_rest.py
+++ b/tests/api/test_documents_rest.py
@@ -25,7 +25,8 @@ import json
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 from rero_ils.modules.documents.views import can_request, \
     item_library_pickup_locations, item_status_text, number_of_requests, \
@@ -35,15 +36,14 @@ from rero_ils.modules.documents.views import can_request, \
 def test_documents_permissions(client, document, json_header):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.doc_item', pid_value='doc1')
-    post_url = url_for('invenio_records_rest.doc_list')
 
     res = client.get(item_url)
     assert res.status_code == 200
 
-    res = client.post(
-        post_url,
-        data={},
-        headers=json_header
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.doc_list',
+        {}
     )
     assert res.status_code == 401
 
@@ -114,19 +114,17 @@ def test_documents_post_put_delete(client, document_data,
     """Test record retrieval."""
     # Create record / POST
     item_url = url_for('invenio_records_rest.doc_item', pid_value='1')
-    post_url = url_for('invenio_records_rest.doc_list')
     list_url = url_for('invenio_records_rest.doc_list', q='pid:1')
 
     document_data['pid'] = '1'
-    res = client.post(
-        post_url,
-        data=json.dumps(document_data),
-        headers=json_header
+    res, data = postdata(
+        client,
+        'invenio_records_rest.doc_list',
+        document_data
     )
     assert res.status_code == 201
 
     # Check that the returned record matches the given data
-    data = get_json(res)
     assert data['metadata'] == document_data
 
     res = client.get(item_url)

--- a/tests/api/test_item_types_rest.py
+++ b/tests/api/test_item_types_rest.py
@@ -23,7 +23,8 @@ import mock
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 from rero_ils.modules.api import IlsRecordError
 
@@ -32,15 +33,14 @@ def test_item_types_permissions(client, item_type_standard_martigny,
                                 json_header):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.itty_item', pid_value='itty1')
-    post_url = url_for('invenio_records_rest.itty_list')
 
     res = client.get(item_url)
     assert res.status_code == 401
 
-    res = client.post(
-        post_url,
-        data={},
-        headers=json_header
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.itty_list',
+        {}
     )
     assert res.status_code == 401
 
@@ -97,19 +97,17 @@ def test_item_types_post_put_delete(client, org_martigny,
     """Test record retrieval."""
     # Create record / POST
     item_url = url_for('invenio_records_rest.itty_item', pid_value='1')
-    post_url = url_for('invenio_records_rest.itty_list')
     list_url = url_for('invenio_records_rest.itty_list', q='pid:1')
 
     item_type_standard_martigny_data['pid'] = '1'
-    res = client.post(
-        post_url,
-        data=json.dumps(item_type_standard_martigny_data),
-        headers=json_header
+    res, data = postdata(
+        client,
+        'invenio_records_rest.itty_list',
+        item_type_standard_martigny_data
     )
     assert res.status_code == 201
 
     # Check that the returned record matches the given data
-    data = get_json(res)
     assert data['metadata'] == item_type_standard_martigny_data
 
     res = client.get(item_url)
@@ -251,23 +249,23 @@ def test_item_type_secure_api_create(client, json_header,
     """Test item type secure api create."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)
-    post_url = url_for('invenio_records_rest.itty_list')
+    post_entrypoint = 'invenio_records_rest.itty_list'
 
     del item_type_standard_martigny_data['pid']
-    res = client.post(
-        post_url,
-        data=json.dumps(item_type_standard_martigny_data),
-        headers=json_header
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        item_type_standard_martigny_data
     )
     assert res.status_code == 201
 
     # Sion
     login_user_via_session(client, librarian_sion_no_email.user)
 
-    res = client.post(
-        post_url,
-        data=json.dumps(item_type_standard_martigny_data),
-        headers=json_header
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        item_type_standard_martigny_data
     )
     assert res.status_code == 403
 

--- a/tests/api/test_mef_persons_rest.py
+++ b/tests/api/test_mef_persons_rest.py
@@ -21,21 +21,20 @@
 # from utils import get_json, to_relative_url
 
 from flask import url_for
-from utils import get_json, to_relative_url
+from utils import get_json, postdata, to_relative_url
 
 
 def test_mef_persons_permissions(client, mef_person, json_header):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.pers_item', pid_value='pers1')
-    post_url = url_for('invenio_records_rest.pers_list')
 
     res = client.get(item_url)
     assert res.status_code == 200
 
-    res = client.post(
-        post_url,
-        data={},
-        headers=json_header
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.pers_list',
+        {}
     )
     assert res.status_code == 401
 

--- a/tests/api/test_organisations_rest_api.py
+++ b/tests/api/test_organisations_rest_api.py
@@ -22,7 +22,8 @@ import json
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 
 def test_location_can_delete(client, org_martigny, lib_martigny):
@@ -61,23 +62,23 @@ def test_organisation_secure_api_create(client, json_header, org_martigny,
     """Test organisation secure api create."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)
-    post_url = url_for('invenio_records_rest.org_list')
+    post_entrypoint = 'invenio_records_rest.org_list'
 
     del org_martigny_data['pid']
-    res = client.post(
-        post_url,
-        data=json.dumps(org_martigny_data),
-        headers=json_header
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        org_martigny_data
     )
     assert res.status_code == 403
 
     # Sion
     login_user_via_session(client, librarian_sion_no_email.user)
 
-    res = client.post(
-        post_url,
-        data=json.dumps(org_martigny_data),
-        headers=json_header
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        org_martigny_data
     )
     assert res.status_code == 403
 

--- a/tests/api/test_patrons_rest.py
+++ b/tests/api/test_patrons_rest.py
@@ -24,7 +24,8 @@ import mock
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.api import ItemStatus
@@ -75,15 +76,14 @@ def test_patrons_permissions(client, librarian_martigny_no_email,
     item_url = url_for(
         'invenio_records_rest.ptrn_item',
         pid_value=librarian_martigny_no_email.pid)
-    post_url = url_for('invenio_records_rest.ptrn_list')
 
     res = client.get(item_url)
     assert res.status_code == 401
 
-    res = client.post(
-        post_url,
-        data={},
-        headers=json_header
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.ptrn_list',
+        {}
     )
     assert res.status_code == 401
 
@@ -144,7 +144,6 @@ def test_patrons_post_put_delete(client, lib_martigny,
                                  roles):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.ptrn_item', pid_value='1')
-    post_url = url_for('invenio_records_rest.ptrn_list')
     list_url = url_for('invenio_records_rest.ptrn_list', q='pid:1')
     patron_data = librarian_martigny_data
 
@@ -155,10 +154,10 @@ def test_patrons_post_put_delete(client, lib_martigny,
     patron_data['pid'] = '1'
     patron_data['email'] = 'test@rero.ch'
 
-    res = client.post(
-        post_url,
-        data=json.dumps(patron_data),
-        headers=json_header
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.ptrn_list',
+        patron_data
     )
 
     assert res.status_code == 201
@@ -238,23 +237,23 @@ def test_patron_secure_api_create(client, json_header,
     """Test patron secure api create."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)
-    post_url = url_for('invenio_records_rest.ptrn_list')
+    post_entrypoint = 'invenio_records_rest.ptrn_list'
 
     del patron_martigny_data['pid']
-    res = client.post(
-        post_url,
-        data=json.dumps(patron_martigny_data),
-        headers=json_header
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_martigny_data
     )
     assert res.status_code == 201
 
     # # Sion
     # login_user_via_session(client, librarian_sion_no_email.user)
 
-    # res = client.post(
-    #     post_url,
-    #     data=json.dumps(patron_martigny_data),
-    #     headers=json_header
+    # res, _ = postdata(
+    #     client,
+    #     post_entrypoint,
+    #     patron_martigny_data
     # )
     # assert res.status_code == 403
 

--- a/tests/api/test_patrons_views.py
+++ b/tests/api/test_patrons_views.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import get_json
+from utils import get_json, postdata
 
 from rero_ils.modules.items.api import ItemStatus
 from rero_ils.modules.loans.api import LoanAction
@@ -45,19 +45,16 @@ def test_patron_can_delete(client, librarian_martigny_no_email,
     assert not data.get_organisation()
 
     # request
-    res = client.post(
-        url_for('api_item.librarian_request'),
-        data=json.dumps(
-            dict(
-                item_pid=item.pid,
-                pickup_location_pid=location.pid,
-                patron_pid=patron.pid
-            )
-        ),
-        content_type='application/json',
+    res, data = postdata(
+        client,
+        'api_item.librarian_request',
+        dict(
+            item_pid=item.pid,
+            pickup_location_pid=location.pid,
+            patron_pid=patron.pid
+        )
     )
     assert res.status_code == 200
-    data = get_json(res)
     loan_pid = data.get('action_applied')[LoanAction.REQUEST].get('pid')
 
     links = patron_martigny_no_email.get_links_to_me()

--- a/tests/api/test_permissions_librarian.py
+++ b/tests/api/test_permissions_librarian.py
@@ -24,7 +24,8 @@ import mock
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.api import ItemStatus
@@ -63,7 +64,7 @@ def test_librarian_permissions(
     assert data['hits']['total'] == 3
 
     # can create all type of users except system_librarians
-    post_url = url_for('invenio_records_rest.ptrn_list')
+    post_entrypoint = 'invenio_records_rest.ptrn_list'
     system_librarian = deepcopy(record)
     librarian = deepcopy(record)
     librarian_saxon = deepcopy(record)
@@ -86,10 +87,10 @@ def test_librarian_permissions(
         data['email'] = str(counter) + '@domain.com'
         with mock.patch('rero_ils.modules.patrons.api.'
                         'send_reset_password_instructions'):
-            res = client.post(
-                post_url,
-                data=json.dumps(data),
-                headers=json_header
+            res, _ = postdata(
+                client,
+                post_entrypoint,
+                data
             )
             assert res.status_code == 201
             user = get_json(res)['metadata']
@@ -137,10 +138,10 @@ def test_librarian_permissions(
         data['email'] = str(counter) + '@domain.com'
         with mock.patch('rero_ils.modules.patrons.api.'
                         'send_reset_password_instructions'):
-            res = client.post(
-                post_url,
-                data=json.dumps(data),
-                headers=json_header
+            res, _ = postdata(
+                client,
+                post_entrypoint,
+                data
             )
             assert res.status_code == 403
 
@@ -149,10 +150,10 @@ def test_librarian_permissions(
     system_librarian['email'] = '4@domain.com'
     with mock.patch('rero_ils.modules.patrons.api.'
                     'send_reset_password_instructions'):
-        res = client.post(
-            post_url,
-            data=json.dumps(system_librarian),
-            headers=json_header
+        res, _ = postdata(
+            client,
+            post_entrypoint,
+            system_librarian,
         )
         assert res.status_code == 403
 

--- a/tests/api/test_permissions_patron.py
+++ b/tests/api/test_permissions_patron.py
@@ -24,7 +24,8 @@ import mock
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.api import ItemStatus
@@ -58,7 +59,6 @@ def test_patron_permissions(
     assert res.status_code == 403
 
     # can not create any type of users.
-    post_url = url_for('invenio_records_rest.ptrn_list')
     system_librarian = deepcopy(record)
     librarian = deepcopy(record)
     patron = deepcopy(record)
@@ -75,9 +75,9 @@ def test_patron_permissions(
         data['email'] = str(counter) + '@domain.com'
         with mock.patch('rero_ils.modules.patrons.api.'
                         'send_reset_password_instructions'):
-            res = client.post(
-                post_url,
-                data=json.dumps(data),
-                headers=json_header
+            res, _ = postdata(
+                client,
+                'invenio_records_rest.ptrn_list',
+                data
             )
             assert res.status_code == 403

--- a/tests/api/test_permissions_sys_librarian.py
+++ b/tests/api/test_permissions_sys_librarian.py
@@ -24,7 +24,8 @@ import mock
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.api import ItemStatus
@@ -60,7 +61,6 @@ def test_system_librarian_permissions(
     assert data['hits']['total'] == 3
 
     # can create all type of users.
-    post_url = url_for('invenio_records_rest.ptrn_list')
     system_librarian = deepcopy(record)
     librarian = deepcopy(record)
     patron = deepcopy(record)
@@ -77,10 +77,10 @@ def test_system_librarian_permissions(
         data['email'] = str(counter) + '@domain.com'
         with mock.patch('rero_ils.modules.patrons.api.'
                         'send_reset_password_instructions'):
-            res = client.post(
-                post_url,
-                data=json.dumps(data),
-                headers=json_header
+            res, _ = postdata(
+                client,
+                'invenio_records_rest.ptrn_list',
+                data
             )
             assert res.status_code == 201
             user = get_json(res)['metadata']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,7 @@
 import json
 
 import mock
+from flask import url_for
 from invenio_accounts.testutils import login_user_via_session, \
     login_user_via_view
 from invenio_circulation.api import get_loan_for_item
@@ -61,6 +62,29 @@ def login_user_for_view(client, user):
 def get_json(response):
     """Get JSON from response."""
     return json.loads(response.get_data(as_text=True))
+
+
+def postdata(client, endpoint, data=None, headers=None):
+    """
+    Build URL from given endpoint and send given data to it.
+
+    Returns result and JSON from result.
+    """
+    if data is None:
+        data = {}
+    if headers is None:
+        headers = [
+            ('Accept', 'application/json'),
+            ('Content-Type', 'application/json')
+        ]
+    res = client.post(
+        url_for(endpoint),
+        data=json.dumps(data),
+        content_type='application/json',
+        headers=headers
+    )
+    output = get_json(res)
+    return res, output
 
 
 def to_relative_url(url):


### PR DESCRIPTION
* create a `post_dict_to(client, entrypoint, data, headers)` function to replace all `client.post()` functions in tests
* replace all `client.post()` calls in tests