### PR TITLE
acquisition: create library budget

### DIFF
--- a/data/acq_accounts.json
+++ b/data/acq_accounts.json
@@ -1,0 +1,600 @@
+[
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "1",
+    "name": "fiction",
+    "description": "Romans, nouvelles et pi\u00e8ces de th\u00e9\u00e2tre de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 15000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "2",
+    "name": "documentaires",
+    "description": "Documentaires de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 12000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "3",
+    "name": "fiction",
+    "description": "Romans, nouvelles et pi\u00e8ces de th\u00e9\u00e2tre de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/2"
+    },
+    "amount_allocated": 14000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "4",
+    "name": "fiction",
+    "description": "Romans, nouvelles et pi\u00e8ces de th\u00e9\u00e2tre de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/3"
+    },
+    "amount_allocated": 13000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "5",
+    "name": "general",
+    "description": "Compte g\u00e9n\u00e9ral site de Pont-saint-Martin",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 6500,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/2"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "6",
+    "name": "general",
+    "description": "Compte g\u00e9n\u00e9ral acquisitions",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 3000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/3"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "7",
+    "name": "astronomy",
+    "description": "astronomy",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 500,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "8",
+    "name": "defence against the dark arts",
+    "description": "defence against the dark arts",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 6200,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "9",
+    "name": "history of magic",
+    "description": "history of magic",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 4000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "10",
+    "name": "history of magic",
+    "description": "history of magic",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/2"
+    },
+    "amount_allocated": 4000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "11",
+    "name": "history of magic",
+    "description": "history of magic",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/3"
+    },
+    "amount_allocated": 4000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "12",
+    "name": "potions",
+    "description": "potions",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 10050,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "13",
+    "name": "transfiguration",
+    "description": "transfiguration",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 750,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/5"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "14",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/6"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "15",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1200,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/7"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "16",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 800,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/8"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "17",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1600,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/9"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "18",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 9000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/10"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "19",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 11000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/11"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "20",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 3580,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/12"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "21",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1500,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/13"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "22",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 560,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/14"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "23",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 300,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/15"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "24",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/16"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "25",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1100,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/17"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "26",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 666,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/18"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "27",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 0.5,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/19"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "28",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 18700,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/20"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "29",
+    "name": "documentaries",
+    "description": "Account for documentaries",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/21"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "30",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1120,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/6"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "31",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 2000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/7"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "32",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 5000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/8"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "33",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 4500,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/9"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "34",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/10"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "35",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 200,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/11"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "36",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 54000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/12"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "37",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 15000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/13"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "38",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1200,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/14"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "39",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 8400,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/15"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "40",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 2600,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/16"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "41",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 7400,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/17"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "42",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 6900,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/18"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "43",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 1230,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/19"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "44",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 900,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/20"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "45",
+    "name": "fiction",
+    "description": "Account for fiction",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/4"
+    },
+    "amount_allocated": 8000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/21"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "46",
+    "name": "general",
+    "description": "Account for general",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/1"
+    },
+    "amount_allocated": 8000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/4"
+    }
+  }
+]

--- a/data/budgets.json
+++ b/data/budgets.json
@@ -1,0 +1,57 @@
+[
+  {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "1",
+    "name": "2020",
+    "start_date": "2020-01-01T00:00:00.355920+00:00",
+    "end_date": "2020-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "2",
+    "name": "2019",
+    "start_date": "2019-01-01T00:00:00.355920+00:00",
+    "end_date": "2019-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "3",
+    "name": "2018",
+    "start_date": "2018-01-01T00:00:00.355920+00:00",
+    "end_date": "2018-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/1"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "4",
+    "name": "2020",
+    "start_date": "2020-01-01T00:00:00.355920+00:00",
+    "end_date": "2020-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/2"
+    }
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "5",
+    "name": "2020",
+    "start_date": "2020-01-01T00:00:00.355920+00:00",
+    "end_date": "2020-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/3"
+    }
+  }
+]

--- a/data/organisations.json
+++ b/data/organisations.json
@@ -6,6 +6,7 @@
     "name": "R\u00e9seau des biblioth\u00e8ques du Canton d'Aoste",
     "code": "aoste",
     "default_currency": "EUR",
+    "current_budget_pid": "1",
     "online_harvested_source": "ebibliomedia"
   },
   {
@@ -15,6 +16,7 @@
     "name": "Libraries of the British Ministry of Magic",
     "code": "highlands",
     "default_currency": "GBP",
+    "current_budget_pid": "4",
     "online_harvested_source": "mv-cantook"
   },
   {
@@ -23,6 +25,7 @@
     "address": "The imagination",
     "name": "Network of fictive libraries",
     "code": "fictive",
-    "default_currency": "CHF"
+    "default_currency": "CHF",
+    "current_budget_pid": "5"
   }
 ]

--- a/rero_ils/modules/acq_accounts/__init__.py
+++ b/rero_ils/modules/acq_accounts/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""AcqAccount Records."""

--- a/rero_ils/modules/acq_accounts/api.py
+++ b/rero_ils/modules/acq_accounts/api.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""API for manipulating acq_accounts."""
+
+from functools import partial
+
+from flask import current_app
+
+from .models import AcqAccountIdentifier
+from ..api import IlsRecord, IlsRecordsSearch
+from ..fetchers import id_fetcher
+from ..libraries.api import Library
+from ..minters import id_minter
+from ..providers import Provider
+
+# provider
+AcqAccountProvider = type(
+    'AcqAccountProvider',
+    (Provider,),
+    dict(identifier=AcqAccountIdentifier, pid_type='acac')
+)
+# minter
+acq_account_id_minter = partial(id_minter, provider=AcqAccountProvider)
+# fetcher
+acq_account_id_fetcher = partial(id_fetcher, provider=AcqAccountProvider)
+
+
+class AcqAccountsSearch(IlsRecordsSearch):
+    """AcqAccountsSearch."""
+
+    class Meta:
+        """Search only on acq_account index."""
+
+        index = 'acq_accounts'
+
+
+class AcqAccount(IlsRecord):
+    """AcqAccount class."""
+
+    minter = acq_account_id_minter
+    fetcher = acq_account_id_fetcher
+    provider = AcqAccountProvider
+
+    @classmethod
+    def create(cls, data, id_=None, delete_pid=False,
+               dbcommit=False, reindex=False, **kwargs):
+        """Create acq account record."""
+        cls._acq_account_build_org_ref(data)
+        record = super(AcqAccount, cls).create(
+            data, id_, delete_pid, dbcommit, reindex, **kwargs)
+        return record
+
+    @classmethod
+    def _acq_account_build_org_ref(cls, data):
+        """Build $ref for the organisation of the acq account."""
+        library_pid = data.get('library', {}).get('pid')
+        if not library_pid:
+            library_pid = data.get('library').get(
+                '$ref').split('libraries/')[1]
+            org_pid = Library.get_record_by_pid(library_pid).organisation_pid
+        base_url = current_app.config.get('RERO_ILS_APP_BASE_URL')
+        url_api = '{base_url}/api/{doc_type}/{pid}'
+        org_ref = {
+            '$ref': url_api.format(
+                base_url=base_url,
+                doc_type='organisations',
+                pid=org_pid or cls.organisation_pid)
+        }
+        data['organisation'] = org_ref
+
+    @property
+    def library_pid(self):
+        """Shortcut for acq account library pid."""
+        return self.replace_refs().get('library').get('pid')
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        # TODO: add purchase order links here
+        links = {}
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/acq_accounts/jsonresolver.py
+++ b/rero_ils/modules/acq_accounts/jsonresolver.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""AcqAccount resolver."""
+
+import jsonresolver
+from flask import current_app
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+
+
+@jsonresolver.route('/api/acq_accounts/<pid>', host='ils.rero.ch')
+def acq_account_resolver(pid):
+    """Resolver for acq_account record."""
+    persistent_id = PersistentIdentifier.get('acac', pid)
+    if persistent_id.status == PIDStatus.REGISTERED:
+        return dict(pid=persistent_id.pid_value)
+    current_app.logger.error(
+        'Doc resolver error: /api/acq_accounts/{pid} {persistent_id}'.format(
+            pid=pid,
+            persistent_id=persistent_id
+        )
+    )
+    raise Exception('unable to resolve')

--- a/rero_ils/modules/acq_accounts/jsonschemas/__init__.py
+++ b/rero_ils/modules/acq_accounts/jsonschemas/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON schemas."""
+
+from __future__ import absolute_import, print_function

--- a/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Acquisition account",
+  "description": "JSON schema for an acquisition account",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "pid",
+    "name",
+    "budget",
+    "amount_allocated",
+    "library"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "Schema to validate account records against.",
+      "type": "string",
+      "minLength": 9,
+      "default": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json"
+    },
+    "pid": {
+      "title": "Account ID",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "description": "Name of the Acquisition account.",
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "title": "Description",
+      "description": "Description of the Acquisition account.",
+      "type": "string",
+      "minLength": 1
+    },
+    "budget": {
+      "title": "Budget",
+      "type": "object",
+      "description": "The Acquisition account belongs to which budget.",
+      "properties": {
+        "$ref": {
+          "title": "Budget URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/budgets/.*?$"
+        }
+      }
+    },
+    "amount_allocated": {
+      "title": "Amount allocated",
+      "description": "The amount allocated for the Acquisition account.",
+      "type": "number"
+    },
+    "library": {
+      "title": "Library",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Library URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/libraries/.*?$"
+        }
+      }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/organisations/.*?$"
+        }
+      }
+    }
+  }
+}

--- a/rero_ils/modules/acq_accounts/jsonschemas/form_acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/jsonschemas/form_acq_accounts/acq_account-v0.0.1.json
@@ -1,0 +1,57 @@
+[
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "title": "Library",
+        "key": "library.$ref",
+        "type": "select",
+        "remoteRecordType": "libraries",
+        "remoteRecordFiltersByOwningOrganisation": "pid",
+        "readonly": "true"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "title": "Budget",
+        "key": "budget.$ref",
+        "type": "select",
+        "remoteRecordType": "budgets",
+        "remoteRecordFiltersByOwningOrganisation": "pid",
+        "readonly": "true"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "name",
+        "required": true,
+        "validationMessage": {
+          "alreadyTakenMessage": "The acquisition account name is already taken"
+        },
+        "remoteRecordType": "acq_accounts"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "description"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "amount_allocated"
+      }
+    ]
+  }
+]

--- a/rero_ils/modules/acq_accounts/mappings/__init__.py
+++ b/rero_ils/modules/acq_accounts/mappings/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mappings."""
+
+from __future__ import absolute_import, print_function

--- a/rero_ils/modules/acq_accounts/mappings/v6/__init__.py
+++ b/rero_ils/modules/acq_accounts/mappings/v6/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mappings."""
+
+from __future__ import absolute_import, print_function

--- a/rero_ils/modules/acq_accounts/mappings/v6/acq_accounts/acq_account-v0.0.1.json
+++ b/rero_ils/modules/acq_accounts/mappings/v6/acq_accounts/acq_account-v0.0.1.json
@@ -5,7 +5,7 @@
     "max_result_window": 20000
   },
   "mappings": {
-    "organisation-v0.0.1": {
+    "acq_account-v0.0.1": {
       "date_detection": false,
       "numeric_detection": false,
       "properties": {
@@ -16,22 +16,34 @@
           "type": "keyword"
         },
         "name": {
-          "type": "text"
-        },
-        "address": {
-          "type": "text"
-        },
-        "code": {
           "type": "keyword"
         },
-        "default_currency": {
+        "description": {
           "type": "keyword"
         },
-        "current_budget_pid": {
-          "type": "keyword"
+        "budget": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
         },
-        "online_harvested_source": {
-          "type": "keyword"
+        "amount_allocated": {
+          "type": "float"
+        },
+        "library": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "organisation": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
         },
         "_created": {
           "type": "date"

--- a/rero_ils/modules/acq_accounts/models.py
+++ b/rero_ils/modules/acq_accounts/models.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Define relation between records and buckets."""
+
+from __future__ import absolute_import
+
+from invenio_db import db
+from invenio_pidstore.models import RecordIdentifier
+
+
+class AcqAccountIdentifier(RecordIdentifier):
+    """Sequence generator for AcqAccount identifiers."""
+
+    __tablename__ = 'acq_account_id'
+    __mapper_args__ = {'concrete': True}
+
+    recid = db.Column(
+        db.BigInteger().with_variant(db.Integer, 'sqlite'),
+        primary_key=True, autoincrement=True,
+    )

--- a/rero_ils/modules/acq_accounts/permissions.py
+++ b/rero_ils/modules/acq_accounts/permissions.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""AcqAccount permissions."""
+
+from ...permissions import staffer_is_authenticated
+
+
+def can_read_update_delete_acq_account_factory(record, *args, **kwargs):
+    """Checks if logged user can update or delete its organisation accounts.
+
+    user must have librarian or system_librarian role
+    librarian can only update or delete its affiliated library accounts.
+    sys_librarian can update or delete any account of its organisation.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron and patron.organisation_pid == record.organisation_pid:
+            if not patron.is_system_librarian:
+                if patron.library_pid and \
+                        record.library_pid != patron.library_pid:
+                    return False
+            return True
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_create_acq_account_factory(record, *args, **kwargs):
+    """Checks if the logged user can create accounts of its organisation.
+
+    librarian can create accounts for its library only.
+    system_librarian can create accounts at any library of its org.
+    system_librarian or librarian can not create accounts at another org.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron and not record:
+            return True
+        if patron and patron.organisation_pid == record.organisation_pid:
+            if patron.is_system_librarian:
+                return True
+            if patron.is_librarian and \
+                    record.library_pid == patron.library_pid:
+                return True
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_list_acq_account_factory(record, *args, **kwargs):
+    """Checks if the logged user have access to accounts list.
+
+    only authenticated users can place a search on accounts.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron:
+            return True
+        return False
+    return type('Check', (), {'can': can})()

--- a/rero_ils/modules/acq_accounts/serializers.py
+++ b/rero_ils/modules/acq_accounts/serializers.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquisition account serialization."""
+
+from invenio_records_rest.serializers.response import search_responsify
+
+from ..libraries.api import Library
+from ..serializers import JSONSerializer, RecordSchemaJSONV1
+
+
+class AcqAccountJSONSerializer(JSONSerializer):
+    """Mixin serializing records as JSON."""
+
+    def post_process_serialize_search(self, results, pid_fetcher):
+        """Post process the search results."""
+        # Add library name
+        for lib_term in results.get('aggregations', {}).get(
+                'library', {}).get('buckets', []):
+            pid = lib_term.get('key')
+            name = Library.get_record_by_pid(pid).get('name')
+            lib_term['key'] = pid
+            lib_term['name'] = name
+
+        return super(
+            AcqAccountJSONSerializer, self).post_process_serialize_search(
+                results, pid_fetcher)
+
+
+json_acq_account = AcqAccountJSONSerializer(RecordSchemaJSONV1)
+"""JSON v1 serializer."""
+
+json_acq_account_search = search_responsify(
+    json_acq_account, 'application/rero+json')

--- a/rero_ils/modules/budgets/__init__.py
+++ b/rero_ils/modules/budgets/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Budget Records."""

--- a/rero_ils/modules/budgets/api.py
+++ b/rero_ils/modules/budgets/api.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""API for manipulating budgets."""
+
+from functools import partial
+
+from .models import BudgetIdentifier
+from ..acq_accounts.api import AcqAccountsSearch
+from ..api import IlsRecord, IlsRecordsSearch
+from ..fetchers import id_fetcher
+from ..minters import id_minter
+from ..providers import Provider
+
+# provider
+BudgetProvider = type(
+    'BudgetProvider',
+    (Provider,),
+    dict(identifier=BudgetIdentifier, pid_type='budg')
+)
+# minter
+budget_id_minter = partial(id_minter, provider=BudgetProvider)
+# fetcher
+budget_id_fetcher = partial(id_fetcher, provider=BudgetProvider)
+
+
+class BudgetsSearch(IlsRecordsSearch):
+    """BudgetsSearch."""
+
+    class Meta:
+        """Search only on budget index."""
+
+        index = 'budgets'
+
+
+class Budget(IlsRecord):
+    """Budget class."""
+
+    minter = budget_id_minter
+    fetcher = budget_id_fetcher
+    provider = BudgetProvider
+
+    def get_number_of_acq_accounts(self):
+        """Get number of acq accounts."""
+        results = AcqAccountsSearch().filter(
+            'term', budget__pid=self.pid).source().count()
+        return results
+
+    def get_links_to_me(self):
+        """Get number of links."""
+        links = {}
+        acq_accounts = self.get_number_of_acq_accounts()
+        if acq_accounts:
+            links['acq_accounts'] = acq_accounts
+        return links
+
+    def reasons_not_to_delete(self):
+        """Get reasons not to delete record."""
+        cannot_delete = {}
+        links = self.get_links_to_me()
+        if links:
+            cannot_delete['links'] = links
+        return cannot_delete

--- a/rero_ils/modules/budgets/jsonresolver.py
+++ b/rero_ils/modules/budgets/jsonresolver.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Budget resolver."""
+
+import jsonresolver
+from flask import current_app
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+
+
+@jsonresolver.route('/api/budgets/<pid>', host='ils.rero.ch')
+def budget_resolver(pid):
+    """Resolver for budget record."""
+    persistent_id = PersistentIdentifier.get('budg', pid)
+    if persistent_id.status == PIDStatus.REGISTERED:
+        return dict(pid=persistent_id.pid_value)
+    current_app.logger.error(
+        'Doc resolver error: /api/budgets/{pid} {persistent_id}'.format(
+            pid=pid,
+            persistent_id=persistent_id
+        )
+    )
+    raise Exception('unable to resolve')

--- a/rero_ils/modules/budgets/jsonschemas/__init__.py
+++ b/rero_ils/modules/budgets/jsonschemas/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON schemas."""
+
+from __future__ import absolute_import, print_function

--- a/rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json
+++ b/rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Budget",
+  "description": "JSON schema for budget.",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "pid"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "Schema to validate budget records against.",
+      "type": "string",
+      "minLength": 9
+    },
+    "pid": {
+      "title": "Budget ID",
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "title": "Budget name",
+      "description": "Name of the budget.",
+      "type": "string",
+      "minLength": 1
+    },
+    "start_date": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Budget start date"
+    },
+    "end_date": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Budget end date"
+    },
+    "is_active": {
+      "type": "boolean",
+      "title": "True if budget is active",
+      "description": "True if budget is active",
+      "default": false
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/organisations/.*?$"
+        }
+      }
+    }
+  }
+}

--- a/rero_ils/modules/budgets/jsonschemas/form_budgets/budget-v0.0.1.json
+++ b/rero_ils/modules/budgets/jsonschemas/form_budgets/budget-v0.0.1.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "title": "Organisation",
+        "key": "organisation.$ref",
+        "type": "select",
+        "remoteRecordType": "organisations",
+        "remoteRecordFiltersByOwningOrganisation": "pid",
+        "readonly": "true"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "name",
+        "required": true,
+        "validationMessage": {
+          "alreadyTakenMessage": "The budget name is already taken"
+        },
+        "remoteRecordType": "budgets"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "start_date"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "end_date"
+      }
+    ]
+  },
+  {
+    "type": "fieldset",
+    "items": [
+      {
+        "key": "is_active"
+      }
+    ]
+  }
+]

--- a/rero_ils/modules/budgets/mappings/__init__.py
+++ b/rero_ils/modules/budgets/mappings/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mappings."""
+
+from __future__ import absolute_import, print_function

--- a/rero_ils/modules/budgets/mappings/v6/__init__.py
+++ b/rero_ils/modules/budgets/mappings/v6/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mappings."""
+
+from __future__ import absolute_import, print_function

--- a/rero_ils/modules/budgets/mappings/v6/budgets/budget-v0.0.1.json
+++ b/rero_ils/modules/budgets/mappings/v6/budgets/budget-v0.0.1.json
@@ -5,7 +5,7 @@
     "max_result_window": 20000
   },
   "mappings": {
-    "organisation-v0.0.1": {
+    "budget-v0.0.1": {
       "date_detection": false,
       "numeric_detection": false,
       "properties": {
@@ -16,22 +16,23 @@
           "type": "keyword"
         },
         "name": {
-          "type": "text"
-        },
-        "address": {
-          "type": "text"
-        },
-        "code": {
           "type": "keyword"
         },
-        "default_currency": {
-          "type": "keyword"
+        "start_date": {
+          "type": "date"
         },
-        "current_budget_pid": {
-          "type": "keyword"
+        "end_date": {
+          "type": "date"
         },
-        "online_harvested_source": {
-          "type": "keyword"
+        "is_active": {
+          "type": "boolean"
+        },
+        "organisation": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
         },
         "_created": {
           "type": "date"

--- a/rero_ils/modules/budgets/models.py
+++ b/rero_ils/modules/budgets/models.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Define relation between records and buckets."""
+
+from __future__ import absolute_import
+
+from invenio_db import db
+from invenio_pidstore.models import RecordIdentifier
+
+
+class BudgetIdentifier(RecordIdentifier):
+    """Sequence generator for Budget identifiers."""
+
+    __tablename__ = 'budget_id'
+    __mapper_args__ = {'concrete': True}
+
+    recid = db.Column(
+        db.BigInteger().with_variant(db.Integer, 'sqlite'),
+        primary_key=True, autoincrement=True,
+    )

--- a/rero_ils/modules/budgets/permissions.py
+++ b/rero_ils/modules/budgets/permissions.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Budget permissions."""
+
+from ...permissions import staffer_is_authenticated
+
+
+def can_update_delete_budgets_factory(record, *args, **kwargs):
+    """Checks if logged user can update or delete its organisation budgets.
+
+    user must have librarian or system_librarian role
+    librarian can not update nor delete its affiliated library budgets.
+    sys_librarian can update or delete any budgets of its organisation.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron and patron.organisation_pid == record.organisation_pid:
+            if not patron.is_system_librarian:
+                return False
+            return True
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_create_budgets_factory(record, *args, **kwargs):
+    """Checks if the logged user can create budgets of its organisation.
+
+    librarian may not create budgets for its organisation.
+    system_librarian can create budgets of its org.
+    system_librarian or librarian can not create budgets at another org.
+    """
+    def can(self):
+        if record is None:
+            return True
+        patron = staffer_is_authenticated()
+        if patron and patron.organisation_pid == record.organisation_pid:
+            if patron.is_system_librarian:
+                return True
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_list_budgets_factory(record, *args, **kwargs):
+    """Checks if the logged user have access to budget list.
+
+    only authenticated users can place a search on budgets.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron:
+            return True
+        return False
+    return type('Check', (), {'can': can})()

--- a/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
+++ b/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
@@ -42,6 +42,11 @@
       "type": "string",
       "minLength": 2
     },
+    "current_budget_pid": {
+      "title": "Current ID of the budget",
+      "description": "The ID of the current budget of the organisation",
+      "type": "string"
+    },
     "default_currency": {
       "title": "Default currency",
       "description": "The default currency of the organisation",

--- a/rero_ils/modules/organisations/permissions.py
+++ b/rero_ils/modules/organisations/permissions.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Organisation permissions."""
+
+from ...permissions import staffer_is_authenticated
+
+
+def can_update_organisations_factory(record, *args, **kwargs):
+    """Checks if logged user can update its organisation.
+
+    user must have system_librarian role
+    librarian can not update its organisations.
+    sys_librarian can not update another organisations.
+    """
+    def can(self):
+        patron = staffer_is_authenticated()
+        if patron and patron.organisation_pid == record.get('pid') and \
+                patron.is_system_librarian:
+            return True
+        return False
+    return type('Check', (), {'can': can})()

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -97,6 +97,24 @@ def loans_search_factory(self, search, query_parser=None):
     return (search, urlkwargs)
 
 
+def acq_accounts_search_factory(self, search, query_parser=None):
+    """Acq accounts search factory.
+
+    Restricts results to oraganisation level for sys_lib.
+    Restricts results to library level for librarians.
+    """
+    search, urlkwargs = search_factory(self, search)
+    if current_patron:
+        if current_patron.is_system_librarian:
+            search = search.filter(
+                'term', organisation__pid=current_patron.get_organisation(
+                    )['pid'])
+        elif current_patron.is_librarian:
+            search = search.filter(
+                'term', library__pid=current_patron.library_pid)
+    return (search, urlkwargs)
+
+
 def search_factory(self, search, query_parser=None):
     """Parse query using elasticsearch DSL query.
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2019-12-09 12:11+0100\n"
+"POT-Creation-Date: 2019-12-18 14:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,71 +16,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.7.0\n"
 
-#: rero_ils/config.py:101
+#: rero_ils/config.py:109
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:150
 msgid "French"
 msgstr ""
 
-#: rero_ils/config.py:102
+#: rero_ils/config.py:110
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:154
 msgid "German"
 msgstr ""
 
-#: rero_ils/config.py:103
+#: rero_ils/config.py:111
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:158
 msgid "Italian"
 msgstr ""
 
-#: rero_ils/config.py:142 rero_ils/config.py:146
+#: rero_ils/config.py:150 rero_ils/config.py:154
 msgid "rero-ils"
 msgstr ""
 
-#: rero_ils/config.py:189
+#: rero_ils/config.py:196
 msgid "Welcome to RERO-ILS!"
 msgstr ""
 
-#: rero_ils/config.py:843
+#: rero_ils/config.py:890
 msgid "document_type"
 msgstr ""
 
-#: rero_ils/config.py:844
+#: rero_ils/config.py:891
 msgid "organisation"
 msgstr ""
 
-#: rero_ils/config.py:847
+#: rero_ils/config.py:894 rero_ils/config.py:938
 msgid "library"
 msgstr ""
 
-#: rero_ils/config.py:848
+#: rero_ils/config.py:895
 msgid "author__en"
 msgstr ""
 
-#: rero_ils/config.py:849
+#: rero_ils/config.py:896
 msgid "author__fr"
 msgstr ""
 
-#: rero_ils/config.py:850
+#: rero_ils/config.py:897
 msgid "author__de"
 msgstr ""
 
-#: rero_ils/config.py:851
+#: rero_ils/config.py:898
 msgid "author__it"
 msgstr ""
 
-#: rero_ils/config.py:852
+#: rero_ils/config.py:899
 msgid "language"
 msgstr ""
 
-#: rero_ils/config.py:853
+#: rero_ils/config.py:900
 msgid "subject"
 msgstr ""
 
-#: rero_ils/config.py:854
+#: rero_ils/config.py:901
 msgid "status"
 msgstr ""
 
-#: rero_ils/config.py:870
+#: rero_ils/config.py:917
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:886
+#: rero_ils/config.py:939
+msgid "budget"
+msgstr ""
+
+#: rero_ils/config.py:955
 msgid "sources"
 msgstr ""
 
@@ -233,25 +240,31 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: rero_ils/views.py:149
+#: rero_ils/views.py:143
+msgid "Switch to professional view"
+msgstr ""
+
+#: rero_ils/views.py:160
 msgid "Logout"
 msgstr ""
 
 #: rero_ils/templates/rero_ils/forgot_password.html:47
 #: rero_ils/templates/rero_ils/login_user.html:43
 #: rero_ils/templates/rero_ils/register_user.html:45
-#: rero_ils/templates/rero_ils/reset_password.html:47 rero_ils/views.py:160
+#: rero_ils/templates/rero_ils/reset_password.html:47 rero_ils/views.py:171
 msgid "Sign Up"
 msgstr ""
 
-#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:4
-msgid "Circulation policy"
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:4
+msgid "Acquisition account"
 msgstr ""
 
-#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:5
-msgid "JSON schema for circulation policies."
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:5
+msgid "JSON schema for an acquisition account"
 msgstr ""
 
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:17
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:13
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:16
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json:954
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:954
@@ -264,12 +277,166 @@ msgstr ""
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:16
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:15
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:15
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:18
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 msgid "Schema"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:18
+msgid "Schema to validate account records against."
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:24
+msgid "Account ID"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:28
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json:1556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1069
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:28
+#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:32
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:31
+msgid "Name"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:29
+msgid "Name of the Acquisition account."
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:34
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:34
+msgid "Description"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:35
+msgid "Description of the Acquisition account."
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:40
+#: rero_ils/modules/acq_accounts/jsonschemas/form_acq_accounts/acq_account-v0.0.1.json:19
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:4
+msgid "Budget"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:42
+msgid "The Acquisition account belongs to which budget."
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:45
+msgid "Budget URI"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:52
+msgid "Amount allocated"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:53
+msgid "The amount allocated for the Acquisition account."
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:57
+#: rero_ils/modules/acq_accounts/jsonschemas/form_acq_accounts/acq_account-v0.0.1.json:6
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:46
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:50
+#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/form_locations/location-v0.0.1.json:6
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:108
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:98
+msgid "Library"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:61
+#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:59
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+msgid "Library URI"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:68
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
+#: rero_ils/modules/budgets/jsonschemas/form_budgets/budget-v0.0.1.json:6
+#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
+#: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:102
+#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
+#: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:81
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
+#: rero_ils/modules/patron_types/jsonschemas/form_patron_types/patron_type-v0.0.1.json:6
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:38
+msgid "Organisation"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:50
+#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:106
+#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:31
+#: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:42
+msgid "Organisation URI"
+msgstr ""
+
+#: rero_ils/modules/acq_accounts/jsonschemas/form_acq_accounts/acq_account-v0.0.1.json:35
+msgid "The acquisition account name is already taken"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:5
+msgid "JSON schema for budget."
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:14
+msgid "Schema to validate budget records against."
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:19
+msgid "Budget ID"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:24
+msgid "Budget name"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:25
+msgid "Name of the budget."
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:32
+msgid "Budget start date"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:37
+msgid "Budget end date"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:41
+msgid "ACTIVE"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:42
+msgid "True if budget is active"
+msgstr ""
+
+#: rero_ils/modules/budgets/jsonschemas/form_budgets/budget-v0.0.1.json:22
+msgid "The budget name is already taken"
+msgstr ""
+
+#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:4
+msgid "Circulation policy"
+msgstr ""
+
+#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:5
+msgid "JSON schema for circulation policies."
 msgstr ""
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:17
@@ -294,27 +461,6 @@ msgstr ""
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:35
 msgid "The description of the circulation policy."
-msgstr ""
-
-#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/item_types/jsonschemas/form_item_types/item_type-v0.0.1.json:6
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:49
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:102
-#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
-#: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:81
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
-#: rero_ils/modules/patron_types/jsonschemas/form_patron_types/patron_type-v0.0.1.json:6
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:38
-msgid "Organisation"
-msgstr ""
-
-#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:106
-#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:31
-#: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:42
-msgid "Organisation URI"
 msgstr ""
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:50
@@ -393,12 +539,6 @@ msgstr ""
 msgid "List of libraries"
 msgstr ""
 
-#: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:59
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
-msgid "Library URI"
-msgstr ""
-
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:130
 msgid "Patron + Item types links"
 msgstr ""
@@ -419,22 +559,22 @@ msgstr ""
 msgid "Item type URI"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:217
-#: rero_ils/modules/documents/views.py:352
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:197
+#: rero_ils/modules/documents/views.py:356
 msgid "available"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:217
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:219
-#: rero_ils/modules/documents/views.py:354
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:197
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:199
+#: rero_ils/modules/documents/views.py:358
 msgid "not available"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:361 rero_ils/modules/items/views.py:138
+#: rero_ils/modules/documents/views.py:365 rero_ils/modules/items/views.py:138
 msgid "due until"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:367
 msgid "requested"
 msgstr ""
 
@@ -583,7 +723,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:128
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:126
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:123
 msgid "Language"
 msgstr ""
 
@@ -660,19 +800,6 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1550
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1064
 msgid "Corresponding pid of the MEF record."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json:1556
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:1555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1069
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:28
-#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:32
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:28
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:31
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
-msgid "Name"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1.json:1557
@@ -1056,7 +1183,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json:2356
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1388
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:136
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr ""
@@ -1182,7 +1309,7 @@ msgid "Country"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json:63
-#: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:26
+#: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:26
 msgid "Person"
 msgstr ""
 
@@ -3254,48 +3381,40 @@ msgstr ""
 msgid "Uniform title"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:135
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:132
 msgid "Online Access"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:145
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:139
 msgid "Permalink"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:157
-msgid "Document cannot be deleted: there are still items linked to this document."
-msgstr ""
-
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:163
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:47
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:151
+#: rero_ils/templates/rero_ils/_editor_button_actions.html:22
 msgid "JSON"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:175
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:161
 msgid "Holdings"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:178
-msgid "Add"
-msgstr ""
-
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:207
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:187
 msgid "items"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:207
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:187
 msgid "item"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:258
 msgid "Request"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:283
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:263
 msgid "Select a Pickup Location"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:311
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:291
 msgid "Export Formats"
 msgstr ""
 
@@ -3420,16 +3539,6 @@ msgstr ""
 msgid "Call number"
 msgstr ""
 
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:46
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:50
-#: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/form_locations/location-v0.0.1.json:6
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:108
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:98
-msgid "Library"
-msgstr ""
-
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:48
 msgid "Circulation category"
 msgstr ""
@@ -3447,8 +3556,8 @@ msgid "Items"
 msgstr ""
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:68
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:27
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:30
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:27
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:30
 msgid "ID"
 msgstr ""
 
@@ -3494,10 +3603,6 @@ msgstr ""
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:29
 msgid "Name of the ItemType."
-msgstr ""
-
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:34
-msgid "Description"
 msgstr ""
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:35
@@ -3580,75 +3685,20 @@ msgstr ""
 msgid "Holding URI"
 msgstr ""
 
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:69
-msgid "Item cannot be deleted: there are still transactions linked to this item."
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:80
-msgid "Transactions"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:85
-msgid "In Transit"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:92
-msgid "Borrowed by"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:99
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:142
-msgid "Patron"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:100
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:86
-msgid "Due date"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:101
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
-msgid "Renewals"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:135
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:35
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:37
-msgid "Pending"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:143
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:81
-msgid "Pickup library"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:144
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
-msgid "Reservation date"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:157
-msgid "No patron found!"
-msgstr ""
-
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:170
-msgid "No Date"
-msgstr ""
-
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:5
 msgid "JSON schema for a library"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:17
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:16
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:23
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:21
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:25
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:21
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:25
 msgid "Library ID"
 msgstr ""
 
@@ -3677,6 +3727,7 @@ msgid "Address of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:131
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:48
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 msgid "Email"
@@ -3836,99 +3887,6 @@ msgstr ""
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:4
-msgid "Mef person"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:5
-msgid "JSON schema for a mef person"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:29
-msgid "VIAF ID"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:33
-msgid "Source authorities list"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:48
-msgid "RERO authorities"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:52
-msgid "GND authorities"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/jsonschemas/persons/mef_person-v0.0.1.json:56
-msgid "BNF authorities"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source.html:25
-#: rero_ils/webpack_assets/package.json:6
-msgid "RERO"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source.html:44
-msgid "GND"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source.html:63
-msgid "BNF"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:22
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:25
-msgid "Birth date"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:23
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:26
-msgid "Death date"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:24
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:27
-msgid "Language of person"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:25
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:28
-msgid "Gender"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:26
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:29
-msgid "Biographical information"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:29
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:32
-msgid "Variant name"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_by_source_data.html:30
-#: rero_ils/modules/mef_persons/templates/rero_ils/_person_unified.html:33
-msgid "Authorized access point"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:39
-msgid "All sources"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:41
-msgid "Unified"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:46
-#: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:48
-msgid "By source"
-msgstr ""
-
-#: rero_ils/modules/mef_persons/templates/rero_ils/detailed_view_persons.html:67
-msgid "Documents"
-msgstr ""
-
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:5
 msgid "JSON schema for notifications."
 msgstr ""
@@ -3991,18 +3949,26 @@ msgid "Code of the organisation."
 msgstr ""
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
-msgid "Default currency"
+msgid "Current ID of the budget"
 msgstr ""
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
-msgid "The default currency of the organisation"
+msgid "The ID of the current budget of the organisation"
+msgstr ""
+
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+msgid "Default currency"
 msgstr ""
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+msgid "The default currency of the organisation"
+msgstr ""
+
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:53
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
 msgid "Online harvested source as configured in ebooks server."
 msgstr ""
 
@@ -4095,6 +4061,14 @@ msgstr ""
 #: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:109
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 msgid "Library affiliation."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:135
+msgid "Mail"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json:146
+msgid "English"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -4213,6 +4187,11 @@ msgstr ""
 msgid "Checkouts"
 msgstr ""
 
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:35
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:37
+msgid "Pending"
+msgstr ""
+
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "No loan"
 msgstr ""
@@ -4225,8 +4204,117 @@ msgstr ""
 msgid "Call Number"
 msgstr ""
 
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:81
+msgid "Pickup library"
+msgstr ""
+
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:86
+msgid "Due date"
+msgstr ""
+
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+msgid "Reservation date"
+msgstr ""
+
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+msgid "Renewals"
+msgstr ""
+
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:130
 msgid "Renew"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:4
+msgid "Mef person"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:5
+msgid "JSON schema for a mef person"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:29
+msgid "VIAF ID"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:33
+msgid "Source authorities list"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:48
+msgid "RERO authorities"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:52
+msgid "GND authorities"
+msgstr ""
+
+#: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:56
+msgid "BNF authorities"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source.html:25
+#: rero_ils/webpack_assets/package.json:6
+msgid "RERO"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source.html:44
+msgid "GND"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source.html:63
+msgid "BNF"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:22
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:25
+msgid "Birth date"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:23
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:26
+msgid "Death date"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:24
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:27
+msgid "Language of person"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:25
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:28
+msgid "Gender"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
+msgid "Biographical information"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:29
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:32
+msgid "Variant name"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:30
+#: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:33
+msgid "Authorized access point"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:39
+msgid "All sources"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:41
+msgid "Unified"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:46
+#: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:48
+msgid "By source"
+msgstr ""
+
+#: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:67
+msgid "Documents"
 msgstr ""
 
 #: rero_ils/static/templates/rero_ils/count.html:22
@@ -4237,31 +4325,6 @@ msgstr[1] ""
 
 #: rero_ils/static/templates/rero_ils/count.html:23
 msgid "No results found."
-msgstr ""
-
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:24
-msgid "Confirm Delete"
-msgstr ""
-
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:31
-msgid "You are about to delete one record, this procedure is irreversible."
-msgstr ""
-
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:32
-msgid "Do you want to proceed?"
-msgstr ""
-
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:36
-msgid "Cancel"
-msgstr ""
-
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:38
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:55
-msgid "Delete"
-msgstr ""
-
-#: rero_ils/templates/rero_ils/_editor_button_actions.html:50
-msgid "Edit"
 msgstr ""
 
 #: rero_ils/templates/rero_ils/footer.html:21
@@ -4374,19 +4437,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: rero_ils/templates/rero_ils/header_login.html:22
-msgid "Log in"
-msgstr ""
-
-#: rero_ils/templates/rero_ils/header_login.html:23
-msgid "Sign up"
-msgstr ""
-
-#: rero_ils/templates/rero_ils/header_login.html:40
-#: rero_ils/templates/rero_ils/header_login.html:44
-msgid "Log out"
-msgstr ""
-
 #: rero_ils/templates/rero_ils/login_user.html:25
 msgid "Log in to account"
 msgstr ""
@@ -4432,3 +4482,4 @@ msgstr ""
 #: rero_ils/webpack_assets/package.json:4
 msgid "Invenio assets"
 msgstr ""
+

--- a/scripts/setup
+++ b/scripts/setup
@@ -292,6 +292,19 @@ eval ${PREFIX} pipenv run invenio fixtures create --pid_type vndr ${DATA_PATH}/v
 eval ${PREFIX} pipenv run invenio index reindex -t vndr --yes-i-know
 eval ${PREFIX} pipenv run invenio index run -c 4 --raise-on-error
 
+# create library budgets
+info_msg "Library budgets:"
+eval ${PREFIX} pipenv run invenio fixtures create --pid_type budg ${DATA_PATH}/budgets.json --append
+eval ${PREFIX} pipenv run invenio index reindex -t budg --yes-i-know
+eval ${PREFIX} pipenv run invenio index run -c 4 --raise-on-error 
+
+
+# create acquisition accounts
+info_msg "Acquisition accounts:"
+eval ${PREFIX} pipenv run invenio fixtures create --pid_type acac ${DATA_PATH}/acq_accounts.json --append
+eval ${PREFIX} pipenv run invenio index reindex -t acac --yes-i-know
+eval ${PREFIX} pipenv run invenio index run -c 4 --raise-on-error 
+
 # # OAI configuration
 info_msg "OAI configuration:"
 eval ${PREFIX} pipenv run invenio oaiharvester initconfig ${DATA_PATH}/oaisources.yml

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,8 @@ setup(
             'holdings = rero_ils.modules.holdings.models',
             'fees = rero_ils.modules.fees.models',
             'vendors = rero_ils.modules.vendors.models',
+            'acq_accounts = rero_ils.modules.acq_accounts.models',
+            'budgets = rero_ils.modules.budgets.models',
         ],
         'invenio_pidstore.minters': [
             'organisation_id = \
@@ -185,6 +187,9 @@ setup(
             'holding_id = rero_ils.modules.holdings.api:holding_id_minter',
             'fee_id = rero_ils.modules.fees.api:fee_id_minter',
             'vendor_id = rero_ils.modules.vendors.api:vendor_id_minter',
+            'acq_account_id = \
+                rero_ils.modules.acq_accounts.api:acq_account_id_minter',
+            'budget_id = rero_ils.modules.budgets.api:budget_id_minter',
         ],
         'invenio_pidstore.fetchers': [
             'organisation_id = rero_ils.modules.organisations'
@@ -213,6 +218,9 @@ setup(
                 rero_ils.modules.holdings.api:holding_id_fetcher',
             'fee_id = rero_ils.modules.fees.api:fee_id_fetcher',
             'vendor_id = rero_ils.modules.vendors.api:vendor_id_fetcher',
+            'acq_account_id = \
+                rero_ils.modules.acq_accounts.api:acq_account_id_fetcher',
+            'budget_id = rero_ils.modules.budgets.api:budget_id_fetcher',
         ],
         'invenio_jsonschemas.schemas': [
             'organisations = rero_ils.modules.organisations.jsonschemas',
@@ -230,6 +238,8 @@ setup(
             'holdings = rero_ils.modules.holdings.jsonschemas',
             'fees = rero_ils.modules.fees.jsonschemas',
             'vendors = rero_ils.modules.vendors.jsonschemas',
+            'acq_accounts = rero_ils.modules.acq_accounts.jsonschemas',
+            'budgets = rero_ils.modules.budgets.jsonschemas',
         ],
         'invenio_search.mappings': [
             'organisations = rero_ils.modules.organisations.mappings',
@@ -247,6 +257,8 @@ setup(
             'holdings = rero_ils.modules.holdings.mappings',
             'fees = rero_ils.modules.fees.mappings',
             'vendors = rero_ils.modules.vendors.mappings',
+            'acq_accounts = rero_ils.modules.acq_accounts.mappings',
+            'budgets = rero_ils.modules.budgets.mappings',
         ],
         'invenio_search.templates': [
             'base-record = rero_ils.es_templates:list_es_templates'
@@ -270,6 +282,8 @@ setup(
             'notifications = rero_ils.modules.notifications.jsonresolver',
             'persons = rero_ils.modules.persons.jsonresolver',
             'vendors = rero_ils.modules.vendors.jsonresolver',
+            'acq_accounts = rero_ils.modules.acq_accounts.jsonresolver',
+            'budgets = rero_ils.modules.budgets.jsonresolver',
         ]
     },
     classifiers=[

--- a/tests/api/test_acq_accounts_rest.py
+++ b/tests/api/test_acq_accounts_rest.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST API acquisition accounts."""
+
+import json
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_acq_accounts_library_facets(
+    client, org_martigny, acq_account_fiction_martigny, rero_json_header
+):
+    """Test record retrieval."""
+    list_url = url_for('invenio_records_rest.acac_list', view='org1')
+
+    res = client.get(list_url, headers=rero_json_header)
+    data = get_json(res)
+    aggs = data['aggregations']
+    assert 'library' in aggs
+
+
+def test_acq_accounts_permissions(client, acq_account_fiction_martigny,
+                                  json_header):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.acac_item', pid_value='acac1')
+
+    res = client.get(item_url)
+    assert res.status_code == 401
+
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.acac_list',
+        {}
+    )
+    assert res.status_code == 401
+
+    res = client.put(
+        url_for('invenio_records_rest.acac_item', pid_value='acac1'),
+        data={},
+        headers=json_header
+    )
+
+    res = client.delete(item_url)
+    assert res.status_code == 401
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_acq_accounts_get(client, acq_account_fiction_martigny):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.acac_item', pid_value='acac1')
+    acq_account = acq_account_fiction_martigny
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    assert res.headers['ETag'] == '"{}"'.format(acq_account.revision_id)
+
+    data = get_json(res)
+    assert acq_account.dumps() == data['metadata']
+
+    # Check metadata
+    for k in ['created', 'updated', 'metadata', 'links']:
+        assert k in data
+
+    # Check self links
+    res = client.get(to_relative_url(data['links']['self']))
+    assert res.status_code == 200
+    assert data == get_json(res)
+    assert acq_account.dumps() == data['metadata']
+
+    list_url = url_for('invenio_records_rest.acac_list', pid='acac1')
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+
+    assert data['hits']['hits'][0]['metadata'] == acq_account.replace_refs()
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_acq_accounts_post_put_delete(client,
+                                      acq_account_books_saxon,
+                                      json_header):
+    """Test record retrieval."""
+    # Create record / POST
+    item_url = url_for('invenio_records_rest.acac_item', pid_value='1')
+    list_url = url_for('invenio_records_rest.acac_list', q='pid:1')
+
+    acq_account_books_saxon['pid'] = '1'
+    res, data = postdata(
+        client,
+        'invenio_records_rest.acac_list',
+        acq_account_books_saxon
+    )
+    assert res.status_code == 201
+
+    # Check that the returned record matches the given data
+    assert data['metadata'] == acq_account_books_saxon
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert acq_account_books_saxon == data['metadata']
+
+    # Update record/PUT
+    data = acq_account_books_saxon
+    data['name'] = 'Test Name'
+    res = client.put(
+        item_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    # assert res.headers['ETag'] != '"{}"'.format(librarie.revision_id)
+
+    # Check that the returned record matches the given data
+    data = get_json(res)
+    assert data['metadata']['name'] == 'Test Name'
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    data = get_json(res)
+    assert data['metadata']['name'] == 'Test Name'
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    data = get_json(res)['hits']['hits'][0]
+    assert data['metadata']['name'] == 'Test Name'
+
+    # Delete record/DELETE
+    res = client.delete(item_url)
+    assert res.status_code == 204
+
+    res = client.get(item_url)
+    assert res.status_code == 410
+
+
+def test_acq_accounts_can_delete(client, acq_account_fiction_martigny):
+    """Test can delete an acq account."""
+    links = acq_account_fiction_martigny.get_links_to_me()
+    assert not links
+
+    assert acq_account_fiction_martigny.can_delete
+
+    reasons = acq_account_fiction_martigny.reasons_not_to_delete()
+    assert not reasons
+
+
+def test_filtered_acq_accounts_get(
+        client, librarian_martigny_no_email, acq_account_fiction_martigny,
+        librarian_sion_no_email, acq_account_fiction_sion):
+    """Test acq accounts filter by organisation."""
+    list_url = url_for('invenio_records_rest.acac_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 401
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    list_url = url_for('invenio_records_rest.acac_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.acac_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+
+def test_acq_account_secure_api(client, json_header,
+                                acq_account_fiction_martigny,
+                                librarian_martigny_no_email,
+                                librarian_sion_no_email):
+    """Test acq account secure api access."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.acac_item',
+                         pid_value=acq_account_fiction_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for('invenio_records_rest.acac_item',
+                         pid_value=acq_account_fiction_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 403
+
+
+def test_acq_account_secure_api_create(client, json_header,
+                                       acq_account_fiction_martigny,
+                                       librarian_martigny_no_email,
+                                       librarian_sion_no_email,
+                                       acq_account_books_saxon,
+                                       system_librarian_martigny_no_email):
+    """Test acq account secure api create."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    post_entrypoint = 'invenio_records_rest.acac_list'
+
+    del acq_account_books_saxon['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        acq_account_books_saxon
+    )
+    assert res.status_code == 403
+
+    del acq_account_fiction_martigny['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        acq_account_fiction_martigny
+    )
+    assert res.status_code == 201
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        acq_account_fiction_martigny
+    )
+    assert res.status_code == 201
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        acq_account_books_saxon
+    )
+    assert res.status_code == 403
+
+
+def test_acq_account_secure_api_update(client,
+                                       acq_account_books_martigny,
+                                       librarian_martigny_no_email,
+                                       librarian_sion_no_email,
+                                       acq_account_books_martigny_data,
+                                       json_header):
+    """Test acq account secure api update."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.acac_item',
+                         pid_value=acq_account_books_martigny.pid)
+
+    data = acq_account_books_martigny
+    data['name'] = 'Test Name'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_acq_account_secure_api_delete(client,
+                                       acq_account_books_martigny,
+                                       librarian_martigny_no_email,
+                                       librarian_sion_no_email,
+                                       acq_account_general_fully,
+                                       json_header):
+    """Test acq account secure api delete."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.acac_item',
+                         pid_value=acq_account_books_martigny.pid)
+
+    res = client.delete(record_url)
+    assert res.status_code == 204
+
+    record_url = url_for('invenio_records_rest.acac_item',
+                         pid_value=acq_account_general_fully.pid)
+
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.delete(record_url)
+    assert res.status_code == 403

--- a/tests/api/test_budgets_rest.py
+++ b/tests/api/test_budgets_rest.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST API acquisition accounts."""
+
+import json
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
+
+
+def test_budgets_permissions(client, budget_2020_martigny,
+                             json_header):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.budg_item', pid_value='budg1')
+
+    res = client.get(item_url)
+    assert res.status_code == 401
+
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.budg_list',
+        {}
+    )
+    assert res.status_code == 401
+
+    res = client.put(
+        url_for('invenio_records_rest.budg_item', pid_value='budg1'),
+        data={},
+        headers=json_header
+    )
+
+    res = client.delete(item_url)
+    assert res.status_code == 401
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_budgets_get(client, budget_2020_martigny):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.budg_item', pid_value='budg1')
+    budget = budget_2020_martigny
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    assert res.headers['ETag'] == '"{}"'.format(budget.revision_id)
+
+    data = get_json(res)
+    assert budget.dumps() == data['metadata']
+
+    # Check metadata
+    for k in ['created', 'updated', 'metadata', 'links']:
+        assert k in data
+
+    # Check self links
+    res = client.get(to_relative_url(data['links']['self']))
+    assert res.status_code == 200
+    assert data == get_json(res)
+    assert budget.dumps() == data['metadata']
+
+    list_url = url_for('invenio_records_rest.budg_list', pid='budg1')
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+
+    assert data['hits']['hits'][0]['metadata'] == budget.replace_refs()
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_budgets_post_put_delete(client,
+                                 budget_2019_martigny,
+                                 json_header):
+    """Test record retrieval."""
+    # Create record / POST
+    item_url = url_for('invenio_records_rest.budg_item', pid_value='1')
+    list_url = url_for('invenio_records_rest.budg_list', q='pid:1')
+
+    budget_2019_martigny['pid'] = '1'
+    res, data = postdata(
+        client,
+        'invenio_records_rest.budg_list',
+        budget_2019_martigny
+    )
+    assert res.status_code == 201
+
+    # Check that the returned record matches the given data
+    assert data['metadata'] == budget_2019_martigny
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert budget_2019_martigny == data['metadata']
+
+    # Update record/PUT
+    data = budget_2019_martigny
+    data['name'] = 'Test Name'
+    res = client.put(
+        item_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    # assert res.headers['ETag'] != '"{}"'.format(librarie.revision_id)
+
+    # Check that the returned record matches the given data
+    data = get_json(res)
+    assert data['metadata']['name'] == 'Test Name'
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    data = get_json(res)
+    assert data['metadata']['name'] == 'Test Name'
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    data = get_json(res)['hits']['hits'][0]
+    assert data['metadata']['name'] == 'Test Name'
+
+    # Delete record/DELETE
+    res = client.delete(item_url)
+    assert res.status_code == 204
+
+    res = client.get(item_url)
+    assert res.status_code == 410
+
+
+def test_budgets_can_delete(
+        client, budget_2020_martigny, acq_account_fiction_martigny):
+    """Test can delete an acq account."""
+    links = budget_2020_martigny.get_links_to_me()
+    assert 'acq_accounts' in links
+
+    assert not budget_2020_martigny.can_delete
+
+    reasons = budget_2020_martigny.reasons_not_to_delete()
+    assert 'links' in reasons
+
+
+def test_filtered_budgets_get(
+        client, librarian_martigny_no_email, budget_2020_martigny,
+        librarian_sion_no_email, budget_2020_sion):
+    """Test acq accounts filter by organisation."""
+    list_url = url_for('invenio_records_rest.budg_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 401
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    list_url = url_for('invenio_records_rest.budg_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 3
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.budg_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 3
+
+
+def test_budget_secure_api(client, json_header,
+                           budget_2020_martigny,
+                           librarian_martigny_no_email,
+                           librarian_sion_no_email):
+    """Test acq account secure api access."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.budg_item',
+                         pid_value=budget_2020_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for('invenio_records_rest.budg_item',
+                         pid_value=budget_2020_martigny.pid)
+
+    res = client.get(record_url)
+    assert res.status_code == 403
+
+
+def test_budget_secure_api_create(client, json_header,
+                                  budget_2020_martigny,
+                                  librarian_martigny_no_email,
+                                  librarian_sion_no_email,
+                                  budget_2019_martigny,
+                                  system_librarian_martigny_no_email):
+    """Test acq account secure api create."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    post_entrypoint = 'invenio_records_rest.budg_list'
+
+    del budget_2019_martigny['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        budget_2019_martigny
+    )
+    assert res.status_code == 403
+
+    del budget_2020_martigny['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        budget_2020_martigny
+    )
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        budget_2020_martigny
+    )
+    assert res.status_code == 201
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        budget_2019_martigny
+    )
+    assert res.status_code == 403
+
+
+def test_budget_secure_api_update(client,
+                                  budget_2018_martigny,
+                                  librarian_martigny_no_email,
+                                  system_librarian_martigny_no_email,
+                                  system_librarian_sion_no_email,
+                                  librarian_sion_no_email,
+                                  budget_2018_martigny_data,
+                                  json_header):
+    """Test acq account secure api update."""
+    # Martigny
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.budg_item',
+                         pid_value=budget_2018_martigny.pid)
+
+    data = budget_2018_martigny
+    data['name'] = 'Test Name'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_budget_secure_api_delete(client,
+                                  budget_2018_martigny,
+                                  librarian_martigny_no_email,
+                                  librarian_sion_no_email,
+                                  budget_2019_martigny,
+                                  system_librarian_martigny_no_email,
+                                  json_header):
+    """Test acq account secure api delete."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.budg_item',
+                         pid_value=budget_2018_martigny.pid)
+
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.delete(record_url)
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.delete(record_url)
+    assert res.status_code == 204

--- a/tests/api/test_organisations_rest_api.py
+++ b/tests/api/test_organisations_rest_api.py
@@ -24,6 +24,45 @@ from invenio_accounts.testutils import login_user_via_session
 from utils import postdata
 
 
+def test_organisation_secure_api_update(client, json_header, org_martigny,
+                                        librarian_martigny_no_email,
+                                        system_librarian_martigny_no_email,
+                                        librarian_sion_no_email,
+                                        org_martigny_data):
+    """Test organisation secure api create."""
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.org_item',
+                         pid_value=org_martigny.pid)
+
+    data = org_martigny_data
+    data['name'] = 'New Name 1'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    data['name'] = 'New Name 2'
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
 def test_location_can_delete(client, org_martigny, lib_martigny):
     """Test can delete an organisation."""
     links = org_martigny.get_links_to_me()
@@ -77,35 +116,6 @@ def test_organisation_secure_api_create(client, json_header, org_martigny,
         client,
         post_entrypoint,
         org_martigny_data
-    )
-    assert res.status_code == 403
-
-
-def test_organisation_secure_api_update(client, json_header, org_martigny,
-                                        librarian_martigny_no_email,
-                                        librarian_sion_no_email,
-                                        org_martigny_data):
-    """Test organisation secure api create."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    record_url = url_for('invenio_records_rest.org_item',
-                         pid_value=org_martigny.pid)
-
-    data = org_martigny_data
-    data['name'] = 'New Name'
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
-    )
-    assert res.status_code == 403
-
-    # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
-
-    res = client.put(
-        record_url,
-        data=json.dumps(data),
-        headers=json_header
     )
     assert res.status_code == 403
 

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -80,5 +80,127 @@
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/org2"
     }
+  },
+  "budg1": {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "budg1",
+    "name": "2020",
+    "start_date": "2020-01-01T00:00:00.355920+00:00",
+    "end_date": "2020-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    }
+  },
+  "budg2": {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "budg2",
+    "name": "2020",
+    "start_date": "2020-01-01T00:00:00.355920+00:00",
+    "end_date": "2020-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org2"
+    }
+  },
+  "budg3": {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "budg3",
+    "name": "2019",
+    "start_date": "2019-01-01T00:00:00.355920+00:00",
+    "end_date": "2019-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    }
+  },
+  "budg4": {
+    "$schema": "https://ils.rero.ch/schema/budgets/budget-v0.0.1.json",
+    "pid": "budg4",
+    "name": "2018",
+    "start_date": "2018-01-01T00:00:00.355920+00:00",
+    "end_date": "2018-12-31T00:00:00.355920+00:00",
+    "is_active": true,
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    }
+  },
+  "acac1": {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "acac1",
+    "name": "fiction",
+    "description": "Romans, nouvelles et pi\u00e8ces de th\u00e9\u00e2tre de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/budg1"
+    },
+    "amount_allocated": 15000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib1"
+    }
+  },
+  "acac2": {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "acac2",
+    "name": "books",
+    "description": "Documentaires de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/budg1"
+    },
+    "amount_allocated": 10000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib2"
+    }
+  },
+  "acac3": {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "acac3",
+    "name": "general",
+    "description": "Compte g\u00e9n\u00e9ral",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/budg1"
+    },
+    "amount_allocated": 12000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib3"
+    }
+  },
+  "acac4": {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "acac4",
+    "name": "fiction",
+    "description": "Romans, nouvelles et pi\u00e8ces de th\u00e9\u00e2tre de l'espace public",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/budg2"
+    },
+    "amount_allocated": 11000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib4"
+    }
+  },
+  "acac5": {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "acac4",
+    "name": "general",
+    "description": "Compte g\u00e9n\u00e9ral",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/budg2"
+    },
+    "amount_allocated": 14000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib5"
+    }
+  },
+  "acac6": {
+    "$schema": "https://ils.rero.ch/schema/acq_accounts/acq_account-v0.0.1.json",
+    "pid": "acac6",
+    "name": "books",
+    "description": "Books",
+    "budget": {
+      "$ref": "https://ils.rero.ch/api/budgets/budg2"
+    },
+    "amount_allocated": 16000,
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib1"
+    }
   }
 }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -6,6 +6,7 @@
     "address": "Ave de la gare, Martigny CH-1920",
     "code": "org1",
     "default_currency": "CHF",
+    "current_budget_pid": "1",
     "online_harvested_source": "ebibliomedia"
   },
   "org2": {
@@ -15,6 +16,7 @@
     "address": "Ave de la gare, Martigny CH-1950",
     "code": "org2",
     "default_currency": "EUR",
+    "current_budget_pid": "2",
     "online_harvested_source": "mv-cantook"
   },
   "lib1": {

--- a/tests/fixtures/acquisition.py
+++ b/tests/fixtures/acquisition.py
@@ -23,6 +23,8 @@ from copy import deepcopy
 import pytest
 from utils import flush_index
 
+from rero_ils.modules.acq_accounts.api import AcqAccount, AcqAccountsSearch
+from rero_ils.modules.budgets.api import Budget, BudgetsSearch
 from rero_ils.modules.vendors.api import Vendor, VendorsSearch
 
 
@@ -126,3 +128,207 @@ def vendor2_sion(app, vendor2_sion_data):
         reindex=True)
     flush_index(VendorsSearch.Meta.index)
     return vendor
+
+
+@pytest.fixture(scope="function")
+def budget_2020_martigny_data_tmp(acquisition):
+    """Load standard budget 2020 of martigny."""
+    return deepcopy(acquisition.get('budg1'))
+
+
+@pytest.fixture(scope="module")
+def budget_2020_sion_data(acquisition):
+    """Load budget 2020 sion."""
+    return deepcopy(acquisition.get('budg2'))
+
+
+@pytest.fixture(scope="module")
+def budget_2020_martigny_data(acquisition):
+    """Load budget 2020 martigny."""
+    return deepcopy(acquisition.get('budg1'))
+
+
+@pytest.fixture(scope="module")
+def budget_2019_martigny_data(acquisition):
+    """Load budget 2019 martigny."""
+    return deepcopy(acquisition.get('budg3'))
+
+
+@pytest.fixture(scope="module")
+def budget_2018_martigny_data(acquisition):
+    """Load budget 2018 martigny."""
+    return deepcopy(acquisition.get('budg4'))
+
+
+@pytest.fixture(scope="module")
+def budget_2018_martigny(
+        app, org_martigny, budget_2018_martigny_data):
+    """Load budget 2018 martigny record."""
+    budget = Budget.create(
+        data=budget_2018_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(BudgetsSearch.Meta.index)
+    return budget
+
+
+@pytest.fixture(scope="module")
+def budget_2020_martigny(
+        app, org_martigny, budget_2020_martigny_data):
+    """Load budget 2020 martigny record."""
+    budget = Budget.create(
+        data=budget_2020_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(BudgetsSearch.Meta.index)
+    return budget
+
+
+@pytest.fixture(scope="module")
+def budget_2019_martigny(
+        app, org_martigny, budget_2019_martigny_data):
+    """Load budget 2019 martigny record."""
+    budget = Budget.create(
+        data=budget_2019_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(BudgetsSearch.Meta.index)
+    return budget
+
+
+@pytest.fixture(scope="module")
+def budget_2020_sion(
+        app, org_sion, budget_2020_sion_data):
+    """Load budget 2020 sion record."""
+    budget = Budget.create(
+        data=budget_2020_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(BudgetsSearch.Meta.index)
+    return budget
+
+
+@pytest.fixture(scope="function")
+def acq_account_fiction_martigny_data_tmp(acquisition):
+    """Load standard acq account of martigny."""
+    return deepcopy(acquisition.get('acac1'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_fiction_martigny_data(acquisition):
+    """Load acq_account lib martigny fiction data."""
+    return deepcopy(acquisition.get('acac1'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_books_martigny_data(acquisition):
+    """Load acq_account lib martigny books data."""
+    return deepcopy(acquisition.get('acac6'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_fiction_martigny(
+        app, lib_martigny, acq_account_fiction_martigny_data,
+        budget_2020_martigny):
+    """Load acq_account lib martigny fiction record."""
+    acac = AcqAccount.create(
+        data=acq_account_fiction_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqAccountsSearch.Meta.index)
+    return acac
+
+
+@pytest.fixture(scope="module")
+def acq_account_books_martigny(
+        app, lib_martigny, acq_account_books_martigny_data,
+        budget_2020_martigny):
+    """Load acq_account lib martigny books record."""
+    acac = AcqAccount.create(
+        data=acq_account_books_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqAccountsSearch.Meta.index)
+    return acac
+
+
+@pytest.fixture(scope="module")
+def acq_account_books_saxon_data(acquisition):
+    """Load acq_account lib saxon books data."""
+    return deepcopy(acquisition.get('acac2'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_books_saxon(
+        app, lib_saxon, acq_account_books_saxon_data, budget_2020_martigny):
+    """Load acq_account lib saxon books record."""
+    acac = AcqAccount.create(
+        data=acq_account_books_saxon_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqAccountsSearch.Meta.index)
+    return acac
+
+
+@pytest.fixture(scope="module")
+def acq_account_general_fully_data(acquisition):
+    """Load acq_account lib fully general data."""
+    return deepcopy(acquisition.get('acac3'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_general_fully(
+        app, lib_fully, acq_account_general_fully_data, budget_2020_martigny):
+    """Load acq_account lib fully general record."""
+    acac = AcqAccount.create(
+        data=acq_account_general_fully_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqAccountsSearch.Meta.index)
+    return acac
+
+
+@pytest.fixture(scope="module")
+def acq_account_fiction_sion_data(acquisition):
+    """Load acq_account lib sion fiction data."""
+    return deepcopy(acquisition.get('acac4'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_fiction_sion(
+        app, lib_saxon, acq_account_fiction_sion_data, budget_2020_sion):
+    """Load acq_account lib sion fiction record."""
+    acac = AcqAccount.create(
+        data=acq_account_fiction_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqAccountsSearch.Meta.index)
+    return acac
+
+
+@pytest.fixture(scope="module")
+def acq_account_general_aproz_data(acquisition):
+    """Load acq_account lib aproz general data."""
+    return deepcopy(acquisition.get('acac5'))
+
+
+@pytest.fixture(scope="module")
+def acq_account_general_aproz(
+        app, lib_saxon, acq_account_general_aproz_data, budget_2020_sion):
+    """Load acq_account lib aproz general record."""
+    acac = AcqAccount.create(
+        data=acq_account_general_aproz_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(AcqAccountsSearch.Meta.index)
+    return acac

--- a/tests/ui/acq_accounts/test_acq_accounts_jsonresolver.py
+++ b/tests/ui/acq_accounts/test_acq_accounts_jsonresolver.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acq account JSONResolver tests."""
+
+import pytest
+from invenio_records.api import Record
+from jsonref import JsonRefError
+
+
+def test_acq_accounts_jsonresolver(acq_account_fiction_martigny):
+    """Acquisition accounts resolver tests."""
+    rec = Record.create({
+        'acq_account': {'$ref': 'https://ils.rero.ch/api/acq_accounts/acac1'}
+    })
+    assert rec.replace_refs().get('acq_account') == {'pid': 'acac1'}
+
+    # deleted record
+    acq_account_fiction_martigny.delete()
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()
+
+    # non existing record
+    rec = Record.create({
+        'acq_account': {'$ref': 'https://ils.rero.ch/api/acq_accounts/n_e'}
+    })
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()

--- a/tests/ui/budgets/test_budgets_jsonresolver.py
+++ b/tests/ui/budgets/test_budgets_jsonresolver.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Budget JSONResolver tests."""
+
+import pytest
+from invenio_records.api import Record
+from jsonref import JsonRefError
+
+
+def test_budgets_jsonresolver(budget_2020_martigny):
+    """Budgets resolver tests."""
+    rec = Record.create({
+        'budget': {'$ref': 'https://ils.rero.ch/api/budgets/budg1'}
+    })
+    assert rec.replace_refs().get('budget') == {'pid': 'budg1'}
+
+    # deleted record
+    budget_2020_martigny.delete()
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()
+
+    # non existing record
+    rec = Record.create({
+        'budget': {'$ref': 'https://ils.rero.ch/api/budgets/n_e'}
+    })
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,6 +59,28 @@ def item_type_schema():
 
 
 @pytest.fixture()
+def acq_account_schema():
+    """Acq account Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.acq_accounts.jsonschemas',
+        '/acq_accounts/acq_account-v0.0.1.json'
+    )
+    schema = loads(schema_in_bytes.decode('utf8'))
+    return schema
+
+
+@pytest.fixture()
+def budget_schema():
+    """Budget Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.budgets.jsonschemas',
+        '/budgets/budget-v0.0.1.json'
+    )
+    schema = loads(schema_in_bytes.decode('utf8'))
+    return schema
+
+
+@pytest.fixture()
 def library_schema():
     """Library Jsonschema for records."""
     schema_in_bytes = resource_string(

--- a/tests/unit/test_acq_accounts_jsonschema.py
+++ b/tests/unit/test_acq_accounts_jsonschema.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquistion accounts JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_required(acq_account_schema, acq_account_fiction_martigny_data_tmp):
+    """Test required for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, acq_account_schema)
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+
+def test_pid(acq_account_schema, acq_account_fiction_martigny_data_tmp):
+    """Test pid for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        acq_account_fiction_martigny_data_tmp['pid'] = 25
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+
+def test_name(acq_account_schema, acq_account_fiction_martigny_data_tmp):
+    """Test name for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        acq_account_fiction_martigny_data_tmp['name'] = 25
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+
+def test_description(
+        acq_account_schema, acq_account_fiction_martigny_data_tmp):
+    """Test description for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        acq_account_fiction_martigny_data_tmp['description'] = 25
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+
+def test_organisation_pid(acq_account_schema,
+                          acq_account_fiction_martigny_data_tmp):
+    """Test organisation_pid for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        acq_account_fiction_martigny_data_tmp['organisation_pid'] = 25
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+
+def test_budget(
+        acq_account_schema, acq_account_fiction_martigny_data_tmp):
+    """Test budget for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        acq_account_fiction_martigny_data_tmp['budget'] = 25
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+
+def test_amount_allocated(
+        acq_account_schema, acq_account_fiction_martigny_data_tmp):
+    """Test amount_allocated for acq accounts jsonschemas."""
+    validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)
+
+    with pytest.raises(ValidationError):
+        acq_account_fiction_martigny_data_tmp['amount_allocated'] = 'test'
+        validate(acq_account_fiction_martigny_data_tmp, acq_account_schema)

--- a/tests/unit/test_budgets_jsonschema.py
+++ b/tests/unit/test_budgets_jsonschema.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Acquistion accounts JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_required(budget_schema, budget_2020_martigny_data_tmp):
+    """Test required for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, budget_schema)
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_pid(budget_schema, budget_2020_martigny_data_tmp):
+    """Test pid for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['pid'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_name(budget_schema, budget_2020_martigny_data_tmp):
+    """Test name for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['name'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_organisation_pid(budget_schema,
+                          budget_2020_martigny_data_tmp):
+    """Test organisation_pid for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['organisation_pid'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_library(
+        budget_schema, budget_2020_martigny_data_tmp):
+    """Test library for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['library'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_start_date(
+        budget_schema, budget_2020_martigny_data_tmp):
+    """Test start date for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['start_date'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_end_date(
+        budget_schema, budget_2020_martigny_data_tmp):
+    """Test end date for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['end_date'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)
+
+
+def test_is_active(
+        budget_schema, budget_2020_martigny_data_tmp):
+    """Test is_active te for budgets jsonschemas."""
+    validate(budget_2020_martigny_data_tmp, budget_schema)
+
+    with pytest.raises(ValidationError):
+        budget_2020_martigny_data_tmp['is_active'] = 25
+        validate(budget_2020_martigny_data_tmp, budget_schema)


### PR DESCRIPTION
* Adds a new acq_account and budget resources.
* Creates fixtures and units testing for the two resources.
* Limits acq_account manipulation (edit, delete , update) to librarian of same library.
* Allows system librarians to manipulate acq_accounts of its organisation.
* Limits budget manipulation (edit, delete , update) to system_librarian of same organisation.
* Allows librarians to read its library budgets.
* Inherits acq_account currencies from its organisation default currency.
* Adds library name to acq_account serializer.
* Allows organisation editing for organistions system_librarians.
* Adds current_budget_pid to the resource organisation

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1211?kanban-status=1224894

## How to test?

`bootstrap`
`setup`

API access to the new resource `acq_account` is only available to:
1- system librarian of same organisation
2- librarians of same the library of the acq_account

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
