### PR TITLE
editor: set the focus in the forms

### DIFF
--- a/rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json
@@ -20,7 +20,8 @@
         "validationMessage": {
           "alreadyTakenMessage": "The item type name is already taken"
         },
-        "remoteRecordType": "item_types"
+        "remoteRecordType": "item_types",
+        "autofocus": true
       }
     ]
   },

--- a/rero_ils/modules/items/jsonschemas/form_items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/form_items/item-v0.0.1.json
@@ -8,7 +8,8 @@
           "alreadyTakenMessage": "The barcode is already taken",
           "cannotBeVerifiedMessage": "The server cannot verify the barcode"
         },
-        "remoteRecordType": "items"
+        "remoteRecordType": "items",
+        "autofocus": true
       }
     ]
   },

--- a/rero_ils/modules/locations/jsonschemas/form_locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/form_locations/location-v0.0.1.json
@@ -14,7 +14,8 @@
     "type": "fieldset",
     "items": [
       {
-        "key": "name"
+        "key": "name",
+        "autofocus": true
       }
     ]
   },

--- a/rero_ils/modules/patron_types/jsonschemas/form_patron_types/patron_type-v0.0.1.json
+++ b/rero_ils/modules/patron_types/jsonschemas/form_patron_types/patron_type-v0.0.1.json
@@ -20,7 +20,8 @@
         "validationMessage": {
           "alreadyTakenMessage": "The patron type name is already taken"
         },
-        "remoteRecordType": "patron_types"
+        "remoteRecordType": "patron_types",
+        "autofocus": true
       }
     ]
   },

--- a/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
@@ -5,7 +5,8 @@
     "items": [
       {
         "key": "first_name",
-        "htmlClass": "mr-2"
+        "htmlClass": "mr-2",
+        "autofocus": true
       },
       {
         "key": "last_name"

--- a/ui/src/app/records/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.html
+++ b/ui/src/app/records/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.html
@@ -26,8 +26,14 @@
     <div class="form-group row">
       <label for="name" class="col-sm-2 col-form-label required" translate>Name</label>
       <div class="col-sm-10">
-        <input class="form-control" id="name" formControlName="name"
-          placeholder="{{ 'Please insert a name' | translate }}" required>
+        <input  
+            class="form-control" 
+            id="name" 
+            formControlName="name"
+            placeholder="{{ 'Please insert a name' | translate }}"
+            required
+            [autofocus]=true
+        >
         <div *ngIf="name.invalid && (name.dirty || name.touched)" class="text-danger pt-1">
           <div *ngIf="name.errors.required" translate>
             Name is required.

--- a/ui/src/app/records/custom-editor/libraries/library.component.html
+++ b/ui/src/app/records/custom-editor/libraries/library.component.html
@@ -27,6 +27,7 @@
         formControlName="name"
         placeholder="{{ 'Please insert a name' | translate }}"
         required
+        [autofocus]=true
       >
       <div *ngIf="name.invalid && (name.dirty || name.touched)" class="text-danger pt-1">
         <div *ngIf="name.errors.required" translate>

--- a/ui/src/app/records/editor/editor.component.html
+++ b/ui/src/app/records/editor/editor.component.html
@@ -24,7 +24,13 @@
     <div class="form-group">
       <label class="control-label" translate>Import record from BNF</label>
       <div  class="input-group">
-        <input #searchinput (keyup.enter)="importFromEan(searchinput.value)" type="text" class="form-control" placeholder="Enter an EAN" aria-label="Enter an EAN" aria-describedby="button-import">
+        <input #searchinput (keyup.enter)="importFromEan(searchinput.value)"
+               type="text" class="form-control"
+               placeholder="Enter an EAN"
+               aria-label="Enter an EAN"
+               aria-describedby="button-import"
+               autofocus="true"
+        >
         <div class="input-group-append">
             <button (click)="importFromEan(searchinput.value)" class="btn btn-outline-info" type="button" id="button-import" translate>Import</button>
         </div>

--- a/ui/src/app/records/editor/remote-input/remote-input.component.html
+++ b/ui/src/app/records/editor/remote-input/remote-input.component.html
@@ -35,6 +35,7 @@
   [id]="'control' + layoutNode?._id"
   [name]="controlName"
   [readonly]="options?.readonly ? 'readonly' : null"
+  [attr.autofocus]="options?.autofocus"
   [type]="layoutNode?.type">
   <input *ngIf="!boundControl"
   [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
@@ -49,6 +50,7 @@
   [id]="'control' + layoutNode?._id"
   [name]="controlName"
   [readonly]="options?.readonly ? 'readonly' : null"
+  [attr.autofocus]="options?.autofocus"
   [type]="layoutNode?.type"
   [value]="controlValue"
   (input)="updateValue($event)">

--- a/ui/src/app/search-input/search-input.component.html
+++ b/ui/src/app/search-input/search-input.component.html
@@ -20,7 +20,7 @@
 <div class="input-group px-0">
   <input
     #searchinput
-    autofocus
+    [autofocus]=true
     type="text"
     id="search"
     class="form-control"

--- a/ui/src/app/shared.module.ts
+++ b/ui/src/app/shared.module.ts
@@ -25,9 +25,13 @@ import { DataTablesModule } from 'angular-datatables';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { PaginationModule } from 'ngx-bootstrap';
+import { AutoFocusDirective } from './shared/auto-focus/auto-focus.directive';
 
 @NgModule({
-  declarations: [SearchInputComponent],
+  declarations: [
+    SearchInputComponent,
+    AutoFocusDirective
+  ],
   imports: [
     CommonModule,
     DataTablesModule,
@@ -42,7 +46,8 @@ import { PaginationModule } from 'ngx-bootstrap';
     DataTablesModule,
     SearchInputComponent,
     ModalModule,
-    PaginationModule
+    PaginationModule,
+    AutoFocusDirective,
   ]
 })
 export class SharedModule { }

--- a/ui/src/app/shared/auto-focus/auto-focus.directive.spec.ts
+++ b/ui/src/app/shared/auto-focus/auto-focus.directive.spec.ts
@@ -1,0 +1,27 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { AutoFocusDirective } from './auto-focus.directive';
+
+describe('AutoFocusDirective', () => {
+  it('should create an instance', () => {
+    const directive = new AutoFocusDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/ui/src/app/shared/auto-focus/auto-focus.directive.ts
+++ b/ui/src/app/shared/auto-focus/auto-focus.directive.ts
@@ -1,0 +1,51 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { AfterContentInit, Directive, ElementRef, Input } from '@angular/core';
+
+@Directive({
+  selector: '[autofocus]'
+})
+
+export class AutoFocusDirective implements AfterContentInit {
+
+  @Input()
+  public autofocus: boolean;
+  private readonly element: HTMLElement;
+
+  /**
+   * Constructor
+   * @param el: wrapper around a native element inside of a View
+   */
+  public constructor(private el: ElementRef) {
+    this.element = el.nativeElement;
+  }
+
+  /**
+   * Directive initialisation.
+   */
+  public ngAfterContentInit() {
+    if (this.autofocus) {
+      setTimeout(() => {
+        this.element.focus();
+      }, 200);
+    }
+  }
+
+}


### PR DESCRIPTION
* Adds angular directive.
* Updates remote-input component to add autofocus binding.
* Sets the focus in the forms.
* Updates form options to set default focus.
* Closes #542.

Co-Authored-by: Benoit Erken <erken.benoit@gmail.com>
Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Implements task https://tree.taiga.io/project/rero21-reroils/task/1117.
- Fix issues #542.

## How to test?

- Log in as a librarian.
- Try to create a new resource, for example a new circulation policy.

**note:** It may be necessary to clear the browser cache

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
