### PR TITLE
ui: adapt editor according to publication statement data model

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
@@ -197,21 +197,6 @@
     ]
   },
   {
-    "type": "fieldset",
-    "title": "Date of publication",
-    "items": [
-      {
-        "key": "publicationYear",
-        "notitle": true,
-        "type": "integer"
-      },
-      {
-        "key": "freeFormedPublicationDate",
-        "condition": "model.publicationYear"
-      }
-    ]
-  },
-  {
     "key": "type",
     "title": "Document type",
     "description": "Type of the document"


### PR DESCRIPTION
Implements US931: task#1016

Test: verify that **publication date** field doesn't appear anymore in editor (add and edit)
Needs to be logged as 'AM'

## Code review check list :
- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?