### PR TITLE
ebooks: enable bulk indexing of created records

### DIFF
--- a/rero_ils/modules/ebooks/tasks.py
+++ b/rero_ils/modules/ebooks/tasks.py
@@ -66,7 +66,7 @@ def create_records(records):
                 n_created += 1
                 uuids.append(new_record.id)
     # TODO: bulk indexing does not work with travis, need to check why
-    # bulk_index(uuids, process=True)
+    bulk_index(uuids, process=True)
     # wait for bulk index task to finish
     # inspector = inspect()
     # reserved = inspector.reserved()


### PR DESCRIPTION
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- To fix es indexing problem

## How to test?

- `./scripts/setup` should succeed
- harvest ebooks `pipenv run invenio oaiharvester harvest -n ebooks -a max=100`
- check http://localhost:5000/global/search/documents?size=10&page=1&q= and make sure 100 ebooks exist
- check http://localhost:5000/aoste/search/documents?size=10&page=1&q= and make sure some ebooks exist

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
