### PR TITLE
ui: fix typeahead unexpected behaviour

### DIFF
--- a/ui/src/app/autocomplete/autocomplete.component.html
+++ b/ui/src/app/autocomplete/autocomplete.component.html
@@ -25,14 +25,15 @@
       role="search" autocomplete="off">
 
   <input
+  (keyup.enter)="onEnter($event)"
   name="q"
-  type="search"
+  [typeaheadIsFirstItemActive]="false"
   placeholder="{{ placeholder }}"
   [(ngModel)]="asyncSelected.query"
   [typeaheadAsync]="true"
   [typeahead]="dataSource"
   (typeaheadLoading)="changeTypeaheadLoading($event)"
-    [typeaheadOptionsLimit]="10"
+  [typeaheadOptionsLimit]="10"
   typeaheadOptionField="query"
   class="form-control"
   [typeaheadWaitMs]="300"
@@ -45,6 +46,9 @@
   <input type="hidden" name="page" value="1">
   <input *ngIf="displayScore" type="hidden" name="display_score" value="{{ displayScore }}">
   <div class="input-group-append">
-    <button type="submit" (click)="form.submit()" class="btn btn-light"><i class="fa fa-search"></i></button>
+    <button type="submit" (click)="form.submit()" class="btn btn-light">
+      <i *ngIf="!typeaheadLoading" class="fa fa-search"></i>
+      <i *ngIf="typeaheadLoading" class="fa fa-spinner fa-spin"></i>
+    </button>
   </div>
 </form>


### PR DESCRIPTION
* Adds a loading wheel during the suggestion loading.
* Removes useless query entry in the suggestions.
* Enter keys submit the quey.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- To solve a strange search input behavious.
- The type a head search input submit the search with the enter key as Google.

## How to test?

- Run the bootstrap script.
- Clear the browser cache.
- Try the type a head search in the front and public search page.

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
