### PR TITLE
persons: fix filter to get documents in organisation views

### DIFF
--- a/rero_ils/modules/mef_persons/views.py
+++ b/rero_ils/modules/mef_persons/views.py
@@ -75,7 +75,7 @@ def persons_detailed_view(viewcode, pid):
     )):
         org_pid = Organisation.get_record_by_viewcode(viewcode)['pid']
         search = search.filter(
-            'term', items__organisation__organisation_pid=org_pid
+            'term', holdings__organisation__organisation_pid=org_pid
         )
     for result in search.execute().hits.hits:
         record.setdefault('documents', []).append(result.get('_source'))


### PR DESCRIPTION
## Why are you opening this PR?

- Uses correct filter (holdings in place of items)
  to display documents list in person detailed views
  filtered by organisation views.
- Closes #553

Co-Authored-by: Benoit Erken erken.benoit@gmail.com

## How to test?

- In a person detailed view, I must see a link to a document detailed view, both in the global view and in the organisation view

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
