### PR TITLE
cli: reserve a range of pids

### DIFF
--- a/rero_ils/modules/providers.py
+++ b/rero_ils/modules/providers.py
@@ -21,17 +21,19 @@ from __future__ import absolute_import, print_function
 
 from invenio_db import db
 from invenio_pidstore.errors import PIDDoesNotExistError
-from invenio_pidstore.models import PIDStatus
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_pidstore.providers.base import BaseProvider
+from sqlalchemy import text
 
 
-def append_fixtures_new_identifiers(table, pids):
+def append_fixtures_new_identifiers(identifier, pids, pid_type):
     """Insert pids into the indentifier table and update its sequence."""
     for pid in pids:
-        data = table(recid=pid)
-        db.session.add(data)
+        db.session.add(identifier(recid=pid))
     db.session.commit()
-    table._set_sequence(int(max(pids))+1)
+    max_pid = PersistentIdentifier.query.filter_by(
+        pid_type=pid_type).order_by(text('pid_value desc')).first().id
+    identifier._set_sequence(max_pid)
 
 
 class Provider(BaseProvider):

--- a/tests/ui/organisations/test_organisations_api.py
+++ b/tests/ui/organisations/test_organisations_api.py
@@ -53,5 +53,5 @@ def test_organisation_create(app, db, org_martigny_data, org_sion_data):
     assert org.get('pid') == '2'
 
     identifier = Organisation.provider.identifier
-    append_fixtures_new_identifiers(identifier, ['1', '2'])
+    append_fixtures_new_identifiers(identifier, ['1', '2'], 'org')
     assert identifier.next() == identifier.max() == 3


### PR DESCRIPTION
* Assigns all unused pids the status NEW.
* Assigns all reserved pids the status RESERVED.
* Improves method to insert identifer pids and reset sequence.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## How to test?

-  script/setup
- make sure sequences are set correctly (pgAdmin)

- for information how to use the new cli:
pipenv run invenio utils reserve_pid_range --help

- test the cli and reserve a range of pids and consult the console to check the status of the reserved pids.

- an example to reserve 10 pids for patron future loading and assign status NEW to all unused pids:
`pipenv run invenio utils reserve_pid_range -p ptrn -n 10 -u`

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
