### PR TITLE
data: move validation messages from schema to form options

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
@@ -981,7 +981,6 @@
     "title": {
       "title": "Title",
       "description": "Required. Entire title without statement of responsibility.",
-      "validationMessage": "Required. Entire title without statement of responsibility.",
       "type": "string",
       "minLength": 1
     },
@@ -1039,8 +1038,7 @@
       "minItems": 1,
       "items": {
         "type": "string",
-        "minLength": 2,
-        "validationMessage": "Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for English."
+        "minLength": 2
       }
     },
     "authors": {
@@ -1396,7 +1394,6 @@
             "title": "Status",
             "description": "Status of the ISBN/ISSN identifier.",
             "type": "string",
-            "validationMessage": "ISBN/ISSN status should be selected in the list below.",
             "enum": [
               "invalid",
               "cancelled",

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -980,7 +980,6 @@
     "title": {
       "title": "Title",
       "description": "Required. Entire title without statement of responsibility.",
-      "validationMessage": "Required. Entire title without statement of responsibility.",
       "type": "string",
       "minLength": 1
     },
@@ -1038,8 +1037,7 @@
       "minItems": 1,
       "items": {
         "type": "string",
-        "minLength": 2,
-        "validationMessage": "Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for English."
+        "minLength": 2
       }
     },
     "authors": {
@@ -1394,7 +1392,6 @@
             "title": "Status",
             "description": "Status of the ISBN/ISSN identifier.",
             "type": "string",
-            "validationMessage": "ISBN/ISSN status should be selected in the list below.",
             "enum": [
               "invalid",
               "cancelled",

--- a/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/form_documents/document-v0.0.1.json
@@ -16,7 +16,10 @@
     "title": "Title",
     "items": [
       {
-        "key": "title"
+        "key": "title",
+        "validationMessages": {
+          "required": "Required. Entire title without statement of responsibility."
+        }
       }
     ]
   },
@@ -2102,7 +2105,10 @@
         "items": [
           {
             "key": "translatedFrom[]",
-            "title": "Translated from"
+            "title": "Translated from",
+            "validationMessages": {
+              "minLength": "Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for English."
+            }
           }
         ]
       }
@@ -2323,7 +2329,10 @@
                 "key": "identifiedBy[].value"
               },
               {
-                "key": "identifiedBy[].status"
+                "key": "identifiedBy[].status",
+                "validationMessages": {
+                  "enum": "ISBN/ISSN status should be selected in the list below."
+                }
               },
               {
                 "key": "identifiedBy[].qualifier"

--- a/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
+++ b/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
@@ -26,7 +26,6 @@
     "name": {
       "title": "Name",
       "description": "Required. Name of the organisation.",
-      "validationMessage": "Required. Name of the organisation.",
       "type": "string",
       "minLength": 1
     },

--- a/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/form_patrons/patron-v0.0.1.json
@@ -12,7 +12,10 @@
       },
       {
         "key": "birth_date",
-        "description": "Use the selector or simply type in the input field."
+        "description": "Use the selector or simply type in the input field.",
+        "validationMessage": {
+          "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
+        }
       }
     ]
   },
@@ -25,7 +28,10 @@
       },
       {
         "key": "postal_code",
-        "htmlClass": "flex-shrink-1 mr-2"
+        "htmlClass": "flex-shrink-1 mr-2",
+        "validationMessage": {
+          "minLength": "A valid postal code with a min of 4 characters."
+        }
       },
       {
         "key": "city"
@@ -38,7 +44,13 @@
     "items": [
       {
         "key": "email",
-        "htmlClass": "mr-2"
+        "htmlClass": "mr-2",
+        "validationMessage": {
+          "required": "Is required",
+          "minLength": "A valid email address with a min of 6 characters.",
+          "pattern": "Email should have at least one <code>@</code> and one <code>.</code>",
+          "format": "Email should have at least one <code>@</code> and one <code>.</code>"
+        }
       },
       {
         "key": "phone",

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -27,13 +27,11 @@
     },
     "first_name": {
       "title": "First name",
-      "validationMessage": "First Name is required.",
       "type": "string",
       "minLength": 2
     },
     "last_name": {
       "title": "Last name",
-      "validationMessage": "Last Name is required.",
       "type": "string",
       "minLength": 2
     },
@@ -41,35 +39,30 @@
       "title": "Date of birth",
       "type": "string",
       "format": "date",
-      "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
-      "validationMessage": "Required. Should be in the ISO 8601, YYYY-MM-DD."
+      "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$"
     },
     "email": {
       "title": "Email",
       "type": "string",
       "format": "email",
       "pattern": "^.*@.*\\..*$",
-      "minLength": 6,
-      "validationMessage": "Email should have at least one <code>@</code> and one <code>.</code>"
+      "minLength": 6
     },
     "street": {
       "title": "Street",
       "description": "Street and number of the address, separated by a coma.",
       "type": "string",
-      "minLength": 3,
-      "validationMessage": "Required."
+      "minLength": 3
     },
     "postal_code": {
       "title": "Postal code",
       "type": "string",
-      "minLength": 4,
-      "validationMessage": "Required. A valid postal code with a min of 4 characters."
+      "minLength": 4
     },
     "city": {
       "title": "City",
       "type": "string",
-      "minLength": 3,
-      "validationMessage": "Required."
+      "minLength": 3
     },
     "phone": {
       "title": "Phone number",


### PR DESCRIPTION
* Moves 'validationMessages' strings from resource schemas to corresponding JSON form schema
* Closes #605

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- https://github.com/rero/rero-ils/issues/605

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
