### PR TITLE
fixtures: update third organisation circulation policy

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -384,7 +384,7 @@
       "$ref": "https://ils.rero.ch/api/organisations/3"
     },
     "allow_checkout": true,
-    "checkout_duration": 30,
+    "checkout_duration": 28,
     "allow_requests": true,
     "number_of_days_before_due_date": 5,
     "number_of_days_after_due_date": 5,


### PR DESCRIPTION
In order to allow renewal on the same day of a checkout during a RERO
ILS workshop, the renewal duration is two days longer than the checkout
duration.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To adapt third organisation fixtures to workshops needs

## How to test?

- `./scripts/setup/`
- Verify http://localhost:5000/api/circ_policies/12: checkout duration should be 28, but renewal duration 30

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
