### PR TITLE
#1027 - item availability instead of status

### DIFF
--- a/rero_ils/modules/items/templates/rero_ils/detailed_view_items.html
+++ b/rero_ils/modules/items/templates/rero_ils/detailed_view_items.html
@@ -50,9 +50,13 @@
             _('Library'),
             library.name)
           }}
-          {% if record.status %}
-            {{ dl(_('Status'), _(record.status)) }}
-          {% endif %}
+          {{ dl(
+              _('Availability'),
+              '<i class="fa fa-circle text-{}"></i> {}'.format(
+                'success' if record.available else 'danger',
+                _(record|item_availability_text)
+              )
+          )}}
         </dl>
       </article>
       {% if current_user | can_access_item(record) %}


### PR DESCRIPTION
Item detail view contains status, as last field. But no info appears
about the item availability.

The availability appears in other view as a colored circle. Green circle
while available. Red if not available.

This change adds the colored circle before the item status. It also
changes the field description to *Availability*.