### PR TITLE
#971 - ui: display git commit hash on frontpage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ RUN chown -R invenio:invenio ${WORKING_DIR}
 
 USER 1000
 
+# Set last GIT commit hash. Example:
+# docker build --build-arg GIT_HASH=$(git rev-parse @) .
+ARG GIT_HASH
+# Last GIT commit hash
+ENV INVENIO_RERO_ILS_APP_GIT_HASH ${GIT_HASH:-''}
+
 ENV INVENIO_COLLECT_STORAGE='flask_collect.storage.file'
 RUN ./scripts/bootstrap --deploy && rm -fr ui/node_modules
 

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1015,7 +1015,10 @@ RERO_ILS_APP_BASE_URL = 'https://ils.rero.ch'
 RERO_ILS_PERMALINK_RERO_URL = 'http://data.rero.ch/01-{identifier}'
 RERO_ILS_PERMALINK_BNF_URL = 'http://catalogue.bnf.fr/ark:/12148/{identifier}'
 
-#: RERO_ILS MEF specificconfigurations.
+#: Git commit hash. If set, a link to github commit page is displayed on RERO-ILS frontpage.
+RERO_ILS_APP_GIT_HASH = None
+
+#: RERO_ILS MEF specific configurations.
 RERO_ILS_MEF_HOST = 'mef.rero.ch'
 RERO_ILS_MEF_URL = 'https://{host}/api/mef/'.format(host=RERO_ILS_MEF_HOST)
 RERO_ILS_MEF_RESULT_SIZE = 100

--- a/rero_ils/templates/rero_ils/frontpage.html
+++ b/rero_ils/templates/rero_ils/frontpage.html
@@ -92,7 +92,11 @@
           <p class="card-text pl-2 align-self-center">
             {{_('Software source code')}}
             <a href="https://github.com/rero/rero-ils" class="rero-ils-external-link" title="{{ _('Link to the RERO ILS code source on GitHub') }}">{{_('on GitHub')}}</a>, {{ _('version') }}
-            <a href="https://github.com/rero/rero-ils/releases/tag/v{{ version }}" class="rero-ils-external-link" title="{{ _('Link to the RERO ILS code source on GitHub, last released version') }}">{{ version }}</a>
+            {% if config.RERO_ILS_APP_GIT_HASH %}
+            <a href="https://github.com/rero/rero-ils/commit/{{ config.RERO_ILS_APP_GIT_HASH }}" class="rero-ils-external-link" title="{{ _('Link to the RERO ILS code source on Github, current used version') }}">{{ config.RERO_ILS_APP_GIT_HASH[:8] }}</a>
+            {% else %}
+            <a href="https://github.com/rero/rero-ils/releases/tag/v{{ version }}" class="rero-ils-external-link" title="{{ _('Link to the RERO ILS code source on GitHub, current used version') }}">{{ version }}</a>
+            {% endif %}
           </p>
         </section>
         <section class="d-flex flex-row">


### PR DESCRIPTION
Homepage displays current RERO-ILS version. Version as in "release".
It's not so accurate.
To get more precision we use git hash version. We so:

* fetch GIT_HASH environment variable for Docker containers
* if no GIT_HASH environment variable we read files in .git directory

Info : it's not mandatory to have the complete hash. Just 8 first chars is enough.