### PR TITLE
ui: fix flash messages position

### DIFF
--- a/rero_ils/static/scss/rero_ils/styles.scss
+++ b/rero_ils/static/scss/rero_ils/styles.scss
@@ -96,7 +96,7 @@ html [type=button] {
 }
 
 .toast-container {
-  position: absolute;
+  position: fixed;
   z-index: 9999999;
   top: 0;
   right: 0;

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -53,7 +53,7 @@ typeahead-container {
 }
 
 .toast-container {
-  position: absolute;
+  position: fixed;
   z-index: 9999999;
   top: 0;
   right: 0;


### PR DESCRIPTION
* Position of flash messages are now displayed on top of the screen, not on top of the page
* Closes #232

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Fix issue rero-ils/rero#232

## How to test?

- Logged with user "reroilstest@gmail.com"
- Go to `admin/circulation/requests` page.
- resize the page, if necessary, to have the search barcode box at the top of the screen (on my screen : 1280x800)
- Use a dummy barcode into the search box (ex: `test_barcode` string) and run the search
- The flash message are now displayed on the top of the screen and always stay on position despite we scroll the page.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
