### PR TITLE
ui: display a different logo/color for each orga.

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -153,6 +153,8 @@ THEME_TRACKINGCODE_TEMPLATE = 'rero_ils/trackingcode.html'
 THEME_JAVASCRIPT_TEMPLATE = 'rero_ils/javascript.html'
 #: Brand logo.
 THEME_LOGO = 'images/logo_rero_ils.png'
+# External CSS for each organisation customization
+RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT = 'https://resources.rero.ch/ils/test/css/'
 
 SEARCH_UI_JSTEMPLATE_RESULTS = (
     'templates/rero_ils/brief_view_documents.html'

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -101,7 +101,7 @@ def check_permission(fn):
 
 @api_blueprint.route('/cover/<isbn>')
 def cover(isbn):
-    """Documenet cover service."""
+    """Document cover service."""
     cover_service = current_app.config.get('RERO_ILS_THUMBNAIL_SERVICE_URL')
     url = cover_service + '?height=60px&jsonpCallbackParam=callback'\
                           '&type=isbn&width=60px&callback=thumb&value=' + isbn

--- a/rero_ils/templates/rero_ils/head.html
+++ b/rero_ils/templates/rero_ils/head.html
@@ -63,5 +63,6 @@
   {%- block header %}{% endblock header %}
   {%- block css %}
     {% assets "rero_ils_main_css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
+    <link href="{{ config.get('RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT') }}{{ viewcode }}.css" rel="stylesheet" title="{{ viewcode }}">
   {%- endblock css %}
 {%- endblock head %}

--- a/rero_ils/templates/rero_ils/header.html
+++ b/rero_ils/templates/rero_ils/header.html
@@ -26,11 +26,12 @@
             <div class="align-self-center d-flex w-100 justify-content-between">
               <a href="/{% if viewcode != config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE %}{{ viewcode }}{% endif %}" class="navbar-brand pr-2">
                 <img class="rero-ils-logo navbar-brand" src="{{ url_for('static', filename=config.THEME_LOGO)}}" alt="{{_(config.THEME_SITENAME)}} logo">
+                <div id="{{ viewcode }}-logo"></div>
               </a>
           {%- else %}
               <a href="/{% if viewcode != config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE %}{{ viewcode }}{% endif %}" class="navbar-brand">{{_(config.THEME_SITENAME)}}</a>
-            </div>
           {%- endif %}
+            </div>
         {%- endblock navbar_brand %}
 
         {%- block navbar_search %}

--- a/rero_ils/templates/rero_ils/page.html
+++ b/rero_ils/templates/rero_ils/page.html
@@ -23,7 +23,7 @@
       {% include 'rero_ils/head.html' %}
     {%- endblock head %}
   </head>
-  <body ng-csp {% if body_css_classes %} class="{{ body_css_classes|join(' ') }}" {% else %} class="d-flex flex-column" {% endif %}{% if g.ln %} lang="{{ g.ln.split('_', 1)[0]|safe }}"{% if rtl_direction %} {{ rtl_direction|safe }}{% endif %}{% endif %} itemscope itemtype="http://schema.org/WebPage" data-spy="scroll" data-target=".scrollspy-target">
+  <body ng-csp {% if body_css_classes %} class="{{ body_css_classes|join(' ') }}" {% else %} class="d-flex flex-column" {% endif %}{% if g.ln %} lang="{{ g.ln.split('_', 1)[0]|safe }}"{% if rtl_direction %} {{ rtl_direction|safe }}{% endif %}{% endif %} itemscope itemtype="http://schema.org/WebPage" data-spy="scroll" data-target=".scrollspy-target" {% if viewcode %}id="view-{{ viewcode }}"{% endif %}>
     {%- block outer_body %}
       {%- block browserupgrade %}
         <!--[if lt IE 8]>

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -87,6 +87,17 @@ def test_view_parameter_notfound(client):
     assert result.status_code == 404
 
 
+def test_external_endpoint_on_institution_homepage(client, org_martigny, app):
+    """Test external endpoint on institution homepage."""
+    result = client.get(url_for(
+        'rero_ils.index_with_view_code',
+        viewcode='org1'
+    ))
+    endpoint = app.config['RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT']
+    assert endpoint == "https://resources.rero.ch/ils/test/css/"
+    assert str(result.data).find(endpoint) > 1
+
+
 def test_help(client):
     """Test help entrypoint."""
     result = client.get(url_for('rero_ils.help'))


### PR DESCRIPTION
* Adds RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT configuration variable to gives a
way for each organisation to have a specific stylesheet

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

- It implements [US1200](https://tree.taiga.io/project/rero21-reroils/us/1200?milestone=252915)

## How to test?

1. Launch server
2. Go to each given URL:
  * https://localhost:5000/highlands/
  * https://localhost:5000/aoste/
  * https://localhost:5000/fictive/
  * https://localhost:5000/global/
3. Each URL should have a different logo and color in the header

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
