### PR TITLE
fix: correct circulation policy

### DIFF
--- a/data/circulation_policies.json
+++ b/data/circulation_policies.json
@@ -331,7 +331,7 @@
           "$ref": "https://ils.rero.ch/api/patron_types/1"
         },
         "item_type": {
-          "$ref": "https://ils.rero.ch/api/item_types/7"
+          "$ref": "https://ils.rero.ch/api/item_types/8"
         }
       },
       {
@@ -339,7 +339,7 @@
           "$ref": "https://ils.rero.ch/api/patron_types/2"
         },
         "item_type": {
-          "$ref": "https://ils.rero.ch/api/item_types/7"
+          "$ref": "https://ils.rero.ch/api/item_types/8"
         }
       }
     ]
@@ -359,10 +359,10 @@
     "settings": [
       {
         "patron_type": {
-          "$ref": "https://ils.rero.ch/api/patron_types/3"
+          "$ref": "https://ils.rero.ch/api/patron_types/6"
         },
         "item_type": {
-          "$ref": "https://ils.rero.ch/api/item_types/8"
+          "$ref": "https://ils.rero.ch/api/item_types/9"
         }
       },
       {
@@ -370,7 +370,7 @@
           "$ref": "https://ils.rero.ch/api/patron_types/4"
         },
         "item_type": {
-          "$ref": "https://ils.rero.ch/api/item_types/8"
+          "$ref": "https://ils.rero.ch/api/item_types/9"
         }
       }
     ]

--- a/data/patron_types.json
+++ b/data/patron_types.json
@@ -43,5 +43,14 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/3"
     }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",
+    "pid": "6",
+    "name": "Children",
+    "description": "Children and teenagers (< 16 years old).",
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/2"
+    }
   }
 ]

--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -217,18 +217,22 @@ def init(force):
 @click.option('-s', '--schema', 'schema', default=None)
 @click.option('-p', '--pid_type', 'pid_type', default=None)
 @click.option('-l', '--lazy', 'lazy', is_flag=True, default=False)
+@click.option('-o', '--dont-stop', 'dont_stop_on_error',
+              is_flag=True, default=False)
 @click.argument('infile', type=click.File('r'), default=sys.stdin)
 @with_appcontext
-def create(infile, append, reindex, dbcommit, verbose, schema, pid_type, lazy):
+def create(infile, append, reindex, dbcommit, verbose, schema, pid_type, lazy,
+           dont_stop_on_error):
     """Load REROILS record.
 
-    infile: Json file
-    append: appends pids to database
-    reindex: reindex record by record
-    dbcommit: commit record to database
-    pid_type: record type
-    schema: recoord schema
-    lazy: lazy reads file
+    :param infile: Json file
+    :param append: appends pids to database
+    :param reindex: reindex record by record
+    :param dbcommit: commit record to database
+    :param pid_type: record type
+    :param schema: recoord schema
+    :param lazy: lazy reads file
+    :param dont_stop_on_error: don't stop on error
     """
     click.secho(
         'Loading {pid_type} records from {file_name}.'.format(
@@ -271,7 +275,7 @@ def create(infile, append, reindex, dbcommit, verbose, schema, pid_type, lazy):
         except Exception as err:
             error_records.append(record)
             click.secho(
-                '{count: <8} {pid_type} creat error {pid}: {err}'.format(
+                '{count: <8} {pid_type} create error {pid}: {err}'.format(
                     count=count,
                     pid_type=pid_type,
                     pid=record.get('pid', '???'),
@@ -279,7 +283,9 @@ def create(infile, append, reindex, dbcommit, verbose, schema, pid_type, lazy):
                 ),
                 err=True,
                 fg='red'
-                )
+            )
+            if not dont_stop_on_error:
+                sys.exit(1)
 
     if error_records:
         err_file_name = '{pid_type}_error.json'.format(pid_type=pid_type)

--- a/scripts/setup
+++ b/scripts/setup
@@ -25,6 +25,8 @@ DATA_PATH=$(pipenv --where)/data
 #       used for create only the items and holdings files for the 'big' documents file
 #  --deployment:
 #       used for deploy the 'big' files
+#  --dont_stop:
+#       used for continue script on error
 
 RED='\033[0;31m'
 GREEN='\033[0;0;32m'
@@ -43,9 +45,10 @@ CREATE_ITEMS_HOLDINGS_SMALL=false
 CREATE_ITEMS_HOLDINGS_BIG=false
 STOP_EXECUTION=true
 CREATE_LAZY=""
+DONT_STOP=""
 
 # options may be followed by one colon to indicate they have a required argument
-if ! options=$(getopt -o dsb -l deployment,create_items_holdings_small,create_items_holdings_big,lazy,data_path: -- "$@")
+if ! options=$(getopt -o dsb -l deployment,create_items_holdings_small,create_items_holdings_big,lazy,dont_stop,data_path: -- "$@")
 then
     # something went wrong, getopt will put out an error message for us
     exit 1
@@ -59,6 +62,7 @@ do
     -b|--create_items_holdings_big) CREATE_ITEMS_HOLDINGS_BIG=true ;;
     -c|--continue) STOP_EXECUTION=false ;;
     -l|--lazy) CREATE_LAZY="--lazy" ;;
+    -p|--pursue) DONT_STOP="--dont-stop" ;;
     -D|--data_path) DATA_PATH=$2 ;;
     (--) shift; break;;
     (-*) display_error_message "$0: error - unrecognized option $1"; exit 1;;
@@ -141,25 +145,25 @@ pipenv run invenio access allow superuser-access role superusers
 pipenv run invenio roles add admin@rero.ch admins
 pipenv run invenio roles add admin@rero.ch superusers
 
-display_success_message "Organisations:"
-pipenv run invenio fixtures create --pid_type org ${DATA_PATH}/organisations.json  --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t org --yes-i-know
-display_success_message "Libraries:"
-pipenv run invenio fixtures create --pid_type lib ${DATA_PATH}/libraries.json --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t lib --yes-i-know
-display_success_message "Locations:"
-pipenv run invenio fixtures create --pid_type loc ${DATA_PATH}/locations.json  --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t loc --yes-i-know
-display_success_message "Item types:"
-pipenv run invenio fixtures create --pid_type itty ${DATA_PATH}/item_types.json  --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t itty --yes-i-know
-display_success_message "Patron types:"
-pipenv run invenio fixtures create --pid_type ptty ${DATA_PATH}/patron_types.json --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t ptty --yes-i-know
-display_success_message "Circulation policies:"
-pipenv run invenio fixtures create --pid_type cipo ${DATA_PATH}/circulation_policies.json --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t cipo --yes-i-know
-pipenv run invenio utils runindex --raise-on-error
+display_success_message "Organisations: ${CREATE_LAZY} ${DONT_STOP}"
+pipenv run invenio fixtures create --pid_type org ${DATA_PATH}/organisations.json --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t org --yes-i-know
+display_success_message "Libraries: ${CREATE_LAZY} ${DONT_STOP}"
+pipenv run invenio fixtures create --pid_type lib ${DATA_PATH}/libraries.json --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t lib --yes-i-know
+display_success_message "Locations: ${CREATE_LAZY} ${DONT_STOP}"
+pipenv run invenio fixtures create --pid_type loc ${DATA_PATH}/locations.json  --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t loc --yes-i-know
+display_success_message "Item types: ${CREATE_LAZY} ${DONT_STOP}"
+pipenv run invenio fixtures create --pid_type itty ${DATA_PATH}/item_types.json  --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t itty --yes-i-know
+display_success_message "Patron types: ${CREATE_LAZY} ${DONT_STOP}"
+pipenv run invenio fixtures create --pid_type ptty ${DATA_PATH}/patron_types.json --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t ptty --yes-i-know
+display_success_message "Circulation policies: ${CREATE_LAZY} ${DONT_STOP}"
+pipenv run invenio fixtures create --pid_type cipo ${DATA_PATH}/circulation_policies.json --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t cipo --yes-i-know
+pipenv run invenio index run --raise-on-error
 
 pipenv run invenio fixtures import_users ${DATA_PATH}/users.json -v
 
@@ -185,9 +189,9 @@ else
     HOLDINGS=${DATA_PATH}/holdings_small.json
 fi
 
-display_success_message "Documents:"
+display_success_message "Documents: ${DONT_STOP}"
 echo -e ${DOCUMENTS}
-pipenv run invenio fixtures create --pid_type doc --schema 'http://ils.rero.ch/schema/documents/document-v0.0.1.json' ${DOCUMENTS} --append
+pipenv run invenio fixtures create --pid_type doc --schema 'http://ils.rero.ch/schema/documents/document-v0.0.1.json' ${DOCUMENTS} --append ${DONT_STOP}
 
 if $CREATE_ITEMS_HOLDINGS_SMALL
 then
@@ -211,17 +215,17 @@ then
     fi
 fi
 
-display_success_message "Holdings: ${CREATE_LAZY}"
+display_success_message "Holdings: ${CREATE_LAZY} ${DONT_STOP}"
 echo -e ${HOLDINGS}
-pipenv run invenio fixtures create --pid_type hold --schema 'http://ils.rero.ch/schema/holdings/holding-v0.0.1.json' ${HOLDINGS} --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t hold --yes-i-know
-pipenv run invenio utils runindex -c 4 --raise-on-error
+pipenv run invenio fixtures create --pid_type hold --schema 'http://ils.rero.ch/schema/holdings/holding-v0.0.1.json' ${HOLDINGS} --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t hold --yes-i-know
+pipenv run invenio index run -c 4 --raise-on-error
 
-display_success_message "Items: ${CREATE_LAZY}"
+display_success_message "Items: ${CREATE_LAZY} ${DONT_STOP}"
 echo -e ${ITEMS}
-pipenv run invenio fixtures create --pid_type item --schema 'http://ils.rero.ch/schema/items/item-v0.0.1.json' ${ITEMS}  --append ${CREATE_LAZY}
-pipenv run invenio utils reindex -t item --yes-i-know
-pipenv run invenio utils runindex -c 4 --raise-on-error
+pipenv run invenio fixtures create --pid_type item --schema 'http://ils.rero.ch/schema/items/item-v0.0.1.json' ${ITEMS} --append ${CREATE_LAZY} ${DONT_STOP}
+pipenv run invenio index reindex -t item --yes-i-know
+pipenv run invenio index run -c 4 --raise-on-error
 
 display_success_message "Index Documents:"
 pipenv run invenio utils reindex -t doc --yes-i-know


### PR DESCRIPTION
* BETTER Corrects item types of circulation policy with pid = 10 and 11.
* NEW Adds new patron type.
* NEW Adds test to check data consistency when ci-po are created.
* Closes #625.
* Closes #626.
* Closes #213 

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Some circulation policies have item types and patron types not related to their organisation.

## How to test?

### Circulation policies create (issue #213):
Run `./scripts/setup` -> should proceed as usual with no error 
Then change a patron type or an item type of a circulation policy for one that doesn't belong to the correct organisation in : `data/circulation_policies.json`
Run `./scripts/setup` : the script will raise an error and stop.
Run `./scripts/setup -p` : the script will raise an error and continue.

### Issue #625 :
On rero-ils: open ci-po editor and confirm that patron type and item type settings are loaded.
See also the issue details for more checks.

### Issue #626 :
Login as Irma Pince: reroilstest+irma@gmail.com
Open ci-po editor to add or edit a ci-po. Saving new ci-po or modifications doesn't work on rero-ils-ui with proxy, but on rero-ils it's ok.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations? 
