### PR TITLE
renewals: add renew buttons for patrons checked-out items

### DIFF
--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -19,115 +19,124 @@
 {%- extends 'rero_ils/page.html' %}
 
 {%- block body %}
-  {% include('rero_ils/_patron_profile_head.html') %}
+{% include('rero_ils/_patron_profile_head.html') %}
 
-  <article class="mt-4">
-    <header>
-      <nav>
-       <ul class="nav nav-tabs" id="nav-tab" role="tablist">
+<article class="mt-4">
+  <header>
+    <nav>
+      <ul class="nav nav-tabs" id="nav-tab" role="tablist">
         <li class="nav-item">
-          <a class="nav-link active" href="#checkouts" data-toggle="tab"
-             id="checkouts-tab" title="{{ _('Checkouts') }}" role="tab"
-             aria-controls="checkouts" aria-selected="true">
+          <a class="nav-link active" href="#checkouts" data-toggle="tab" id="checkouts-tab" title="{{ _('Checkouts') }}"
+            role="tab" aria-controls="checkouts" aria-selected="true">
             {{ _('Checkouts') }} ({{ checkouts|length }})
           </a>
         </li>
         <li class="nav-item">
-           <a class="nav-link" href="#pending" data-toggle="tab"
-             id="pending-tab" title="{{ _('Pending') }}" role="tab"
-             aria-controls="pending" aria-selected="false">
+          <a class="nav-link" href="#pending" data-toggle="tab" id="pending-tab" title="{{ _('Pending') }}" role="tab"
+            aria-controls="pending" aria-selected="false">
             {{ _('Pending') }} ({{ pendings|length }})
           </a>
         </li>
         <li class="nav-item">
-           <a class="nav-link"  href="#personal-data" data-toggle="tab"
-             id="personal-data-tab" title="{{ _('Personal data') }}" role="tab"
-             aria-controls="personal-data" aria-selected="false">
+          <a class="nav-link" href="#personal-data" data-toggle="tab" id="personal-data-tab"
+            title="{{ _('Personal data') }}" role="tab" aria-controls="personal-data" aria-selected="false">
             {{ _('Personal data') }}
           </a>
         </li>
-       </ul>
-      </nav>
-    </header>
-    <article class="tab-content">
-      <section class="tab-pane show active py-2" id="checkouts" role="tabpanel" aria-labelledby="checkouts-tab">
-        {% if checkouts|length > 0 %}
-            {{ build_table('checkouts', checkouts) }}
-        {% else %}
-            <p>{{ _('No loan') }}</p>
-        {% endif %}
-      </section>
-      <section class="tab-pane py-2" id="pending" role="tabpanel" aria-labelledby="pending-tab">
-        {% if pendings|length > 0 %}
-            {{ build_table('requests', pendings) }}
-        {% else %}
-            <p>{{ _('No pending') }}</p>
-        {% endif %}
-      </section>
-      <section class="tab-pane py-2" id="personal-data" role="tabpanel" aria-labelledby="personal-data-tab">
-        {% include('rero_ils/_patron_profile_personal.html') %}
-      </section>
-    </article>
+      </ul>
+    </nav>
+  </header>
+  <article class="tab-content">
+    <section class="tab-pane show active py-2" id="checkouts" role="tabpanel" aria-labelledby="checkouts-tab">
+      {% if checkouts|length > 0 %}
+      {{ build_table('checkouts', checkouts) }}
+      {% else %}
+      <p>{{ _('No loan') }}</p>
+      {% endif %}
+    </section>
+    <section class="tab-pane py-2" id="pending" role="tabpanel" aria-labelledby="pending-tab">
+      {% if pendings|length > 0 %}
+      {{ build_table('requests', pendings) }}
+      {% else %}
+      <p>{{ _('No pending') }}</p>
+      {% endif %}
+    </section>
+    <section class="tab-pane py-2" id="personal-data" role="tabpanel" aria-labelledby="personal-data-tab">
+      {% include('rero_ils/_patron_profile_personal.html') %}
+    </section>
   </article>
-{%- endblock body %}
+</article>
 
+
+{%- endblock body %}
 {% macro build_table(type, loans) %}
 <div class="table-responsive">
-    <table class="table table-striped table-sm">
-        <thead>
-            <tr>
-                <th class="col-md-6 border-top-0" scope="col">{{ _('Title') }}</th>
-                <th class="col-md-2 border-top-0" scope="col">{{ _('Call Number') }}</th>
-                {% if type != 'checkouts' %}
-                <th class="col-md-2 border-top-0" scope="col">
-                    {{ _('Pickup library') }}
-                </th>
-                {% endif %}
-                <th class="col-md-2 border-top-0" scope="col">
-                    {% if type == 'checkouts' %}
-                        {{ _('Due date') }}
-                    {% else %}
-                        {{ _('Reservation date') }}
-                    {% endif %}
-                </th>
-                {% if type == 'checkouts' %}
-                <th class="col-md-1 border-top-0" scope="col">
-                        {{ _('Renewals') }}
-                </th>
-                {% endif %}
-            </tr>
-        </thead>
-        <tbody>
-            {% for loan in loans %}
-            <tr>
-                <td>{{ loan.document_title }}</td>
-                <td>{{ loan.item_call_number }}</td>
-                {% if type != 'checkouts' %}
-                <td>
-                  {{ loan.pickup_library_name }}
-                </td>
-                {% endif %}
-                <td>
-                    {% if type == 'checkouts' %}
-                      {{ loan.end_date|format_date(
+  <table class="table table-striped table-sm">
+    <thead>
+      <tr>
+        <th class="col-md-6 border-top-0" scope="col">{{ _('Title') }}</th>
+        <th class="col-md-2 border-top-0" scope="col">{{ _('Call Number') }}</th>
+        {% if type != 'checkouts' %}
+        <th class="col-md-2 border-top-0" scope="col">
+          {{ _('Pickup library') }}
+        </th>
+        {% endif %}
+        <th class="col-md-2 border-top-0" scope="col">
+          {% if type == 'checkouts' %}
+          {{ _('Due date') }}
+          {% else %}
+          {{ _('Reservation date') }}
+          {% endif %}
+        </th>
+        {% if type == 'checkouts' %}
+        <th class="col-md-1 border-top-0" scope="col">
+          {{ _('Renewals') }}
+        </th>
+        {% endif %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for loan in loans %}
+      <tr>
+        <td>{{ loan.document_title }}</td>
+        <td>{{ loan.item_call_number }}</td>
+        {% if type != 'checkouts' %}
+        <td>
+          {{ loan.pickup_library_name }}
+        </td>
+        {% endif %}
+        <td>
+          {% if type == 'checkouts' %}
+          {{ loan.end_date|format_date(
                           format='short_date',
                           locale=current_i18n.locale.language
                       )}}
-                    {% else %}
-                        {{ loan.transaction_date|format_date(
+          {% else %}
+          {{ loan.transaction_date|format_date(
                           format='short_date',
                           locale=current_i18n.locale.language
                       )}}
-                    {% endif %}
-                </td>
-                {% if type == 'checkouts' %}
-                <td>
-                    {{ loan.extension_count }}
-                </td>
-                {% endif %}
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+          {% endif %}
+        </td>
+        {% if type == 'checkouts' %}
+        <td>
+          {{ loan.extension_count }}
+        </td>
+        <td>
+            {% if loan.can_renew %}
+            {%- with form = can_renew_form %}
+              <form action="{{ url_for('patrons.profile') }}" method="POST" name="can_renew_form">
+                <input type="hidden" name="loan_pid" value="{{ loan.pid }}">  
+                <button type="submit" class="btn btn btn-primary btn-bg">{{_('Renew')}}</button>
+              </form>
+            {%- endwith %}
+            {% endif %}
+        </td>
+        {% endif %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 </div>
 {% endmacro %}
+

--- a/tests/ui/holdings/test_holdings_item.py
+++ b/tests/ui/holdings/test_holdings_item.py
@@ -85,6 +85,9 @@ def test_holding_item_links(client, holding_lib_martigny, item_lib_martigny,
     assert not holding_lib_martigny.delete_from_index()
     holding_lib_martigny.dbcommit(forceindex=True)
 
+    # test item count by holdings pid
+    assert holding_lib_martigny.get_items_count_by_holding_pid == 2
+
 
 def test_holding_delete_after_item_deletion(
         client, holding_lib_martigny, item_lib_martigny):


### PR DESCRIPTION
* Displays renew button when renewal of checked-out item is possible.
* Hides renew button when circulation policies do not permit the renewal action.
* Increases units testing coverage.
* Corrects indentation of the patron_profile Jinja template.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Renewal by the patron itself
https://tree.taiga.io/project/rero21-reroils/us/350?milestone=247550

## How to test?

- Login as a patron and visit the patron profile page
- For the checked-out tab, if checked-out items can be renewed, the `renew` button will be displayed
- Click the renew button to change the due date of the current check-out transaction

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [x] Functions docstrings.
- [ ] Unnecessary commited files?
