### PR TITLE
items: create items dump functionality

### DIFF
--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -97,6 +97,17 @@
           "pattern": "^https://ils.rero.ch/api/holdings/.+?$"
         }
       }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/organisations/.*?$"
+        }
+      }
     }
   }
 }

--- a/rero_ils/modules/items/listener.py
+++ b/rero_ils/modules/items/listener.py
@@ -38,3 +38,4 @@ def enrich_item_data(sender, json=None, record=None, index=None,
         json['organisation'] = {
             'pid': org_pid
         }
+        json['available'] = item.available

--- a/tests/api/test_items_rest.py
+++ b/tests/api/test_items_rest.py
@@ -107,14 +107,16 @@ def test_items_post_put_delete(client, document, loc_public_martigny,
     assert res.status_code == 201
 
     # Check that the returned record matches the given data
-    del data['metadata']['holding']
+    for deleted_key in ['holding', 'available']:
+        data['metadata'].pop(deleted_key)
     assert data['metadata'] == item_lib_martigny_data
 
     res = client.get(item_url)
     assert res.status_code == 200
 
     data = get_json(res)
-    del data['metadata']['holding']
+    for deleted_key in ['holding', 'available']:
+        data['metadata'].pop(deleted_key)
     assert item_lib_martigny_data == data['metadata']
 
     # Update record/PUT


### PR DESCRIPTION
* Adds organisation $ref field to item json schema.
* Populates the organisation field from the location organisation field.
* Adds item availability to item index.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

Implements task https://tree.taiga.io/project/rero21-reroils/task/1164?kanban-status=1224894

## How to test?
- `scripts/setup`:
- display an item @ `~/api/items/<pid>` and make sure the two new fields (availability and organisation) are there

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
