### PR TITLE
schema: make the name for publisher optional

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -208,9 +208,6 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "name"
-        ],
         "properties": {
           "name": {
             "type": "array",


### PR DESCRIPTION
* Fixes setup script failure, as the date have some publisher without a
name.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>