### PR TITLE
fixtures: add data for a third organisation

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -1,6 +1,7 @@
 [
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "1",
     "name": "Default",
     "description": "Default circulation policy.",
     "organisation": {
@@ -19,6 +20,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "2",
     "name": "Default",
     "description": "Default circulation policy.",
     "organisation": {
@@ -37,6 +39,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "3",
     "name": "Site d'Aoste: short",
     "description": "Short loan (7 days), applies only at Site d'Aoste.",
     "organisation": {
@@ -70,6 +73,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "4",
     "name": "Short",
     "description": "Short loan (14 days).",
     "organisation": {
@@ -106,6 +110,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "5",
     "name": "Short adults",
     "description": "Short loan (14 days) for adults only.",
     "organisation": {
@@ -134,6 +139,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "6",
     "name": "Standard adults",
     "description": "Standard loan (28 days) for adults.",
     "organisation": {
@@ -162,6 +168,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "7",
     "name": "Extended",
     "description": "Extended loan (3 months).",
     "organisation": {
@@ -222,6 +229,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "8",
     "name": "On-site",
     "description": "On-site consultation.",
     "organisation": {
@@ -252,6 +260,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "9",
     "name": "No checkout",
     "description": "No checkout.",
     "organisation": {
@@ -306,6 +315,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "10",
     "name": "Ebooks no circulation",
     "description": "Ebooks no circulation.",
     "organisation": {
@@ -336,6 +346,7 @@
   },
   {
     "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "11",
     "name": "Ebooks no circulation",
     "description": "Ebooks no circulation.",
     "organisation": {
@@ -363,5 +374,24 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "http://ils.rero.ch/schema/circ_policies/circ_policy-v0.0.1.json",
+    "pid": "12",
+    "name": "Default",
+    "description": "Default circulation policy.",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/3"
+    },
+    "allow_checkout": true,
+    "checkout_duration": 30,
+    "allow_requests": true,
+    "number_of_days_before_due_date": 5,
+    "number_of_days_after_due_date": 5,
+    "reminder_fee_amount": 2.0,
+    "number_renewals": 3,
+    "renewal_duration": 30,
+    "policy_library_level": false,
+    "is_default": true
   }
 ]

--- a/data/item_types.json
+++ b/data/item_types.json
@@ -88,5 +88,15 @@
       "$ref": "https://ils.rero.ch/api/organisations/2"
     },
     "type": "online"
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/item_types/item_type-v0.0.1.json",
+    "pid": "10",
+    "name": "Default",
+    "description": "Default item type",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/3"
+    },
+    "type": "standard"
   }
 ]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -1,6 +1,7 @@
 [
   {
     "$schema": "https://ils.rero.ch/schema/libraries/library-v0.0.1.json",
+    "pid": "1",
     "address": "Via Challand 132, 11100 Aosta",
     "code": "AOSTE-CANT1",
     "email": "reroilstest+aoste1@gmail.com",
@@ -120,6 +121,7 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/libraries/library-v0.0.1.json",
+    "pid": "2",
     "address": "Viale Carlo Viola 931, 11026 Pont-Saint-Martin",
     "code": "AOSTE-CANT2",
     "email": "reroilstest+aoste2@gmail.com",
@@ -229,6 +231,7 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/libraries/library-v0.0.1.json",
+    "pid": "3",
     "address": "Avise 345, 11010 Avise",
     "code": "AOSTE-AVISE",
     "email": "reroilstest+aoste3@gmail.com",
@@ -336,6 +339,7 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/libraries/library-v0.0.1.json",
+    "pid": "4",
     "address": "Via Piave 3, 11027 Saint-Vincent",
     "code": "AOSTE-LYCEE",
     "email": "reroilstest+aoste4@gmail.com",
@@ -429,6 +433,7 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/libraries/library-v0.0.1.json",
+    "pid": "5",
     "address": "Highlands, Scotland, Great Britain",
     "code": "HOG",
     "email": "reroilstest+magic1@gmail.com",
@@ -529,5 +534,16 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/libraries/library-v0.0.1.json",
+    "pid": "6",
+    "address": "Route du Conseil, Village f\u00e9d\u00e9ral",
+    "code": "CANT1",
+    "email": "reroilstest+cantonal1@gmail.com",
+    "name": "Biblioth\u00e8que cantonale",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/3"
+    }
   }
 ]

--- a/data/locations.json
+++ b/data/locations.json
@@ -177,5 +177,16 @@
       "$ref": "https://ils.rero.ch/api/libraries/5"
     },
     "is_online": true
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
+    "pid": "19",
+    "code": "REZ",
+    "name": "Rez-de-chauss\u00e9e",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/6"
+    },
+    "is_pickup": true,
+    "pickup_name": "Biblioth\u00e8que cantonale"
   }
 ]

--- a/data/organisations.json
+++ b/data/organisations.json
@@ -16,5 +16,13 @@
     "code": "highlands",
     "default_currency": "GBP",
     "online_harvested_source": "mv-cantook"
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/organisations/organisation-v0.0.1.json",
+    "pid": "3",
+    "address": "Chemin de l'\u00c9tat, 7878 Village f\u00e9d\u00e9ral",
+    "name": "R\u00e9seau des biblioth\u00e8ques du Canton",
+    "code": "cantonal",
+    "default_currency": "CHF"
   }
 ]

--- a/data/patron_types.json
+++ b/data/patron_types.json
@@ -1,6 +1,7 @@
 [
   {
     "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",
+    "pid": "1",
     "name": "Standard",
     "description": "Standard patron.",
     "organisation": {
@@ -9,6 +10,7 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",
+    "pid": "2",
     "name": "Extended rights",
     "description": "Patron with extended rights: staff, professors, supporting members.",
     "organisation": {
@@ -17,6 +19,7 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",
+    "pid": "3",
     "name": "Children",
     "description": "Children and teenagers (< 16 years old).",
     "organisation": {
@@ -25,10 +28,20 @@
   },
   {
     "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",
+    "pid": "4",
     "name": "Standard",
     "description": "Standard patron.",
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/2"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",
+    "pid": "5",
+    "name": "Default",
+    "description": "Default patron type",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/3"
     }
   }
 ]

--- a/data/users.json
+++ b/data/users.json
@@ -296,5 +296,24 @@
     "street": "Diagon Alley 72",
     "communication_channel": "email",
     "communication_language": "eng"
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",
+    "birth_date": "1972-10-12",
+    "city": "Village f\u00e9d\u00e9ral",
+    "email": "reroilstest+guillaume@gmail.com",
+    "first_name": "Guillaume",
+    "roles": [
+      "system_librarian",
+      "librarian"
+    ],
+    "last_name": "Tell",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/6"
+    },
+    "password": "cantonale",
+    "phone": "+765554433",
+    "postal_code": "7878",
+    "street": "Sentier des Waldst\u00e4tten"
   }
 ]

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -85,7 +85,7 @@ class Library(IlsRecord):
         return Organisation.get_record_by_pid(self.organisation_pid)
 
     def get_pickup_location_pid(self):
-        """Returns librarys first pickup location."""
+        """Returns libraries first pickup location."""
         results = LocationsSearch().filter(
             'term', library__pid=self.pid).filter(
                 'term', is_pickup=True).source(['pid']).scan()
@@ -103,7 +103,7 @@ class Library(IlsRecord):
 
             if time_to_test.hour == time_to_test.minute == \
                     time_to_test.second == 0:
-                # case when ibrary is open or close few hours per day
+                # case when library is open or close few hours per day
                 times_open = times_open or end_time > start_time
             else:
                 times_open = times_open or ((time_to_test >= start_time) and

--- a/scripts/setup
+++ b/scripts/setup
@@ -136,7 +136,7 @@ display_success_message "Organisations:"
 pipenv run invenio fixtures create --pid_type org ${DATA_PATH}/organisations.json  --append
 pipenv run invenio index reindex -t org --yes-i-know
 display_success_message "Libraries:"
-pipenv run invenio fixtures create --pid_type lib ${DATA_PATH}/libraries.json
+pipenv run invenio fixtures create --pid_type lib ${DATA_PATH}/libraries.json --append
 pipenv run invenio index reindex -t lib --yes-i-know
 display_success_message "Locations:"
 pipenv run invenio fixtures create --pid_type loc ${DATA_PATH}/locations.json  --append
@@ -145,10 +145,10 @@ display_success_message "Item types:"
 pipenv run invenio fixtures create --pid_type itty ${DATA_PATH}/item_types.json  --append
 pipenv run invenio index reindex -t itty --yes-i-know
 display_success_message "Patron types:"
-pipenv run invenio fixtures create --pid_type ptty ${DATA_PATH}/patron_types.json
+pipenv run invenio fixtures create --pid_type ptty ${DATA_PATH}/patron_types.json --append
 pipenv run invenio index reindex -t ptty --yes-i-know
 display_success_message "Circulation policies:"
-pipenv run invenio fixtures create --pid_type cipo ${DATA_PATH}/circulation_policies.json
+pipenv run invenio fixtures create --pid_type cipo ${DATA_PATH}/circulation_policies.json --append
 pipenv run invenio index reindex -t cipo --yes-i-know
 pipenv run invenio index run --raise-on-error
 


### PR DESCRIPTION
For the RERO ILS workshops, we need fixtures for a third organisation.

* NEW Adds a third organisation, with it's library, location, system
  librarian, default item type, default patron type and default
  circulation policy.
* BETTER Adds PID for each resource and `--append` parameters in the
  `scripts/setup`, in order to set the PID.
* Fix minor typos in the library api file.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- Taiga task [#1020](https://tree.taiga.io/project/rero21-reroils/task/1020?kanban-status=1224894)

## How to test?

- `./scripts/setup` should succeed
- log in as reroilstest+guillaume@gmail.com (passwd is `cantonale`)
- check the third organisation has a library, a location, a patron type, an item type and a default circulation policy.
- `./run-tests.sh`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
