### PR TITLE
tests: add PID verifications with commit/rollback

### DIFF
--- a/tests/api/test_pid_rest.py
+++ b/tests/api/test_pid_rest.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""API tests for PID and IlsRecords"""
+
+from invenio_accounts.testutils import login_user_via_session
+from rero_ils.modules.locations.api import Location
+from utils import postdata
+
+
+def test_ilsrecord_pid_after_validationerror(
+        client, loc_online_martigny_data, librarian_martigny_no_email):
+    """Check PID before and after a ValidationError: it should be the same"""
+    loc = Location.create(loc_online_martigny_data, delete_pid=True)
+    next_pid = str(int(loc.pid) + 1)
+
+    # post invalid data and post them
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.loc_list',
+        {
+            '$schema':
+                'https://ils.rero.ch/schema/locations/location-v0.0.1.json',
+            'library': {'$ref': 'https://ils.rero.ch/api/libraries/lib1'},
+            'name': 'Library of Foo'
+        }
+    )
+
+    # check http status for invalid record
+    assert res.status_code == 400
+
+    # the pid should be unchanged
+    loc.provider.identifier.query.first().recid == loc.pid
+
+    # check that we can create a new location
+    loc2 = Location.create(loc_online_martigny_data, delete_pid=True)
+    loc2.pid == next_pid

--- a/tests/ui/item_types/test_item_types_api.py
+++ b/tests/ui/item_types/test_item_types_api.py
@@ -34,17 +34,19 @@ def test_item_type_create(db, item_type_data_tmp, org_martigny,
     with pytest.raises(RecordValidationError):
         itty = ItemType.create(item_type_data_tmp, delete_pid=True)
 
+    db.session.rollback()
+
     item_type_data_tmp['type'] = 'standard'
     itty = ItemType.create(item_type_data_tmp, delete_pid=True)
 
     assert itty == item_type_data_tmp
-    assert itty.get('pid') == '2'
+    assert itty.get('pid') == '1'
 
-    itty = ItemType.get_record_by_pid('2')
+    itty = ItemType.get_record_by_pid('1')
     assert itty == item_type_data_tmp
 
     fetched_pid = item_type_id_fetcher(itty.id, itty)
-    assert fetched_pid.pid_value == '2'
+    assert fetched_pid.pid_value == '1'
     assert fetched_pid.pid_type == 'itty'
     assert not ItemType.get_pid_by_name('no exists')
 

--- a/tests/ui/locations/test_locations_api.py
+++ b/tests/ui/locations/test_locations_api.py
@@ -34,16 +34,18 @@ def test_location_create(db, es_clear, loc_public_martigny_data, lib_martigny,
     with pytest.raises(RecordValidationError):
         loc = Location.create(loc_public_martigny_data, delete_pid=True)
 
+    db.session.rollback()
+
     del loc_public_martigny_data['is_online']
     loc = Location.create(loc_public_martigny_data, delete_pid=True)
     assert loc == loc_public_martigny_data
-    assert loc.get('pid') == '2'
+    assert loc.get('pid') == '1'
 
-    loc = Location.get_record_by_pid('2')
+    loc = Location.get_record_by_pid('1')
     assert loc == loc_public_martigny_data
 
     fetched_pid = fetcher(loc.id, loc)
-    assert fetched_pid.pid_value == '2'
+    assert fetched_pid.pid_value == '1'
     assert fetched_pid.pid_type == 'loc'
 
 


### PR DESCRIPTION
Record that failed validation generates a PID. It should not.

If any validation error occurs during a Record validation,
the PID should be canceled in database (using a rollback).

Some tests have been done to check this.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
