### PR TITLE
ui: add a new URL to change the language

### DIFF
--- a/rero_ils/views.py
+++ b/rero_ils/views.py
@@ -230,6 +230,31 @@ def help():
         code=302)
 
 
+@blueprint.route('/language', methods=['POST', 'PUT'])
+def set_language():
+    """Set language in session.
+
+    The call should be a POST or a PUT HTTP request with a JSON body as follow:
+
+    .. code-block:: json
+
+        {
+            "lang": "fr"
+        }
+    """
+    data = request.get_json()
+    if not data or not data.get('lang'):
+        return jsonify(
+            {'errors': [{'code': 400, 'title': 'missing lang property'}]}), 400
+    lang_code = data.get('lang')
+    languages = dict(current_app.extensions['invenio-i18n'].get_languages())
+    if lang_code not in languages:
+        return jsonify(
+            {'errors': [{'code': 400, 'title': 'unsupported language'}]}), 400
+    session[current_app.config['I18N_SESSION_KEY']] = lang_code.lower()
+    return jsonify({'lang': lang_code})
+
+
 @blueprint.route('/<string:viewcode>/search/<recordType>')
 @check_organisation_viewcode
 def search(viewcode, recordType):

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -20,7 +20,8 @@
 from __future__ import absolute_import, print_function
 
 import pytest
-from flask import url_for
+from flask import current_app, session, url_for
+from utils import get_json, postdata
 
 from rero_ils.views import nl2br
 
@@ -110,3 +111,47 @@ def test_search_with_parameters(client):
         page=1
         ))
     assert result.status_code == 200
+
+
+def test_language(client, app):
+    """Test the language endpoint."""
+    res, data = postdata(
+        client,
+        'rero_ils.set_language',
+        dict(
+            lang='fr'
+        )
+    )
+    assert session[app.config['I18N_SESSION_KEY']] == 'fr'
+    assert data == dict(lang='fr')
+    assert res.status_code == 200
+
+    res, data = postdata(
+        client,
+        'rero_ils.set_language',
+        dict(
+            lang='it'
+        )
+    )
+    assert session[app.config['I18N_SESSION_KEY']] == 'it'
+
+    res, data = postdata(
+        client,
+        'rero_ils.set_language',
+        dict(
+            language='fr'
+        )
+    )
+    assert res.status_code == 400
+
+    res, data = postdata(
+        client,
+        'rero_ils.set_language',
+        dict(
+            lang='foo'
+        )
+    )
+    assert res.status_code == 400
+
+    # session is unchanged
+    assert session[app.config['I18N_SESSION_KEY']] == 'it'


### PR DESCRIPTION
* Adds a new HTTP endpoint with a JSON POST or PUT method to change the
session language: this will be usefull to change the language from a
pure js application.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

- this will allows future angular application to change the language of the frontend interface.

## How to test?

- ./scripts/bootstrap && ./scripts/setup (not required if this was done on the dev branch)
- restart the server and try `curl -d '{"lang":"fr"}' -H "Content-Type: application/json" -X POST http://localhost:5000/language`, the language should be changed.

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
