### PR TITLE
Fix CSP problem in Chromium for images

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -288,7 +288,8 @@ APP_DEFAULT_SECURE_HEADERS = {
             'https://www.google-analytics.com',
             'https://services.test.rero.ch',
             'https://services.rero.ch'
-        ]
+        ],
+        'img-src': ['data:', "'self'"]
     },
     'content_security_policy_report_uri': None,
     'content_security_policy_report_only': False,


### PR DESCRIPTION
* Adds new CSP (Content Security Policy) for img-src

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

I get some errors on Chromium for https://ils.test.rero.ch:

![RERO_ILS_img-src_problems](https://user-images.githubusercontent.com/147417/70548394-bda2b480-1b72-11ea-8547-2086e380fa61.jpg)

## How to test?

1. Launch rero-ils server
1. Go to https://localhost:5000/
1. Press F12 on Chrome/Chromium
1. No errors should appears about `img-src` problems

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
