### PR TITLE
dojson: fix provisionActivity unimarc transformation

### DIFF
--- a/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
+++ b/rero_ils/modules/documents/dojson/contrib/unimarctojson/model.py
@@ -273,8 +273,10 @@ def unimarc_publishers_provision_activity_publication(self, key, value):
                 statement.append(place_or_agent_data)
             if blob_key != '__order__':
                 index += 1
-
-        publication['statement'] = statement
+        if statement:
+            publication['statement'] = statement
+    if not publication.get('statement'):
+        publication = None
     return publication or None
 
 

--- a/tests/api/test_external_services.py
+++ b/tests/api/test_external_services.py
@@ -25,6 +25,7 @@ import pytest
 from flask import url_for
 from utils import VerifyRecordPermissionPatch, get_json, to_relative_url
 
+from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.views import create_publication_statement
 
 
@@ -94,8 +95,12 @@ def test_documents_import_bnf_ean(client):
     res = client.get(url_for(
         'api_documents.import_bnf_ean', ean='9782070541270'))
     assert res.status_code == 200
-    data = get_json(res)
-    assert data.get('metadata') == {
+    data = get_json(res).get('metadata')
+    data.update({
+        "$schema": "https://ils.rero.ch/schema/documents/document-v0.0.1.json"
+    })
+    assert data == {
+        '$schema': 'https://ils.rero.ch/schema/documents/document-v0.0.1.json',
         'authors': [
             {'date': '1965-', 'name': 'Rowling, J. K.', 'type': 'person'},
             {
@@ -147,3 +152,12 @@ def test_documents_import_bnf_ean(client):
         'translatedFrom': ['eng'],
         'type': 'book'
     }
+    assert Document.create(data)
+    res = client.get(url_for(
+        'api_documents.import_bnf_ean', ean='9782072862014'))
+    assert res.status_code == 200
+    data = get_json(res).get('metadata')
+    data.update({
+        "$schema": "https://ils.rero.ch/schema/documents/document-v0.0.1.json"
+    })
+    assert Document.create(data)

--- a/tests/unit/test_documents_dojson_unimarc.py
+++ b/tests/unit/test_documents_dojson_unimarc.py
@@ -347,6 +347,43 @@ def test_unimarc_publishers_provision_activity():
 
     unimarcxml = """
     <record>
+      <datafield tag="100" ind1=" " ind2=" ">
+        <subfield code="a">xxxxxxxxx2015????xxxxxxxxx</subfield>
+      </datafield>
+      <datafield tag="210" ind1=" " ind2=" ">
+        <subfield code="a">Lausanne</subfield>
+        <subfield code="c">Payot</subfield>
+        <subfield code="d">2015</subfield>
+      </datafield>
+      <datafield tag="210" ind1=" " ind2=" ">
+        <subfield code="e">Lausanne</subfield>
+      </datafield>
+    </record>
+    """
+    unimarcjson = create_record(unimarcxml)
+    data = unimarctojson.do(unimarcjson)
+    assert data.get('provisionActivity') == [{
+        'type': 'bf:Publication',
+        'statement': [
+            {
+                'label': [
+                    {'value': 'Lausanne'}
+                ],
+                'type': 'bf:Place'
+            },
+            {
+                'label': [
+                    {'value': 'Payot'}
+                ],
+                'type': 'bf:Agent'
+            },
+        ],
+        'startDate': '2015',
+        'date': '2015'
+    }]
+
+    unimarcxml = """
+    <record>
       <datafield tag="102" ind1=" " ind2=" ">
         <subfield code="a">FR</subfield>
       </datafield>


### PR DESCRIPTION
Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

* Adds external tests and dojson transformation tests to deal with a poor provisionActivity field.
* Fixes import EAN with some specific provisionActivity (210__) unimarc equivalent field.

## Why are you opening this PR?

- In order to solve EAN import from BNF for ex. 9782072862014

## How to test?

- Try to import 9782072862014 in the document editor and submit.


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
