### PR TITLE
translation: correct organisation translation

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
@@ -65,7 +65,7 @@
                   },
                   {
                     "value": "organisation",
-                    "name": "Organisation"
+                    "name": "OrganisationAsAuthor"
                   }
                 ]
               },

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2019-10-17 11:54+0200\n"
+"POT-Creation-Date: 2019-10-23 11:33+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2019\n"
 "Language: de\n"
@@ -418,7 +418,6 @@ msgid "The description of the circulation policy."
 msgstr "Die Beschreibung der Ausleihpolitik"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
 #: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -1273,6 +1272,10 @@ msgstr "Einheitstitel"
 #: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Person"
+
+#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
+msgid "OrganisationAsAuthor"
+msgstr "Organisation"
 
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:74
 msgid "Name of Person"

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2019-10-17 11:54+0200\n"
+"POT-Creation-Date: 2019-10-23 11:33+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2019\n"
 "Language: en\n"
@@ -419,7 +419,6 @@ msgid "The description of the circulation policy."
 msgstr "The description of the circulation policy."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
 #: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -1264,6 +1263,10 @@ msgstr "Proper or uniformed titles"
 #: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Person"
+
+#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
+msgid "OrganisationAsAuthor"
+msgstr "Organisation"
 
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:74
 msgid "Name of Person"

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2019-10-17 11:54+0200\n"
+"POT-Creation-Date: 2019-10-23 11:33+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2019\n"
 "Language: fr\n"
@@ -417,7 +417,6 @@ msgid "The description of the circulation policy."
 msgstr "La description de la politique de prêt."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
 #: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -425,7 +424,7 @@ msgstr "La description de la politique de prêt."
 #: rero_ils/modules/patron_types/jsonschemas/form_patron_types/patron_type-v0.0.1.json:6
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:38
 msgid "Organisation"
-msgstr "Collectivité"
+msgstr "Organisation"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
@@ -1273,6 +1272,10 @@ msgstr "Titres propres ou uniformes"
 #: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Personne"
+
+#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
+msgid "OrganisationAsAuthor"
+msgstr "Collectivité"
 
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:74
 msgid "Name of Person"

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2019-10-17 11:54+0200\n"
+"POT-Creation-Date: 2019-10-23 11:33+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2019\n"
 "Language: it\n"
@@ -419,7 +419,6 @@ msgid "The description of the circulation policy."
 msgstr "La descrizione della politica di prestito."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
 #: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -1274,6 +1273,10 @@ msgstr "Titoli propri o uniforme"
 #: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr "Persona"
+
+#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
+msgid "OrganisationAsAuthor"
+msgstr "Ente"
 
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:74
 msgid "Name of Person"

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2019-10-17 11:54+0200\n"
+"POT-Creation-Date: 2019-10-23 11:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -408,7 +408,6 @@ msgid "The description of the circulation policy."
 msgstr ""
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
 #: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -1230,6 +1229,10 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:64
 #: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:68
+msgid "OrganisationAsAuthor"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:74


### PR DESCRIPTION
## Why are you opening this PR?

* Implements task 1078 of US1072
* Corrects organisation translation as following:
Organisation = Organisation
OrganisationAsAuthor = Collectivité
* Closes #540.

## How to test?

See #540 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
