### PR TITLE
deployment: fix pipenv version

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,7 +20,7 @@ FROM python:3.6-slim-stretch
 # require debian packages
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get install --no-install-recommends -y git vim-tiny curl gcc gnupg libc6-dev && rm -rf /var/lib/apt/lists/*
-RUN pip install --upgrade setuptools wheel pip pipenv
+RUN pip install --upgrade setuptools wheel pip pipenv==2018.10.9
 
 # # uwsgi uwsgitop uwsgi-tools
 


### PR DESCRIPTION
* Fixes version of pipenv in Dockerfile.base to version 2018.10.9.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Can not deploy the image.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
