### PR TITLE
circ_policies ui: increase API size limit

### DIFF
--- a/ui/src/app/core/item-type/item-type.service.ts
+++ b/ui/src/app/core/item-type/item-type.service.ts
@@ -18,14 +18,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { ApiService } from '../api/api.service';
 
 const httpOptions = {
   headers: new HttpHeaders({
     'Accept': 'application/json',
     'Content-Type': 'application/json'
-  })
+  }),
+  params: new HttpParams()
+    .set('size', '9999')
 };
 
 @Injectable()

--- a/ui/src/app/core/library/library.service.ts
+++ b/ui/src/app/core/library/library.service.ts
@@ -18,14 +18,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { ApiService } from '../api/api.service';
 
 const httpOptions = {
   headers: new HttpHeaders({
     'Accept': 'application/json',
     'Content-Type': 'application/json'
-  })
+  }),
+  params: new HttpParams()
+    .set('size', '9999')
 };
 
 @Injectable()

--- a/ui/src/app/core/patron-type/patron-type.service.ts
+++ b/ui/src/app/core/patron-type/patron-type.service.ts
@@ -18,14 +18,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { ApiService } from '../api/api.service';
 
 const httpOptions = {
   headers: new HttpHeaders({
     'Accept': 'application/json',
     'Content-Type': 'application/json'
-  })
+  }),
+  params: new HttpParams()
+    .set('size', '9999')
 };
 
 @Injectable()


### PR DESCRIPTION
* Closes #405

Increase the default elasticsearch size result. 10000 is the maximum size for the default search type.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>