### PR TITLE
circulation policy: ignore settings when deleting a policy

### DIFF
--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -208,9 +208,6 @@ class CircPolicy(IlsRecord):
         is_default = self.get('is_default')
         if is_default:
             others['is_default'] = is_default
-        has_settings = self.get('settings')
-        if has_settings:
-            others['has_settings'] = has_settings
         return others
 
     def get_links_to_me(self):

--- a/tests/api/test_circ_policies_rest.py
+++ b/tests/api/test_circ_policies_rest.py
@@ -308,12 +308,11 @@ def test_circ_policy_secure_api_delete(client,
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_short_martigny.pid)
 
-    with pytest.raises(IlsRecordError.NotDeleted):
-        res = client.delete(record_url)
-        assert res.status_code == 200
+    res = client.delete(record_url)
+    assert res.status_code == 204
 
     # Sion
     login_user_via_session(client, librarian_sion_no_email.user)
 
     res = client.delete(record_url)
-    assert res.status_code == 403
+    assert res.status_code == 410

--- a/tests/ui/circ_policies/test_circ_policies_api.py
+++ b/tests/ui/circ_policies/test_circ_policies_api.py
@@ -111,8 +111,7 @@ def test_circ_policy_can_not_delete(circ_policy_default_martigny,
 
     others = circ_policy_short_martigny.reasons_to_keep()
     assert 'is_default' not in others
-    assert not circ_policy_short_martigny.can_delete
-    assert others['has_settings']
+    assert circ_policy_short_martigny.can_delete
 
 
 def test_circ_policy_can_delete(app, circ_policy_martigny_data_tmp):


### PR DESCRIPTION
* Fixes an issue when cipo settings blocked its deletion.
* Closes rero/rero-ils-ui#76

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/task/1215?kanban-status=1224894

## How to test?

- create a new circulation policy with settings.
- you should be able to delete it.


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
