### PR TITLE
document: display holding electronic location

### DIFF
--- a/rero_ils/manual_translations.txt
+++ b/rero_ils/manual_translations.txt
@@ -67,3 +67,7 @@ _('bf:Publication')
 _('bf:Manufacture')
 _('bf:Distribution')
 _('bf:Production')
+
+# Harvested source
+_('ebibliomedia')
+_('mv-cantook')

--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -216,6 +216,19 @@
       <!-- Card body -->
       <div id="collapse-{{ holding.pid }}" data-holding-id="{{ holding.pid }}" class="collapse show" role="tabpanel">
         <div class="card-body p-2">
+          <!-- display holding electronic location -->
+          {% if record.harvested %}
+            {% for elocation in holding.electronic_location %}
+              <div class="row my-2">
+                <div class="col-1">
+                  &nbsp;
+                </div>
+                <div class="col-10">
+                  <a href="{{ elocation.uri }}" target="_blank">{{ _(elocation.source) }}</a>
+                </div>
+              </div>
+            {% endfor %}
+          {% endif %}
           <!-- display items -->
           {% if number_items > 0 %}
           {% for item in items %}


### PR DESCRIPTION
## To test:
- `./script/setup`
- ebook document detail view: show the electronic location link into the holding section.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>