### PR TITLE
permissions: item edit and delete buttons for librarians

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -49,6 +49,8 @@ from .modules.documents.api import Document
 from .modules.holdings.api import Holding, HoldingsIndexer
 from .modules.item_types.api import ItemType
 from .modules.items.api import Item, ItemsIndexer
+from .modules.items.permissions import can_create_item_factory, \
+    can_update_delete_item_factory
 from .modules.libraries.api import Library
 from .modules.libraries.permissions import can_create_library_factory, \
     can_delete_library_factory, can_update_library_factory
@@ -397,9 +399,9 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         read_permission_factory_imp=can_access_organisation_records_factory,
-        create_permission_factory_imp=can_create_organisation_records_factory,
-        update_permission_factory_imp=can_update_organisation_records_factory,
-        delete_permission_factory_imp=can_delete_organisation_records_factory,
+        create_permission_factory_imp=can_create_item_factory,
+        update_permission_factory_imp=can_update_delete_item_factory,
+        delete_permission_factory_imp=can_update_delete_item_factory,
     ),
     itty=dict(
         pid_type='itty',

--- a/rero_ils/modules/items/permissions.py
+++ b/rero_ils/modules/items/permissions.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Item permissions."""
+
+
+from ...permissions import staffer_is_authenticated
+
+
+def can_update_delete_item_factory(record, *args, **kwargs):
+    """Checks if logged user can update or delete its organisation items.
+
+    librarian must have librarian or system_librarian role.
+    librarian can only update, delete items of its affiliated library.
+    sys_librarian can update, delete any item of its org only.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron and patron.organisation_pid == record.organisation_pid:
+            return check_patron_library_permissions(patron, record)
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_create_item_factory(record, *args, **kwargs):
+    """Checks if the logged user can create items for its organisation.
+
+    librarian must have librarian or system_librarian role.
+    librarian can only create items in its affiliated library.
+    sys_librarian can create any item of its org only.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron and not record:
+            return True
+        if patron and patron.organisation_pid == record.organisation_pid:
+            return check_patron_library_permissions(patron, record)
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def check_patron_library_permissions(patron, record):
+    """Checks if the logged user can create items for its organisation.
+
+    librarian must have librarian or system_librarian role.
+    librarian can only create, update, delete items in its affiliated library.
+    sys_librarian can create, update, delete any item of its org only.
+    """
+    if not patron.is_system_librarian:
+        if patron.library_pid and \
+                record.library_pid != patron.library_pid:
+            return False
+    return True

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -134,6 +134,15 @@ def test_items_serializers(
     assert response.status_code == 200
     data = get_json(response)
     assert 'cannot_delete' in data['permissions']
+    assert 'cannot_update' in data['permissions']
+    assert data['metadata'].get('item_type').get('$ref')
+
+    item_url = url_for(
+        'invenio_records_rest.item_item', pid_value=item_lib_martigny.pid)
+    response = client.get(item_url, headers=json_header)
+    assert response.status_code == 200
+    data = get_json(response)
+    assert 'cannot_delete' not in data['permissions']
     assert 'cannot_update' not in data['permissions']
     assert data['metadata'].get('item_type').get('$ref')
 


### PR DESCRIPTION
* Creates separate permission file for the item resource.
* Restricts access to the API item edit, update, delete actions only to librarians of item's affiliated library.
* Creates complete units tests for item permissions.
* Closes #574
* frontend is addressed in the rero-ils-ui project

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
