### PR TITLE
document editor: fix add author after removed all authors from the form

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json
@@ -563,7 +563,7 @@
       "title": "Authors",
       "description": "Author(s) of the resource. Can be either persons or organisations.",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
@@ -563,7 +563,7 @@
       "title": "Authors",
       "description": "Author(s) of the resource. Can be either persons or organisations.",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -562,7 +562,7 @@
       "title": "Authors",
       "description": "Author(s) of the resource. Can be either persons or organisations.",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -562,7 +562,7 @@
       "title": "Authors",
       "description": "Author(s) of the resource. Can be either persons or organisations.",
       "type": "array",
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": [


### PR DESCRIPTION
- Fixes issue in document editor: when you removed all authors, you were unable to add a new one.
- Modify the jsonschemas (update "minItems" attribute from 0 to 1).
- Closes: #609

Co-Authored-by: Benoit Erken erken.benoit@gmail.com
Co-Authored-by: Laurent Dubois laurent.dubois@itld-solutions.be

## Why are you opening this PR?
Try to improve the next workshop.

## How to test?

- In document editor: let's remove all authors. The authors block should disappear 
  and a tab "Authors" must appears on the top of the form.
- when there is no author in your editor, click on the "Authors" tab in order to add a new block "Authors".

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
