### PR TITLE
translation: fix patron form editor translation problem

### DIFF
--- a/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
@@ -125,22 +125,40 @@
       {
         "key": "communication_channel",
         "required": true,
-        "titleMap": {
-          "email": "Email",
-          "mail": "Mail"
-        },
+        "titleMap": [
+          {
+            "value": "email",
+            "name": "Email"
+          },
+          {
+            "value": "mail",
+            "name": "Mail"
+          }
+        ],
         "placeHolder": "Select\u2026"
       },
       {
         "key": "communication_language",
         "required": true,
         "type": "select",
-        "titleMap": {
-          "eng": "English",
-          "fre": "French",
-          "ger": "German",
-          "ita": "Italian"
-        },
+        "titleMap": [
+          {
+            "name": "English",
+            "value": "eng"
+          },
+          {
+            "name": "French",
+            "value": "fre"
+          },
+          {
+            "name": "German",
+            "value": "ger"
+          },
+          {
+            "name": "Italian",
+            "value": "ita"
+          }
+        ],
         "placeHolder": "Select\u2026"
       }
     ]


### PR DESCRIPTION
Rewrite 'titleMap' definitions from "communication_channel" and "communication_language". Now, the label are translated to current interface language.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

![image](https://user-images.githubusercontent.com/10031585/70630366-bf7c7e80-1c2b-11ea-9ba7-12b7806d057c.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
