### PR TITLE
notification: fix "not extendable" string in different languages

### DIFF
--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -35,27 +35,26 @@ class Dispatcher():
                 data['loan']['patron']['communication_channel']
             if communication_channel == 'email':
                 self.send_mail(data=data)
-            if communication_channel == 'sms':
+            elif communication_channel == 'sms':
                 pass
-            if communication_channel == 'whatsapp':
+            elif communication_channel == 'whatsapp':
                 pass
-            if communication_channel == 'letter':
+            elif communication_channel == 'letter':
                 pass
             notification = notification.update_process_date()
         return notification
 
     def send_mail(self, data):
-        """Send email."""
+        """Send the notification by email."""
         notification_type = data.get('notification_type')
         language = data['loan']['patron']['communication_language']
-        template = 'email/{type}/{lang}'.format(
+        template = 'email/{type}/{lang}.txt'.format(
             type=notification_type,
             lang=language
         )
         recipient = data['loan']['patron']['email']
         msg = TemplatedMessage(
-            # template_html='{template}.html'.format(template=template),
-            template_body='{template}.txt'.format(template=template),
+            template_body=template,
             sender=config_value('EMAIL_SENDER'),
             recipients=[recipient],
             ctx=data['loan']

--- a/rero_ils/modules/notifications/templates/email/due_soon/fre.txt
+++ b/rero_ils/modules/notifications/templates/email/due_soon/fre.txt
@@ -6,7 +6,7 @@ Le délai de prêt des documents mentionnés ci-dessous arrive à échéance :
 {% if author %}Auteur : {{ author }}{% endif %}
 Titre : {{ document.title }}
 Echéance : {{ end_date }}
-Note : Non extendable
+Note : Non prolongeable
 
 Vous pouvez consulter votre compte et prolonger la durée de prêt de vos documents à l'adresse : {{ profile_url }}
 

--- a/rero_ils/modules/notifications/templates/email/due_soon/ger.txt
+++ b/rero_ils/modules/notifications/templates/email/due_soon/ger.txt
@@ -6,7 +6,7 @@ Die Ausleihfrist der folgenden Dokumente läuft ab:
 {% if author %}Autor : {{ author }}{% endif %}
 Titel: {{ document.title }}
 Rückgabedatum: {{ end_date }}
-Anmerkung: Non extendable
+Anmerkung: Nicht verlängerbar
 
 Unter folgender Adresse können Sie Ihr Konto einsehen und die Ausleihfrist Ihrer Dokumente verlängern: {{ profile_url }}
 

--- a/rero_ils/modules/notifications/templates/email/due_soon/ita.txt
+++ b/rero_ils/modules/notifications/templates/email/due_soon/ita.txt
@@ -6,7 +6,7 @@ La durata di prestito dei seguenti documenti sta per scadere:
 {% if author %}Autore : {{ author }}{% endif %}
 Titolo: {{ document.title }}
 Scadenza: {{ end_date }}
-Nota: Non extendable
+Nota: Non prorogabile
 
 Lei può consultare il Suo conto et prorogare la durata di prestito dei Suoi documenti al seguente indirizzo: {{ profile_url }}
 

--- a/rero_ils/modules/notifications/templates/email/recall/eng.txt
+++ b/rero_ils/modules/notifications/templates/email/recall/eng.txt
@@ -6,7 +6,7 @@ The document you borrowed has been requested by another person. An extension of 
 {% if author %}Author : {{ author }}{% endif %}
 Title: {{ document.title }}
 Due date: {{ end_date }}
-Note: Non-extendable
+Note: Non extendable
 
 You can consult your account at: {{ profile_url }}
 


### PR DESCRIPTION
* Fixes "not extendable" string into some email template files.
* Closes #571.

## How to test?

- run `scripts/bootstrap`
- Create a "due soon" notification for a non extendable item and an italian speaking patron.

OR 

- run `scripts/bootstrap` and `scripts/setup`
- consult last notification on Gmail for 'reroilstest+simonetta@gmail.com'

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
