### PR TITLE
libraries: fix start date of reroils fixtures

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -205,7 +205,7 @@
       {
         "title": "Dimanche du livre",
         "is_open": true,
-        "start_date": "2019-05-24T10:00:00.000Z",
+        "start_date": "2019-05-24",
         "times": [
           {
             "start_time": "10:00",

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -64,4 +64,7 @@ def bulk_index(uuids, process=False, verbose=False):
 
 def date_string_to_utc(date):
     """Converts a date of string format to a datetime utc aware."""
-    return pytz.utc.localize(parser.parse(date))
+    parsed_date = parser.parse(date)
+    if parsed_date.tzinfo:
+        return parsed_date
+    return pytz.utc.localize(parsed_date)


### PR DESCRIPTION
* Improves date_string_to_utc to skip existing timezone.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>