### PR TITLE
fees: create direct link to fee record from the loan pid

### DIFF
--- a/data/loans.json
+++ b/data/loans.json
@@ -3,6 +3,7 @@
     "barcode": "reroils1",
     "loans": {
       "active": 2,
+      "overdue": 1,
       "requested_by_others": 2
     },
     "requests": {
@@ -13,7 +14,8 @@
   {
     "barcode": "2000000001",
     "loans": {
-      "active": 1
+      "active": 1,
+      "overdue": 1
     },
     "requests": {
       "requests": 1
@@ -22,7 +24,8 @@
   {
     "barcode": "10000001",
     "loans": {
-      "active": 2
+      "active": 2,
+      "overdue": 1
     },
     "requests": {
       "requests": 1
@@ -40,7 +43,8 @@
   {
     "barcode": "kad001",
     "loans": {
-      "active": 1
+      "active": 1,
+      "overdue": 1
     },
     "requests": {
       "requests": 1
@@ -49,7 +53,8 @@
   {
     "barcode": "kad002",
     "loans": {
-      "active": 1
+      "active": 1,
+      "overdue": 1
     },
     "requests": {
       "requests": 1
@@ -285,6 +290,18 @@
     "requests": {
       "rank_1": 1,
       "requests": 1
+    }
+  },
+  {
+    "barcode": "999999",
+    "loans": {
+      "active": 1,
+      "overdue": 1,
+      "requested_by_others": 1
+    },
+    "requests": {
+      "rank_1": 1,
+      "rank_2": 1
     }
   }
 ]

--- a/data/users.json
+++ b/data/users.json
@@ -939,5 +939,26 @@
     "street": "Lungolago 118",
     "communication_channel": "email",
     "communication_language": "ita"
+  },
+  {
+    "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",
+    "barcode": "999999",
+    "birth_date": "1970-01-01",
+    "city": "Flueli-Ranft",
+    "email": "reroilstest+guillaumeB@gmail.com",
+    "first_name": "Guillaume",
+    "roles": [
+      "patron"
+    ],
+    "last_name": "de Baskerville",
+    "password": "123456",
+    "patron_type": {
+      "$ref": "https://ils.rero.ch/api/patron_types/5"
+    },
+    "phone": "+41324993585",
+    "postal_code": "6073",
+    "street": "Ranftweg 1",
+    "communication_channel": "email",
+    "communication_language": "eng"
   }
 ]

--- a/rero_ils/modules/fees/jsonschemas/fees/fee-v0.0.1.json
+++ b/rero_ils/modules/fees/jsonschemas/fees/fee-v0.0.1.json
@@ -11,7 +11,6 @@
     "fee_type",
     "location",
     "amount",
-    "currency",
     "status"
   ],
   "properties": {
@@ -63,15 +62,6 @@
     "amount": {
       "type": "number",
       "title": "Fee amount"
-    },
-    "currency": {
-      "type": "string",
-      "title": "Fee currency",
-      "enum": [
-        "CHF",
-        "EUR",
-        "USD"
-      ]
     },
     "status": {
       "type": "string",

--- a/rero_ils/modules/fees/listener.py
+++ b/rero_ils/modules/fees/listener.py
@@ -35,3 +35,11 @@ def enrich_fee_data(sender, json=None, record=None, index=None,
         json['organisation'] = {
             'pid': org_pid
         }
+        if fee.loan_pid:
+            json['loan'] = {
+                'pid': fee.loan_pid
+            }
+        if fee.patron_pid:
+            json['patron'] = {
+                'pid': fee.patron_pid
+            }

--- a/rero_ils/modules/fees/mappings/v6/fees/fee-v0.0.1.json
+++ b/rero_ils/modules/fees/mappings/v6/fees/fee-v0.0.1.json
@@ -44,6 +44,20 @@
         "status": {
           "type": "keyword"
         },
+        "loan": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "patron": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
         "_created": {
           "type": "date"
         },

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -323,18 +323,3 @@ def get_overdue_loans():
         if now > due_date + timedelta(days=days_after):
             overdue_loans.append(loan)
     return overdue_loans
-
-
-def get_item_on_loan_loans():
-    """Return item on loan."""
-    item_on_loan_loans = []
-    results = current_circulation.loan_search\
-        .source(['pid'])\
-        .params(preserve_order=True)\
-        .filter('term', state='ITEM_ON_LOAN')\
-        .sort({'transaction_date': {'order': 'asc'}})\
-        .scan()
-    for record in results:
-        loan = Loan.get_record_by_pid(record.pid)
-        item_on_loan_loans.append(loan)
-    return item_on_loan_loans

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -31,7 +31,7 @@ from invenio_circulation.api import get_loan_for_item
 from ..circ_policies.api import CircPolicy
 from ..items.api import Item, ItemsSearch, ItemStatus
 from ..libraries.api import Library
-from ..loans.api import get_item_on_loan_loans
+from ..loans.api import Loan
 from ..locations.api import Location
 from ..notifications.tasks import create_over_and_due_soon_notifications
 from ..patron_types.api import PatronType
@@ -39,12 +39,11 @@ from ..patrons.api import Patron, PatronsSearch
 
 
 @click.command('create_loans')
-@click.option('-f', '--fee', 'fee', is_flag=True, default=False)
 @click.option('-v', '--verbose', 'verbose', is_flag=True, default=False)
 @click.option('-d', '--debug', 'debug', is_flag=True, default=False)
 @click.argument('infile', type=click.File('r'))
 @with_appcontext
-def create_loans(infile, fee, verbose, debug):
+def create_loans(infile, verbose, debug):
     """Create circulation transactions.
 
     infile: Json transactions file
@@ -115,17 +114,8 @@ def create_loans(infile, fee, verbose, debug):
                                               loanable_items, verbose, debug)
                 errors_count = print_message(item_barcode, 'rank_2',
                                              errors_count)
-    if fee:
-        loan = get_item_on_loan_loans()[0]
-
-        end_date = datetime.now(timezone.utc) - timedelta(days=7)
-        loan['end_date'] = end_date.isoformat()
-        loan.update(
-            loan,
-            dbcommit=True,
-            reindex=True
-        )
-        create_over_and_due_soon_notifications()
+    # create due soon notifications, overdue notifications are auto created.
+    create_over_and_due_soon_notifications(overdue=False)
     for key, val in errors_count.items():
         click.secho(
             'Errors {transaction_type}: {count}'.format(
@@ -172,9 +162,20 @@ def create_loan(barcode, transaction_type, loanable_items, verbose=False,
             document_pid=item.replace_refs()['document']['pid'],
             item_pid=item.pid,
         )
-        if transaction_type == 'extended':
-            loan = get_loan_for_item(item.pid)
-            loan_pid = loan.get('pid')
+        loan = get_loan_for_item(item.pid)
+        loan_pid = loan.get('pid')
+        if transaction_type == 'overdue':
+            loan = Loan.get_record_by_pid(loan_pid)
+            end_date = datetime.now(timezone.utc) - timedelta(days=70)
+            loan['end_date'] = end_date.isoformat()
+            loan.update(
+                loan,
+                dbcommit=True,
+                reindex=True
+            )
+            notif = loan.create_notification(notification_type='overdue')
+
+        elif transaction_type == 'extended':
             user_pid, user_location = \
                 get_random_librarian_and_transaction_location(patron)
             item.extend_loan(

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -25,19 +25,21 @@ from ..loans.api import get_due_soon_loans, get_overdue_loans
 
 
 @shared_task(ignore_result=True)
-def create_over_and_due_soon_notifications():
+def create_over_and_due_soon_notifications(overdue=True, due_soon=True):
     """Creates due_soon and overdue notifications."""
-    over_due_loans = get_overdue_loans()
     no_over_due_loans = 0
-    for loan in over_due_loans:
-        loan.create_notification(notification_type='overdue')
-        no_over_due_loans += 1
-
-    due_soon_loans = get_due_soon_loans()
     no_due_soon_loans = 0
-    for loan in due_soon_loans:
-        loan.create_notification(notification_type='due_soon')
-        no_due_soon_loans += 1
+    if overdue:
+        over_due_loans = get_overdue_loans()
+
+        for loan in over_due_loans:
+            loan.create_notification(notification_type='overdue')
+            no_over_due_loans += 1
+    if due_soon:
+        due_soon_loans = get_due_soon_loans()
+        for loan in due_soon_loans:
+            loan.create_notification(notification_type='due_soon')
+            no_due_soon_loans += 1
 
     return 'created {no_over_due_loans} overdue loans, '\
         '{no_due_soon_loans} due soon loans'.format(

--- a/scripts/setup
+++ b/scripts/setup
@@ -290,7 +290,7 @@ eval ${PREFIX} pipenv run invenio utils runindex -c 4 --raise-on-error
 
 # create circulation transactions
 info_msg "Circulation transactions:"
-eval ${PREFIX} pipenv run invenio fixtures create_loans --fee ${DATA_PATH}/loans.json
+eval ${PREFIX} pipenv run invenio fixtures create_loans ${DATA_PATH}/loans.json
 
 # # OAI configuration
 info_msg "OAI configuration:"

--- a/tests/api/test_fees.py
+++ b/tests/api/test_fees.py
@@ -34,7 +34,7 @@ def test_create_fee(client, librarian_martigny_no_email,
                     patron_martigny_no_email, loc_public_martigny,
                     item_type_standard_martigny,
                     item_lib_martigny, json_header,
-                    circ_policy_short_martigny):
+                    circ_policy_short_martigny, org_martigny):
     """Test overdue loans."""
     login_user_via_session(client, librarian_martigny_no_email.user)
 
@@ -68,7 +68,7 @@ def test_create_fee(client, librarian_martigny_no_email,
 
     fee = list(notification.fees)[0]
     assert fee.get('amount') == 2
-    assert fee.get('currency') == 'CHF'
+    assert fee.currency == org_martigny.get('default_currency')
 
     fee_url = url_for('invenio_records_rest.fee_item', pid_value=fee.pid)
 
@@ -132,7 +132,7 @@ def test_create_fee_euro(client, librarian_martigny_no_email,
     flush_index(NotificationsSearch.Meta.index)
     flush_index(LoansSearch.Meta.index)
     fee = list(notification.fees)[0]
-    assert fee.get('currency') == org.get('default_currency')
+    assert fee.currency == org.get('default_currency')
 
 
 def test_filtered_fees_get(

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -136,6 +136,8 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
     item_pid = item.pid
     patron_pid = patron_martigny_no_email.pid
 
+    assert not get_last_transaction_loc_for_item(item_pid)
+
     assert not item.is_loaned_to_patron(patron_martigny_no_email.get(
         'barcode'))
     assert item.can_delete
@@ -170,6 +172,9 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
     assert due_soon_loans[0].get('pid') == loan_pid
 
     # test due date hour, should be 22:59 UTC+0 (Europe/Zurich)
+    assert get_last_transaction_loc_for_item(
+        item_pid) == loc_public_martigny.pid
+    # test due date hour
     checkout_loan = Loan.get_record_by_pid(loan_pid)
     end_date = ciso8601.parse_datetime(
         checkout_loan.get('end_date'))

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1914,7 +1914,6 @@
       "$ref": "https://ils.rero.ch/api/locations/loc1"
     },
     "amount": 0.5,
-    "currency": "CHF",
     "status": "open"
   }
 }


### PR DESCRIPTION
* Adds loan.pid and organisation.currency to the resource fee es index.
* Fixes units testing problem with overdue fees creation.
* Increases fees unit testing fixtures and third organisation fixtures.
* Removes currency field from resource fee.
* Remove the option --fee from the loan creation cli.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/task/1231?kanban-status=1224894

## How to test?
- `./script/setup`
- The `fee` es index has a new fields called `loan.pid` and `currency`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
