### PR TITLE
fees: add organisation search filter

### DIFF
--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -30,6 +30,7 @@ from .apiharvester.signals import apiharvest_part
 from .documents.listener import enrich_document_data, mef_person_delete, \
     mef_person_insert, mef_person_revert, mef_person_update
 from .ebooks.receivers import publish_harvested_records
+from .fees.listener import enrich_fee_data
 from .holdings.listener import enrich_holding_data
 from .items.listener import enrich_item_data
 from .loans.listener import enrich_loan_data, listener_loan_state_changed
@@ -97,6 +98,7 @@ class REROILSAPP(object):
         before_record_index.connect(enrich_location_data)
         before_record_index.connect(enrich_holding_data)
         before_record_index.connect(enrich_notification_data)
+        before_record_index.connect(enrich_fee_data)
 
         loan_state_changed.connect(listener_loan_state_changed, weak=False)
 

--- a/rero_ils/modules/fees/listener.py
+++ b/rero_ils/modules/fees/listener.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Signals connector for Fee."""
+
+from .api import Fee, FeesSearch
+
+
+def enrich_fee_data(sender, json=None, record=None, index=None,
+                    **dummy_kwargs):
+    """Signal sent before a record is indexed.
+
+    :params json: The dumped record dictionary which can be modified.
+    :params record: The record being indexed.
+    :params index: The index in which the record will be indexed.
+    :params doc_type: The doc_type for the record.
+    """
+    fee_index_name = FeesSearch.Meta.index
+    if index.startswith(fee_index_name):
+        fee = Fee.get_record_by_pid(record.get('pid'))
+        org_pid = fee.organisation_pid
+        json['organisation'] = {
+            'pid': org_pid
+        }


### PR DESCRIPTION
- Create new signal to enrich data before indexing.
- Add organisation pid in indexed fields.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Closes #560 (search api return 0 records).

## How to test?

- ./script/bootstrap
- ./script/setup
- login as librarian or system librarian (use account  linked to organisation 1)
- make sure a fine is created at ~/api/fees/1
- display all fees : ~/api/fees

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
