### PR TITLE
editor: fix submit button with async validator

### DIFF
--- a/ui/src/app/records/editor/add-reference/add-reference.component.ts
+++ b/ui/src/app/records/editor/add-reference/add-reference.component.ts
@@ -64,7 +64,6 @@ export class AddReferenceComponent implements OnInit {
 
   addItem(event) {
     event.preventDefault();
-    console.log(this);
     this.jsf.addItem(this);
   }
 

--- a/ui/src/app/records/editor/editor.component.html
+++ b/ui/src/app/records/editor/editor.component.html
@@ -37,10 +37,6 @@
     (onSubmit)="save($event)"
     framework="rero"
     [language]="currentLocale"
-    (validationErrors)="validationErrors($event)"
-    (onChanges)="debug($event)"
     [options]="formOptions"
     >
     </json-schema-form>
-  <div *ngIf="validationErrors" class="text-danger"
-  [innerHTML]="prettyValidationErrors"></div>

--- a/ui/src/app/records/editor/editor.component.ts
+++ b/ui/src/app/records/editor/editor.component.ts
@@ -38,6 +38,7 @@ import { CustomBootstrap4Framework } from './bootstrap4-framework/custombootstra
 import { AddReferenceComponent } from './add-reference/add-reference.component';
 import { UserService } from '../../user.service';
 import { MainFieldsManagerComponent } from './main-fields-manager/main-fields-manager.component';
+import { SubmitComponent } from './submit/submit.component';
 // import { Bootstrap4Framework } from 'angular6-json-schema-form';
 // import { Framework } from 'angular6-json-schema-form';
 
@@ -90,6 +91,7 @@ export class EditorComponent implements OnInit {
     this.widgetLibrary.registerWidget('fieldset', FieldsetComponent);
     this.widgetLibrary.registerWidget('$ref', AddReferenceComponent);
     this.widgetLibrary.registerWidget('main-fields-manager', MainFieldsManagerComponent);
+    this.widgetLibrary.registerWidget('submit', SubmitComponent);
 
     this.currentLocale = translateService.currentLang;
     this.userService.userSettings.subscribe(settings => this.userSettings = settings);
@@ -111,9 +113,11 @@ export class EditorComponent implements OnInit {
       }
       );
   }
+
   debug(event) {
     console.log(event);
   }
+
   ngOnInit() {
     combineLatest(this.route.params, this.route.queryParams)
     .pipe(map(results => ({params: results[0], query: results[1]})))
@@ -214,9 +218,5 @@ export class EditorComponent implements OnInit {
       }
     }
     return errorArray.join('<br>');
-  }
-
-  validationErrors(errors) {
-    this.formValidationErrors = errors;
   }
 }

--- a/ui/src/app/records/editor/remote-input/remote-input.component.ts
+++ b/ui/src/app/records/editor/remote-input/remote-input.component.ts
@@ -23,6 +23,7 @@ import { JsonSchemaFormService } from 'angular6-json-schema-form';
 import { of } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { RecordsService } from '../../records.service';
+import { UniqueValidator } from '@app/core';
 
 
 @Component({
@@ -53,19 +54,15 @@ export class RemoteInputComponent implements OnInit {
     this.jsf.initializeControl(this);
     if (this.options.remoteRecordType) {
         this.formControl.setAsyncValidators([
-            this.valueAlreadyTaken.bind(this, this.options.remoteRecordType)
+            UniqueValidator.createValidator(
+              this.recordsService, this.options.remoteRecordType,
+              this.controlName, this.formControl.root.value.pid)
         ]);
     }
   }
 
   updateValue(event) {
     this.jsf.updateValue(this, event.target.value);
-  }
-
-  valueAlreadyTaken(recordType: string, control: AbstractControl) {
-    const pid = control.root.value.pid;
-    return this.recordsService.valueAlreadyExists(
-        recordType, this.controlName, control.value, pid);
   }
 
 }

--- a/ui/src/app/records/editor/submit/submit.component.html
+++ b/ui/src/app/records/editor/submit/submit.component.html
@@ -1,0 +1,33 @@
+<!--
+
+  RERO ILS
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<div
+[class]="options?.htmlClass || ''">
+  <input
+    [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+    [attr.readonly]="options?.readonly ? 'readonly' : null"
+    [attr.required]="options?.required"
+    [class]="options?.fieldHtmlClass || ''"
+    [disabled]="controlDisabled"
+    [id]="'control' + layoutNode?._id"
+    [name]="controlName"
+    [type]="layoutNode?.type"
+    [value]="controlValue"
+    (click)="updateValue($event)"
+  >
+</div>

--- a/ui/src/app/records/editor/submit/submit.component.scss
+++ b/ui/src/app/records/editor/submit/submit.component.scss
@@ -1,0 +1,18 @@
+/*
+
+  RERO ILS
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+ */

--- a/ui/src/app/records/editor/submit/submit.component.spec.ts
+++ b/ui/src/app/records/editor/submit/submit.component.spec.ts
@@ -1,0 +1,44 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SubmitComponent } from './submit.component';
+
+describe('SubmitComponent', () => {
+  let component: SubmitComponent;
+  let fixture: ComponentFixture<SubmitComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SubmitComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SubmitComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/src/app/records/editor/submit/submit.component.ts
+++ b/ui/src/app/records/editor/submit/submit.component.ts
@@ -1,0 +1,72 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService, hasOwn } from 'angular6-json-schema-form';
+import { combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Component({
+  // tslint:disable-next-line:component-selector
+  selector: 'app-submit',
+  templateUrl: './submit.component.html',
+  styleUrls: ['./submit.component.scss'],
+})
+export class SubmitComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+  formValidCode = 'VALID';
+
+  constructor(
+    private jsf: JsonSchemaFormService
+  ) { }
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+    if (hasOwn(this.options, 'disabled')) {
+      this.controlDisabled = this.options.disabled;
+    } else if (this.jsf.formOptions.disableInvalidSubmit) {
+      this.controlDisabled = !(this.jsf.isValid && this.jsf.formGroup.status === this.formValidCode);
+      combineLatest(this.jsf.isValidChanges, this.jsf.formGroup.statusChanges)
+      .subscribe(([jsonSchemaValidChanges, formValidChanges]) => {
+          this.controlDisabled = !(jsonSchemaValidChanges && formValidChanges === this.formValidCode);
+      });
+    }
+    if (this.controlValue === null || this.controlValue === undefined) {
+      this.controlValue = this.options.title;
+    }
+  }
+
+  updateValue(event) {
+    if (typeof this.options.onClick === 'function') {
+      this.options.onClick(event);
+    } else {
+      this.jsf.updateValue(this, event.target.value);
+    }
+  }
+}

--- a/ui/src/app/records/records.module.ts
+++ b/ui/src/app/records/records.module.ts
@@ -75,6 +75,7 @@ import { FieldsetComponent } from './editor/fieldset/fieldset.component';
 import { Bootstrap4FrameworkComponent } from './editor/bootstrap4-framework/bootstrap4-framework.component';
 import { AddReferenceComponent } from './editor/add-reference/add-reference.component';
 import { MainFieldsManagerComponent } from './editor/main-fields-manager/main-fields-manager.component';
+import { SubmitComponent } from './editor/submit/submit.component';
 
 @NgModule({
   declarations: [
@@ -112,7 +113,8 @@ import { MainFieldsManagerComponent } from './editor/main-fields-manager/main-fi
     FieldsetComponent,
     Bootstrap4FrameworkComponent,
     AddReferenceComponent,
-    MainFieldsManagerComponent
+    MainFieldsManagerComponent,
+    SubmitComponent
   ],
   imports: [
     CommonModule,
@@ -147,7 +149,8 @@ import { MainFieldsManagerComponent } from './editor/main-fields-manager/main-fi
     FieldsetComponent,
     Bootstrap4FrameworkComponent,
     AddReferenceComponent,
-    MainFieldsManagerComponent
+    MainFieldsManagerComponent,
+    SubmitComponent
   ],
   providers: [
     LibraryExceptionFormService,


### PR DESCRIPTION
* Disables submit button for invalid async validator.
* Removes useless debug traces.
* Uses core unique validator for remote input component.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## To Test
- ./scripts/bootstrap
- create a new item with an existing barcode: the submit button should be disabled
