### PR TITLE
#1021 - refactoring: delete unused imports

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -46,6 +46,7 @@ invenio-access = "<1.2.0"
 [dev-packages]
 Flask-Debugtoolbar = ">=0.10.1"
 Sphinx = ">=1.5.1"
+autoflake = ">=1.3.1"
 check-manifest = ">=0.35"
 coverage = ">=4.4.1"
 isort = ">=4.3.5,<4.3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "941843aa1c715882fa33b652d3f8fd5a2049d4a560eb6420845c0dbf7f2718b5"
+            "sha256": "997288b5f9602921c59945876a9e053f0728adea47eaf7bf8b1db012a6d1368a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,9 +18,9 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:cdb7d98bd5cbf65acd38d70b1c05573c432e6473a82f955cdea541b5c153b0cc"
+                "sha256:9f907d7e8b286a1cfb22db9084f9ce4fde7ad7956bb496dc7c952e10ac90e36a"
             ],
-            "version": "==1.0.11"
+            "version": "==1.2.1"
         },
         "amqp": {
             "hashes": [
@@ -36,20 +36,12 @@
             "index": "pypi",
             "version": "==0.3"
         },
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "arrow": {
             "hashes": [
-                "sha256:0186026cfd94ca4fb773f30cc5398289a3027480d335e0e5c0d2772643763137",
-                "sha256:a12de0124d812d15061ed36c7eb4a421fa1b95026a502a0b2062e9ea00fc4446"
+                "sha256:10257c5daba1a88db34afa284823382f4963feca7733b9107956bed041aff24f",
+                "sha256:c2325911fcd79972cf493cfd957072f9644af8ad25456201ae1ede3316576eb4"
             ],
-            "version": "==0.14.5"
+            "version": "==0.15.2"
         },
         "asn1crypto": {
             "hashes": [
@@ -116,10 +108,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "cffi": {
             "hashes": [
@@ -367,10 +359,10 @@
         },
         "flask-sqlalchemy": {
             "hashes": [
-                "sha256:0c9609b0d72871c540a7945ea559c8fdf5455192d2db67219509aed680a3d45a",
-                "sha256:8631bbea987bc3eb0f72b1f691d47bd37ceb795e73b59ab48586d76d75a7c605"
+                "sha256:0078d8663330dc05a74bc72b3b6ddc441b9a744e2f56fe60af1a5bfc81334327",
+                "sha256:6974785d913666587949f7c2946f7001e4fa2cb2d19f4e69ead02e4b8f50b33d"
             ],
-            "version": "==2.4.0"
+            "version": "==2.4.1"
         },
         "flask-talisman": {
             "hashes": [
@@ -421,10 +413,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
-                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
-            "version": "==0.19"
+            "markers": "python_version < '3.8'",
+            "version": "==0.23"
         },
         "infinity": {
             "hashes": [
@@ -493,7 +486,6 @@
                 "sha256:6e532854a43e4f54fc7d9b1cbda720ce4ce6383b00cee6ba5f7e86ef78f12fe2",
                 "sha256:f972e10b69a68a80c342f0bcf6b3b02a6a67af4fb6e8e347ce8b482fcb47e973"
             ],
-            "index": "pypi",
             "version": "==1.0.2"
         },
         "invenio-cache": {
@@ -523,10 +515,6 @@
             "version": "==1.0.2"
         },
         "invenio-db": {
-            "extras": [
-                "postgresql",
-                "versioning"
-            ],
             "hashes": [
                 "sha256:610e9a812527469403806a112ae98bd3579a65b93f8a0ed0842c6db07398edf6",
                 "sha256:6c61e40ec7487eba01e1e29b43946c996a44855dd3083d7e7bec8426c0e195b4"
@@ -643,9 +631,6 @@
             "version": "==1.0.0"
         },
         "invenio-search": {
-            "extras": [
-                "elasticsearch6"
-            ],
             "hashes": [
                 "sha256:3db927a9a447bcfb8f84f4798a3bf656ab8ff6f093d8de83224bdde4518bf830",
                 "sha256:b51d0af749fb08a6d8e46e8d7d2232e75462d87bb11a78aade33497ed1079773"
@@ -675,10 +660,10 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:1d3a1692921e932751bc1a1f7bb96dc38671eeefdc66ed33ee4cbc57e92a410e",
-                "sha256:537cd0176ff6abd06ef3e23f2d0c4c2c8a4d9277b7451544c6cbf56d1c79a83d"
+                "sha256:c4ab005921641e40a68e405e286e7a1fcc464497e14d81b6914b4fd95e5dee9b",
+                "sha256:dd76831f065f17bddd7eaa5c781f5ea32de5ef217592cf019e34043b56895aa1"
             ],
-            "version": "==7.7.0"
+            "version": "==7.8.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -855,22 +840,29 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:8a1ee88594c983336acba749d1788950d095f96538ba193fda882844c5d35129",
-                "sha256:a339159e422a055269f5625df51fbdc7fb20512cfffa08451cd5727783ddca39"
+                "sha256:ee20892f41b2ac51f9f1927f30696a2fb91b99fe9e12bf54624e78654612cba7",
+                "sha256:f88fdf8b9cad487bf74cc03382e0e3792dd740144d4ef3395d74b03f31dcd9cf"
             ],
-            "version": "==2.20.2"
+            "version": "==2.20.5"
         },
         "maxminddb": {
             "hashes": [
-                "sha256:df1451bcd848199905ac0de4631b3d02d6a655ad28ba5e5a4ca29a23358db712"
+                "sha256:449a1713d37320d777d0db286286ab22890f0a176492ecf3ad8d9319108f2f79"
             ],
-            "version": "==1.4.1"
+            "version": "==1.5.1"
         },
         "maxminddb-geolite2": {
             "hashes": [
                 "sha256:2bd118c5567f3a8323d6c5da23a6e6d52cfc09cd9987b54eb712cf6001a96e03"
             ],
             "version": "==2018.703"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+            ],
+            "version": "==7.2.0"
         },
         "msgpack-python": {
             "hashes": [
@@ -922,10 +914,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "poyo": {
             "hashes": [
@@ -1170,9 +1162,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0459bf0ea6478f3e904de074d65769a11d74cdc34438ab3159250c96d089aef0"
+                "sha256:2f8ff566a4d3a92246d367f2e9cd6ed3edeef670dcd6dda6dfdc9efed88bcd80"
             ],
-            "version": "==1.3.7"
+            "version": "==1.3.8"
         },
         "sqlalchemy-continuum": {
             "hashes": [
@@ -1181,9 +1173,6 @@
             "version": "==1.3.9"
         },
         "sqlalchemy-utils": {
-            "extras": [
-                "encrypted"
-            ],
             "hashes": [
                 "sha256:6689b29d7951c5c7c4d79fa6b8c95f9ff9ec708b07aa53f82060599bd14dcc88"
             ],
@@ -1268,11 +1257,11 @@
         },
         "webargs": {
             "hashes": [
-                "sha256:132216236980316da205a4cfb571913109a07a2e014bcc2313b72d0b83dce507",
-                "sha256:538c9f333f1f7ce06a1eb14b3daf640351057907be71b58d2b5a23c7d6d026be",
-                "sha256:63cecd4dc79f504c31c33a8470624f79f54c1b35a23141cc52c5a3fa37dc674b"
+                "sha256:97b94d375196422a7037971a0a7e0b405a15b06099635dddcb3ecad48872f073",
+                "sha256:d23e57ebcaf44722349d7d3b235479d329fcc91b7db2f1df7fab950d7ade54f8",
+                "sha256:e0ece4ce48e880b16dc764e613972314acb4fb99f9043b7cbf5776f3a6a4b531"
             ],
-            "version": "==5.4.0"
+            "version": "==5.5.1"
         },
         "webassets": {
             "hashes": [
@@ -1289,17 +1278,17 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4",
-                "sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6"
+                "sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7",
+                "sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"
             ],
-            "version": "==0.15.5"
+            "version": "==0.16.0"
         },
         "whichcraft": {
             "hashes": [
-                "sha256:0acf1d3aebb5ab16243edbf818024ce21938f06150563041665a23b33eb11dd8",
-                "sha256:d54caa14cc3f7b1d2276f8753fd05f1dc5a554df6f83a36c5c2a551e81de2498"
+                "sha256:acdbb91b63d6a15efbd6430d1d7b2d36e44a71697e93e19b7ded477afd9fce87",
+                "sha256:deda9266fbb22b8c64fd3ee45c050d61139cd87419765f588e37c8d23e236dd9"
             ],
-            "version": "==0.6.0"
+            "version": "==0.6.1"
         },
         "wtforms": {
             "hashes": [
@@ -1322,10 +1311,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     },
     "develop": {
@@ -1357,6 +1346,13 @@
             ],
             "version": "==19.1.0"
         },
+        "autoflake": {
+            "hashes": [
+                "sha256:680cb9dade101ed647488238ccb8b8bfb4369b53d58ba2c8cdf7d5d54e01f95b"
+            ],
+            "index": "pypi",
+            "version": "==1.3.1"
+        },
         "babel": {
             "hashes": [
                 "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
@@ -1373,10 +1369,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -1448,10 +1444,10 @@
         },
         "execnet": {
             "hashes": [
-                "sha256:0dd40ad3b960aae93bdad7fe1c3f049bbcc8fba47094655a4301f5b33e906816",
-                "sha256:3839f3c1e9270926e7b3d9b0a52a57be89c302a3826a2b19c8d6e6c3d2b506d2"
+                "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50",
+                "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"
             ],
-            "version": "==1.7.0"
+            "version": "==1.7.1"
         },
         "flask": {
             "hashes": [
@@ -1484,10 +1480,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
-                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
-            "version": "==0.19"
+            "markers": "python_version < '3.8'",
+            "version": "==0.23"
         },
         "isort": {
             "hashes": [
@@ -1546,10 +1543,10 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:8a1ee88594c983336acba749d1788950d095f96538ba193fda882844c5d35129",
-                "sha256:a339159e422a055269f5625df51fbdc7fb20512cfffa08451cd5727783ddca39"
+                "sha256:ee20892f41b2ac51f9f1927f30696a2fb91b99fe9e12bf54624e78654612cba7",
+                "sha256:f88fdf8b9cad487bf74cc03382e0e3792dd740144d4ef3395d74b03f31dcd9cf"
             ],
-            "version": "==2.20.2"
+            "version": "==2.20.5"
         },
         "mock": {
             "hashes": [
@@ -1568,10 +1565,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
-                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
             ],
-            "version": "==19.1"
+            "version": "==19.2"
         },
         "pep8": {
             "hashes": [
@@ -1582,10 +1579,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -1601,6 +1598,13 @@
             ],
             "index": "pypi",
             "version": "==4.0.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
         },
         "pygments": {
             "hashes": [
@@ -1721,9 +1725,9 @@
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:9f3b9ffe0809d174f7047e121431acf99c89a7040f0ca84f94ba53a498e6d0c9"
+                "sha256:713e53b79cbcf97bc5245a06080a33d54a77e7cce2f789c835a143bcdb5c033e"
             ],
-            "version": "==1.9.0"
+            "version": "==1.9.1"
         },
         "sphinx": {
             "hashes": [
@@ -1812,17 +1816,17 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4",
-                "sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6"
+                "sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7",
+                "sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"
             ],
-            "version": "==0.15.5"
+            "version": "==0.16.0"
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,6 @@ from __future__ import print_function
 
 import os
 
-import sphinx.environment
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -45,7 +45,6 @@ from invenio_search import RecordsSearch
 from rero_ils.modules.api import IlsRecordIndexer
 from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.organisations.api import Organisation
-from rero_ils.utils import get_agg_config
 
 from .modules.circ_policies.api import CircPolicy
 from .modules.documents.api import Document

--- a/rero_ils/modules/api.py
+++ b/rero_ils/modules/api.py
@@ -41,22 +41,14 @@ class IlsRecordError:
     class Deleted(Exception):
         """IlsRecord is deleted."""
 
-        pass
-
     class NotDeleted(Exception):
         """IlsRecord is not deleted."""
-
-        pass
 
     class PidMissing(Exception):
         """IlsRecord pid missing."""
 
-        pass
-
     class PidChange(Exception):
         """IlsRecord pid change."""
-
-        pass
 
 
 class IlsRecordsSearch(RecordsSearch):

--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -42,7 +42,6 @@ from invenio_search.proxies import current_search
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from pkg_resources import resource_string
-from sqlalchemy import MetaData, create_engine
 from werkzeug.local import LocalProxy
 
 from .items.cli import create_items, reindex_items

--- a/rero_ils/modules/ebooks/tasks.py
+++ b/rero_ils/modules/ebooks/tasks.py
@@ -19,15 +19,15 @@
 
 from __future__ import absolute_import, print_function
 
-from time import sleep
-
 from celery import shared_task
-from celery.task.control import inspect
+# from celery.task.control import inspect
 from flask import current_app
 
 from .utils import create_document_holding, update_document_holding
-from ..documents.api import Document, DocumentsSearch
+from ..documents.api import DocumentsSearch
 from ..utils import bulk_index
+
+# from time import sleep
 
 
 @shared_task(ignore_result=True)

--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -22,7 +22,6 @@ from functools import partial, wraps
 
 from elasticsearch.exceptions import NotFoundError
 from flask import current_app
-from flask_babelex import gettext as _
 from invenio_circulation.api import get_loan_for_item, \
     patron_has_active_loan_on_item
 from invenio_circulation.errors import MissingRequiredParameterError, \

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -48,8 +48,6 @@ library_id_fetcher = partial(id_fetcher, provider=LibraryProvider)
 class LibraryNeverOpen(Exception):
     """Raised when the library has no open days."""
 
-    pass
-
 
 class LibrariesSearch(RecordsSearch):
     """Libraries search."""

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -30,7 +30,7 @@ from invenio_circulation.api import get_loan_for_item
 from ..circ_policies.api import CircPolicy
 from ..items.api import Item, ItemsSearch, ItemStatus
 from ..libraries.api import Library
-from ..loans.api import Loan, get_item_on_loan_loans
+from ..loans.api import get_item_on_loan_loans
 from ..locations.api import Location
 from ..notifications.tasks import create_over_and_due_soon_notifications
 from ..patron_types.api import PatronType

--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -19,7 +19,6 @@
 
 from functools import partial
 
-import invenio_records
 from flask_babelex import gettext as _
 from invenio_search.api import RecordsSearch
 

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -19,7 +19,6 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import current_app
 from flask_security.utils import config_value
 from invenio_mail.api import TemplatedMessage
 from invenio_mail.tasks import send_email

--- a/rero_ils/modules/notifications/views.py
+++ b/rero_ils/modules/notifications/views.py
@@ -19,9 +19,7 @@
 
 from __future__ import absolute_import, print_function
 
-from functools import wraps
-
-from flask import Blueprint, jsonify
+from flask import Blueprint
 
 blueprint = Blueprint(
     'notifications',

--- a/rero_ils/modules/patrons/listener.py
+++ b/rero_ils/modules/patrons/listener.py
@@ -17,11 +17,7 @@
 
 """Signals connector for patron."""
 
-from flask_babelex import gettext as _
-
-from .api import Patron, PatronsSearch
-from ..documents.api import Document
-from ...utils import send_mail
+from .api import PatronsSearch
 
 
 def enrich_patron_data(sender, json=None, record=None, index=None,

--- a/rero_ils/views.py
+++ b/rero_ils/views.py
@@ -299,5 +299,4 @@ def schemaform(document_type):
         data['layout'] = prepare_form_option(form)
     except JSONSchemaNotFound as e:
         raise(e)
-        pass
     return jsonify(data)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,16 +20,17 @@ RED='\033[0;31m'
 GREEN='\033[0;0;32m'
 NC='\033[0m' # No Color
 
-RED='\033[0;31m'
-GREEN='\033[0;0;32m'
-NC='\033[0m' # No Color
-
 display_error_message () {
 	echo -e "${RED}$1${NC}" 1>&2
 }
 
 display_success_message () {
     echo -e "${GREEN}$1${NC}" 1>&2
+}
+
+display_error_message_and_exit () {
+  display_error_message "$1"
+  exit 1
 }
 
 if [ $# -eq 0 ]
@@ -49,6 +50,8 @@ if [ $# -eq 0 ]
         pipenv run pydocstyle rero_ils tests docs
         display_success_message "Test isort:"
         pipenv run isort -rc -c -df --skip ui
+        echo -e ${GREEN}Test useless imports:${NC}
+        pipenv run autoflake --remove-all-unused-imports -c -r --exclude ui --ignore-init-module-imports . || display_error_message_and_exit "\nUse this command to check imports:\n\tautoflake --remove-all-unused-imports -r --exclude ui --ignore-init-module-imports .\n"
 
         # syntax check for typescript
         display_success_message "Syntax check for typescript:"

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -67,6 +67,12 @@ fi
 msg "Install with command: ${cmd} ${flags[@]}"
 ${cmd} ${flags[@]}
 
+# to avoid IPython dependency problem on Mac OS X
+if [ "$(uname -s)" == "Darwin" ]; then
+  msg "Install 'appnope' for Mac OS X"
+  pipenv run pip install appnope
+fi
+
 # install assets utils
 virtualenv_path=`pipenv --venv`
 msg "Install npm assets utils in: ${virtualenv_path}"

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import json
-
 import mock
 import pytz
 from dateutil import parser

--- a/tests/api/test_documents_rest.py
+++ b/tests/api/test_documents_rest.py
@@ -17,16 +17,12 @@
 
 """Tests REST API documents."""
 
-# import json
-# from utils import get_json, to_relative_url
-
 import json
 
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, postdata, \
-    to_relative_url
+from utils import VerifyRecordPermissionPatch, get_json, postdata
 
 from rero_ils.modules.documents.views import can_request, \
     item_library_pickup_locations, item_status_text, number_of_requests, \

--- a/tests/api/test_fees.py
+++ b/tests/api/test_fees.py
@@ -17,13 +17,12 @@
 
 """Tests REST API notifications."""
 
-import json
 from datetime import datetime, timedelta, timezone
 
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_circulation.search.api import LoansSearch
-from utils import flush_index, get_json, postdata, to_relative_url
+from utils import flush_index, postdata
 
 from rero_ils.modules.loans.api import Loan, LoanAction, get_overdue_loans
 from rero_ils.modules.notifications.api import NotificationsSearch

--- a/tests/api/test_holdings_rest.py
+++ b/tests/api/test_holdings_rest.py
@@ -19,16 +19,13 @@
 
 
 import json
-from copy import deepcopy
 
 import mock
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import VerifyRecordPermissionPatch, flush_index, get_json, \
     postdata, to_relative_url
 
-from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.holdings.api import Holding, HoldingsSearch
 
 

--- a/tests/api/test_items_rest.py
+++ b/tests/api/test_items_rest.py
@@ -18,7 +18,7 @@
 """Tests REST API items."""
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone  # noqa
 
 import ciso8601
 import mock

--- a/tests/api/test_items_rest_views.py
+++ b/tests/api/test_items_rest_views.py
@@ -19,22 +19,17 @@
 
 import json
 from copy import deepcopy
-from datetime import datetime, timedelta
 
-import ciso8601
 import mock
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, flush_index, get_json, postdata
+from utils import postdata
 
-from rero_ils.modules.api import IlsRecordError
-from rero_ils.modules.circ_policies.api import CircPoliciesSearch, CircPolicy
 from rero_ils.modules.documents.views import item_status_text
 from rero_ils.modules.errors import InvalidRecordID
 from rero_ils.modules.items.api import Item, ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction
-from rero_ils.modules.loans.utils import get_extension_params
+from rero_ils.modules.loans.api import LoanAction
 
 
 def test_checkout_no_loan_given(client, librarian_martigny_no_email,

--- a/tests/api/test_libraries_rest.py
+++ b/tests/api/test_libraries_rest.py
@@ -26,7 +26,7 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import VerifyRecordPermissionPatch, get_json, postdata, \
     to_relative_url
 
-from rero_ils.modules.libraries.api import Library, LibraryNeverOpen
+from rero_ils.modules.libraries.api import LibraryNeverOpen
 from rero_ils.modules.utils import date_string_to_utc
 
 

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -17,7 +17,6 @@
 
 """Tests REST API item_types."""
 
-import json
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
@@ -28,7 +27,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_circulation.api import get_loan_for_item
 from invenio_circulation.search.api import LoansSearch
-from utils import flush_index, get_json, postdata
+from utils import flush_index, postdata
 
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.loans.api import Loan, LoanAction, get_due_soon_loans, \

--- a/tests/api/test_locations_rest.py
+++ b/tests/api/test_locations_rest.py
@@ -20,13 +20,10 @@
 import json
 
 import mock
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import VerifyRecordPermissionPatch, get_json, postdata, \
     to_relative_url
-
-from rero_ils.modules.api import IlsRecordError
 
 
 def test_locations_permissions(client, loc_public_martigny, json_header):

--- a/tests/api/test_organisations_rest_api.py
+++ b/tests/api/test_organisations_rest_api.py
@@ -19,11 +19,9 @@
 
 import json
 
-import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, postdata, \
-    to_relative_url
+from utils import postdata
 
 
 def test_location_can_delete(client, org_martigny, lib_martigny):

--- a/tests/api/test_patrons_rest.py
+++ b/tests/api/test_patrons_rest.py
@@ -21,17 +21,12 @@ import json
 from copy import deepcopy
 
 import mock
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import VerifyRecordPermissionPatch, get_json, postdata, \
     to_relative_url
 
-from rero_ils.modules.api import IlsRecordError
-from rero_ils.modules.items.api import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction
 from rero_ils.modules.patrons.api import Patron
-from rero_ils.modules.patrons.utils import user_has_patron
 
 
 def test_patrons_shortcuts(

--- a/tests/api/test_patrons_views.py
+++ b/tests/api/test_patrons_views.py
@@ -17,13 +17,11 @@
 
 """Tests Views for patrons."""
 
-import json
 from copy import deepcopy
 
 import mock
-from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import get_json, postdata
+from utils import postdata
 
 from rero_ils.modules.items.api import ItemStatus
 from rero_ils.modules.loans.api import LoanAction

--- a/tests/api/test_permissions_librarian.py
+++ b/tests/api/test_permissions_librarian.py
@@ -21,16 +21,9 @@ import json
 from copy import deepcopy
 
 import mock
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, postdata, \
-    to_relative_url
-
-from rero_ils.modules.api import IlsRecordError
-from rero_ils.modules.items.api import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction
-from rero_ils.modules.patrons.utils import user_has_patron
+from utils import get_json, postdata
 
 
 def test_librarian_permissions(

--- a/tests/api/test_permissions_patron.py
+++ b/tests/api/test_permissions_patron.py
@@ -17,20 +17,12 @@
 
 """Tests REST API patrons."""
 
-import json
 from copy import deepcopy
 
 import mock
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, postdata, \
-    to_relative_url
-
-from rero_ils.modules.api import IlsRecordError
-from rero_ils.modules.items.api import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction
-from rero_ils.modules.patrons.utils import user_has_patron
+from utils import postdata
 
 
 def test_patron_permissions(

--- a/tests/api/test_permissions_sys_librarian.py
+++ b/tests/api/test_permissions_sys_librarian.py
@@ -21,16 +21,9 @@ import json
 from copy import deepcopy
 
 import mock
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from utils import VerifyRecordPermissionPatch, get_json, postdata, \
-    to_relative_url
-
-from rero_ils.modules.api import IlsRecordError
-from rero_ils.modules.items.api import ItemStatus
-from rero_ils.modules.loans.api import Loan, LoanAction
-from rero_ils.modules.patrons.utils import user_has_patron
+from utils import get_json, postdata
 
 
 def test_system_librarian_permissions(

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -18,9 +18,8 @@
 """Tests Serializers."""
 
 
-import mock
 from flask import url_for
-from utils import VerifyRecordPermissionPatch, get_json, login_user
+from utils import get_json, login_user
 
 
 def test_patrons_serializers(

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -17,13 +17,11 @@
 
 """Tasks tests."""
 
-import json
 from datetime import datetime, timedelta, timezone
 
-from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_circulation.search.api import LoansSearch
-from utils import flush_index, get_json, postdata
+from utils import flush_index, postdata
 
 from rero_ils.modules.loans.api import Loan, LoanAction, get_due_soon_loans, \
     get_overdue_loans

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,7 +34,6 @@ from rero_ils.modules.holdings.api import Holding
 from rero_ils.modules.item_types.api import ItemType
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.libraries.api import Library
-from rero_ils.modules.loans.api import Loan
 from rero_ils.modules.locations.api import Location
 from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patron_types.api import PatronType


### PR DESCRIPTION
More and more imports are useless in the project.

To avoid this problem, 2 things are needed:

* delete current imports
* check imports regularly

To delete current imports it uses a program: `autoflakes`

```bash
autoflake --remove-all-unused-imports -i -r --exclude ui \
--ignore-init-module-imports .
```

Also checks that no more useless imports remains. It also uses
`autoflakes` during `run-tests.sh` script.