### PR TITLE
editor: fix editor button validation

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json
@@ -486,11 +486,12 @@
       "minLength": 1
     },
     "titlesProper": {
-      "title": "Proper or uniformed title",
+      "title": "Proper or uniformed titles",
       "description": "Uniform title, a related or an analytical title that is controlled by an authority file or list, used as an added access point.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Proper or uniformed title",
         "type": "string",
         "minLength": 1
       }
@@ -502,7 +503,7 @@
       "minLength": 3
     },
     "language": {
-      "title": "Language",
+      "title": "Languages",
       "description": "List of languages for the resource.",
       "type": "array",
       "minItems": 1,
@@ -610,7 +611,7 @@
       }
     },
     "copyrightDate": {
-      "title": "Copyright Date",
+      "title": "Copyright Dates",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -1151,7 +1152,7 @@
       "minLength": 1
     },
     "formats": {
-      "title": "Format",
+      "title": "Formats",
       "description": "Format of the resource, ie dimensions in cm.",
       "type": "array",
       "minItems": 1,
@@ -1192,21 +1193,23 @@
       }
     },
     "notes": {
-      "title": "Note",
+      "title": "Notes",
       "description": "Note on the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Note",
         "type": "string",
         "minLength": 1
       }
     },
     "abstracts": {
-      "title": "Abstract",
+      "title": "Abstracts",
       "description": "Abstract of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Abstract",
         "type": "string",
         "minLength": 3
       }
@@ -1257,8 +1260,8 @@
             "minLength": 1
           },
           "note": {
-            "title": "Qualifier",
-            "description": "Qualifier of the identifier.",
+            "title": "Note",
+            "description": "Note of the identifier.",
             "type": "string",
             "minLength": 1
           },
@@ -1295,11 +1298,12 @@
       }
     },
     "subjects": {
-      "title": "Subject",
+      "title": "Subjects",
       "description": "Subject of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Subject",
         "type": "string",
         "minLength": 1
       }
@@ -1311,7 +1315,7 @@
       "format": "uri"
     },
     "electronic_location": {
-      "title": "Electronic Location",
+      "title": "Electronic Locations",
       "description": "Information needed to locate and access an electronic resource.",
       "type": "array",
       "minItems": 1,

--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
@@ -486,11 +486,12 @@
       "minLength": 1
     },
     "titlesProper": {
-      "title": "Proper or uniformed title",
+      "title": "Proper or uniformed titles",
       "description": "Uniform title, a related or an analytical title that is controlled by an authority file or list, used as an added access point.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Proper or uniformed title",
         "type": "string",
         "minLength": 1
       }
@@ -502,7 +503,7 @@
       "minLength": 3
     },
     "language": {
-      "title": "Language",
+      "title": "Languages",
       "description": "List of languages for the resource.",
       "type": "array",
       "minItems": 1,
@@ -610,10 +611,11 @@
       }
     },
     "copyrightDate": {
-      "title": "Copyright Date",
+      "title": "Copyright Dates",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Copyright Date",
         "type": "string",
         "pattern": "^([\u00a9\u2117]\\s)?\\d{4}.*",
         "minLength": 4
@@ -727,7 +729,7 @@
       "minLength": 1
     },
     "formats": {
-      "title": "Format",
+      "title": "Formats",
       "description": "Format of the resource, ie dimensions in cm.",
       "type": "array",
       "minItems": 1,
@@ -768,21 +770,23 @@
       }
     },
     "notes": {
-      "title": "Note",
+      "title": "Notes",
       "description": "Note on the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Note",
         "type": "string",
         "minLength": 1
       }
     },
     "abstracts": {
-      "title": "Abstract",
+      "title": "Abstracts",
       "description": "Abstract of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Abstract",
         "type": "string",
         "minLength": 3
       }
@@ -833,8 +837,8 @@
             "minLength": 1
           },
           "note": {
-            "title": "Qualifier",
-            "description": "Qualifier of the identifier.",
+            "title": "Note",
+            "description": "Note of the identifier.",
             "type": "string",
             "minLength": 1
           },
@@ -871,11 +875,12 @@
       }
     },
     "subjects": {
-      "title": "Subject",
+      "title": "Subjects",
       "description": "Subject of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Subject",
         "type": "string",
         "minLength": 1
       }
@@ -887,7 +892,7 @@
       "format": "uri"
     },
     "electronic_location": {
-      "title": "Electronic Location",
+      "title": "Electronic Locations",
       "description": "Information needed to locate and access an electronic resource.",
       "type": "array",
       "minItems": 1,

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -490,6 +490,7 @@
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Proper or uniformed title",
         "type": "string",
         "minLength": 1
       }
@@ -1150,11 +1151,12 @@
       "minLength": 1
     },
     "formats": {
-      "title": "Format",
+      "title": "Formats",
       "description": "Format of the resource, ie dimensions in cm.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Format",
         "type": "string",
         "minLength": 1
       }
@@ -1191,21 +1193,23 @@
       }
     },
     "notes": {
-      "title": "Note",
+      "title": "Notes",
       "description": "Note on the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Note",
         "type": "string",
         "minLength": 1
       }
     },
     "abstracts": {
-      "title": "Abstract",
+      "title": "Abstracts",
       "description": "Abstract of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Abstract",
         "type": "string",
         "minLength": 3
       }
@@ -1256,8 +1260,8 @@
             "minLength": 1
           },
           "note": {
-            "title": "Qualifier",
-            "description": "Qualifier of the identifier.",
+            "title": "Note",
+            "description": "Note of the identifier.",
             "type": "string",
             "minLength": 1
           },
@@ -1294,11 +1298,12 @@
       }
     },
     "subjects": {
-      "title": "Subject",
+      "title": "Subjects",
       "description": "Subject of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Subject",
         "type": "string",
         "minLength": 1
       }
@@ -1310,7 +1315,7 @@
       "format": "uri"
     },
     "electronic_location": {
-      "title": "Electronic Location",
+      "title": "Electronic Locations",
       "description": "Information needed to locate and access an electronic resource.",
       "type": "array",
       "minItems": 1,
@@ -1319,11 +1324,13 @@
         "required": [
           "uri"
         ],
-        "uri": {
-          "title": "Uniform Resource Identifier",
-          "description": "Uniform Resource Identifier (URI), which provides standard syntax for locating an object using existing Internet protocols.",
-          "type": "string",
-          "format": "uri"
+        "properties": {
+          "uri": {
+            "title": "Uniform Resource Identifier",
+            "description": "Uniform Resource Identifier (URI), which provides standard syntax for locating an object using existing Internet protocols.",
+            "type": "string",
+            "format": "uri"
+          }
         }
       }
     },

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -485,11 +485,12 @@
       "minLength": 1
     },
     "titlesProper": {
-      "title": "Proper or uniformed title",
+      "title": "Proper or uniformed titles",
       "description": "Uniform title, a related or an analytical title that is controlled by an authority file or list, used as an added access point.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Proper or uniformed title",
         "type": "string",
         "minLength": 1
       }
@@ -501,7 +502,7 @@
       "minLength": 3
     },
     "language": {
-      "title": "Language",
+      "title": "Languages",
       "description": "List of languages for the resource.",
       "type": "array",
       "minItems": 1,
@@ -609,7 +610,7 @@
       }
     },
     "copyrightDate": {
-      "title": "Copyright Date",
+      "title": "Copyright Dates",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -726,7 +727,7 @@
       "minLength": 1
     },
     "formats": {
-      "title": "Format",
+      "title": "Formats",
       "description": "Format of the resource, ie dimensions in cm.",
       "type": "array",
       "minItems": 1,
@@ -767,21 +768,23 @@
       }
     },
     "notes": {
-      "title": "Note",
+      "title": "Notes",
       "description": "Note on the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Note",
         "type": "string",
         "minLength": 1
       }
     },
     "abstracts": {
-      "title": "Abstract",
+      "title": "Abstracts",
       "description": "Abstract of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Abstract",
         "type": "string",
         "minLength": 3
       }
@@ -832,8 +835,8 @@
             "minLength": 1
           },
           "note": {
-            "title": "Qualifier",
-            "description": "Qualifier of the identifier.",
+            "title": "Note",
+            "description": "Note of the identifier.",
             "type": "string",
             "minLength": 1
           },
@@ -870,11 +873,12 @@
       }
     },
     "subjects": {
-      "title": "Subject",
+      "title": "Subjects",
       "description": "Subject of the resource.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Subject",
         "type": "string",
         "minLength": 1
       }
@@ -886,7 +890,7 @@
       "format": "uri"
     },
     "electronic_location": {
-      "title": "Electronic Location",
+      "title": "Electronic Locations",
       "description": "Information needed to locate and access an electronic resource.",
       "type": "array",
       "minItems": 1,
@@ -895,11 +899,13 @@
         "required": [
           "uri"
         ],
-        "uri": {
-          "title": "Uniform Resource Identifier",
-          "description": "Uniform Resource Identifier (URI), which provides standard syntax for locating an object using existing Internet protocols.",
-          "type": "string",
-          "format": "uri"
+        "properties": {
+          "uri": {
+            "title": "Uniform Resource Identifier",
+            "description": "Uniform Resource Identifier (URI), which provides standard syntax for locating an object using existing Internet protocols.",
+            "type": "string",
+            "format": "uri"
+          }
         }
       }
     },

--- a/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
@@ -31,8 +31,7 @@
         "description": "",
         "items": [
           {
-            "key": "titlesProper[]",
-            "title": "Proper or uniformed title"
+            "key": "titlesProper[]"
           }
         ]
       }
@@ -114,6 +113,7 @@
     "items": [
       {
         "notitle": true,
+        "description": "",
         "type": "array",
         "items": [
           {
@@ -235,6 +235,7 @@
     "items": [
       {
         "notitle": true,
+        "description": "",
         "type": "array",
         "items": [
           {
@@ -277,7 +278,6 @@
         "items": [
           {
             "key": "formats[]",
-            "title": "Format",
             "description": "Format of the resource, ie dimensions in cm."
           }
         ]
@@ -471,6 +471,7 @@
       {
         "key": "notes",
         "notitle": true,
+        "description": "",
         "items": [
           {
             "key": "notes[]"

--- a/ui/src/app/records/editor/fieldset/fieldset.component.ts
+++ b/ui/src/app/records/editor/fieldset/fieldset.component.ts
@@ -174,6 +174,7 @@ export class FieldsetComponent implements OnInit {
     }
     for (const item of field.items) {
       this.resetFormGroup(item);
+      this.disableFormGroup(item);
     }
   }
 
@@ -188,4 +189,14 @@ export class FieldsetComponent implements OnInit {
     control.reset();
     return true;
   }
+
+  private disableFormGroup(layoutNode) {
+    const control = getControl(this.jsf.formGroup, layoutNode.dataPointer);
+    if (!control) {
+      return false;
+    }
+    control.disable();
+    return true;
+  }
+
 }

--- a/ui/src/app/records/editor/main-fields-manager/main-fields-manager.component.html
+++ b/ui/src/app/records/editor/main-fields-manager/main-fields-manager.component.html
@@ -18,8 +18,8 @@
 -->
 
 <div>
-<h5 *ngIf="fieldsToShow.length" translate>New</h5>
-  <button class="btn btn-light mr-2 mb-2" *ngFor="let field of fieldsToShow" (click)="show(field)">
+<h5 *ngIf="hiddenFields.length" translate>New</h5>
+  <button class="btn btn-light mr-2 mb-2" *ngFor="let field of hiddenFields" (click)="show(field)">
  {{field.options.title}}
 </button>
 </div>


### PR DESCRIPTION
* Enable/disable FormControl when a fieldset is show/hidden.
* Adapt json schema form and json schema documents.
* Fix save button disabled in document editor.
* Fix identifier subfield labelled with the same text.
* Close #556, Close #557

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Implement task 1074
- Fix issue #556 and #557

## How to test?

- ./scripts/bootstrap & ./scripts/setup
- login as librarian
- go to document editor
- import EAN from BNF, edit or create document

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
