### PR TITLE
script: add rero-ils-ui install from tgz

### DIFF
--- a/rero_ils/bundles.py
+++ b/rero_ils/bundles.py
@@ -26,6 +26,9 @@ from invenio_assets import AngularGettextFilter, GlobBundle, LazyNpmBundle, \
 from pkg_resources import resource_filename
 
 
+RERO_ILS_UI_VERSION = '0.0.9'
+
+
 def catalog(domain):
     """Return glob matching path to tranlated messages for a given domain."""
     return os.path.join(
@@ -77,7 +80,7 @@ admin_ui_js = NpmBundle(
     'node_modules/@rero/rero-ils-ui/dist/admin/main.*.js',
     output='gen/rero_ils_admin_ui.%(version)s.js',
     npm={
-        '@rero/rero-ils-ui': '0.0.9'
+        '@rero/rero-ils-ui': '~{version}'.format(version=RERO_ILS_UI_VERSION)
     }
 )
 
@@ -89,7 +92,7 @@ public_search_ui_js = NpmBundle(
     'node_modules/@rero/rero-ils-ui/dist/public-search/main.*.js',
     output='gen/rero_ils_public-search_ui.%(version)s.js',
     npm={
-        '@rero/rero-ils-ui': '0.0.9'
+        '@rero/rero-ils-ui': '~{version}'.format(version=RERO_ILS_UI_VERSION)
     }
 )
 
@@ -98,6 +101,6 @@ search_bar_ui_js = NpmBundle(
     'node_modules/@rero/rero-ils-ui/dist/search-bar/main.*.js',
     output='gen/rero_ils_search-bar_ui.%(version)s.js',
     npm={
-        '@rero/rero-ils-ui': '0.0.9'
+        '@rero/rero-ils-ui': '~{version}'.format(version=RERO_ILS_UI_VERSION)
     }
 )

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -57,29 +57,41 @@ success_msg() {
 # Displays program name
 msg "PROGRAM: ${PROGRAM}"
 
-# The real bootstrap script starts 20 lines below ;-)
+# options may be followed by one colon to indicate they have a required argument
+if ! options=$(getopt -o dsb -l -t deploy,ci,tgz_path: -- "$@")
+then
+    # something went wrong, getopt will put out an error message for us
+    exit 1
+fi
+
+# The real bootstrap script starts with app installation below ;-)
 flags=()
 deploy=false
 cmd="pipenv sync"
 ci=false
-while test $# -gt 0; do
-    case "$1" in
-        --deploy)
-            # We are probably inside travis, check for env variables
-            deploy=true
-            shift
-            ;;
-        --ci)
-            # We are probably inside travis, check for env variables
-            ci=true
-            shift
-            ;;
-        *)
-            # Use the flags that are passed to the script directly to install
-            flags+=("$1")
-            shift
-            ;;
-    esac
+TGZ_PATH=""
+while test $# -gt 0
+do
+  case "$1" in
+    -d|--deploy)
+      # We are probably inside travis, check for env variables
+      deploy=true ;;
+    -c|--ci)
+      # We are probably inside travis, check for env variables
+      ci=true ;;
+    -t|--tgz_path)
+      TGZ_PATH=$2
+      if [ -z $2 ]
+        then
+          error_msg+exit "Please give path to .tgz"
+        else
+          TGZ_PATH=$2
+        fi ;;
+    (--) shift; break;;
+    (-*) flags+=("$1") ;;
+    (*) break;;
+  esac
+  shift
 done
 
 if ! $deploy || $ci ; then
@@ -95,6 +107,7 @@ fi
 # go generate a clean lock file
 # pipenv --rm; pipenv install --sequential
 
+# BOOTSTRAP START
 # install the application and all the dependencies
 info_msg "Install with command: ${cmd} ${flags[@]}"
 ${cmd} ${flags[@]}
@@ -119,6 +132,11 @@ info_msg "Search static folder location"
 static_folder=$(pipenv run invenio shell --no-term-title -c "print('static_folder:%s' % app.static_folder)"|grep static_folder| cut -d: -f2-)
 info_msg "Install static folder npm dependencies in: ${static_folder}"
 pipenv run npm install --prefix "${static_folder}"
+if [ ! -d $TGZ_PATH ]
+then
+  info_msg "Install RERO-ILS-UI from tgz"
+  pipenv run npm install "${TGZ_PATH}" --prefix "${static_folder}"
+fi
 
 # build the web assets
 info_msg "Build web assets: collect"


### PR DESCRIPTION
* Updates bootstrap script to install rero-ils-ui from .tgz if needed.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To simplify rero-ils-ui integration from PR.
To allow its deployment.

## How to test?

1. In RERO-ILS-UI
* `npm run pack`
* Copy path/to/rero-rero-ils-ui-0.0.x.tgz

2. In RERO-ILS
* Go to static folder of invenio instance
* `npm install @rero/rero-ils-ui@latest`
* OPTIONAL: `cat package.json`
* OPTIONAL: You should see: `"@rero/rero-ils-ui": "0.0.8",` (or other latest version)
* Go back to rero-ils project folder
* `./scripts/bootstrap -t path/to/rero-rero-ils-ui-0.0.x.tgz`
* Go to static folder of invenio instance (again)
* `cat package.json`
* You should see: `"@rero/rero-ils-ui": "file:../../../rero-ils-ui/rero-rero-ils-ui-0.0.x.tgz",`

3. Check also `./scripts/bootstrap --deploy` and `./scripts/bootstrap --ci` behaviour

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
