### PR TITLE
Paging (stack request) functionnalities

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -8,7 +8,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/1"
     },
     "is_pickup": true,
-    "pickup_name": "AOSTE CANT1: Espaces publics"
+    "pickup_name": "AOSTE CANT1: Espaces publics",
+    "allow_request": true
   },
   {
     "pid": "2",
@@ -17,7 +18,8 @@
     "name": "Bibliographie vald\u00f4taine",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/1"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "3",
@@ -26,7 +28,8 @@
     "name": "Magasin A",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/1"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "4",
@@ -37,7 +40,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/1"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   {
     "pid": "5",
@@ -48,7 +52,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/2"
     },
     "is_pickup": true,
-    "pickup_name": "AOSTE CANT2: Espaces publics"
+    "pickup_name": "AOSTE CANT2: Espaces publics",
+    "allow_request": true
   },
   {
     "pid": "7",
@@ -57,7 +62,8 @@
     "name": "Section fiction",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/3"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "8",
@@ -66,7 +72,8 @@
     "name": "Section documentaires",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/3"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "9",
@@ -75,7 +82,8 @@
     "name": "Section enfants",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/3"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "10",
@@ -84,7 +92,8 @@
     "name": "Section multim\u00e9dia",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/3"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "11",
@@ -95,7 +104,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/3"
     },
     "is_pickup": true,
-    "pickup_name": "AOSTE-AVISE-PUB: Espaces publics"
+    "pickup_name": "AOSTE-AVISE-PUB: Espaces publics",
+    "allow_request": true
   },
   {
     "pid": "12",
@@ -106,7 +116,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/3"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   {
     "pid": "13",
@@ -117,7 +128,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/4"
     },
     "is_pickup": true,
-    "pickup_name": "AOSTE-LYCEE: Espaces publics"
+    "pickup_name": "AOSTE-LYCEE: Espaces publics",
+    "allow_request": true
   },
   {
     "pid": "14",
@@ -126,7 +138,8 @@
     "name": "Travaux de maturit\u00e9",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/4"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "16",
@@ -135,7 +148,8 @@
     "name": "Restricted Section",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/5"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "17",
@@ -146,7 +160,8 @@
     "pickup_name": "Public Section",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/5"
-    }
+    },
+    "allow_request": true
   },
   {
     "pid": "18",
@@ -157,7 +172,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/5"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -169,7 +185,8 @@
     },
     "is_pickup": true,
     "pickup_name": "La Citadelle",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -181,7 +198,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Beast's Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -193,7 +211,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Dream's Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -205,7 +224,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Lux Foundation Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -217,7 +237,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Hogwarts Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -229,7 +250,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Biblioth\u00e8que de Babel",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -241,7 +263,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Biblioth\u00e8que de l\u2019abbaye",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -253,7 +276,8 @@
     },
     "is_pickup": true,
     "pickup_name": "The University's Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -265,7 +289,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Cemetery of Forgotten Books",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -277,7 +302,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Ministry of Truth",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -289,7 +315,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Rivendell Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -301,7 +328,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Matilda's Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -313,7 +341,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Unseen University Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -325,7 +354,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Wan Shi Tong's Library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -337,7 +367,8 @@
     },
     "is_pickup": true,
     "pickup_name": "Sunnydale High School library",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   },
   {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -349,6 +380,7 @@
     },
     "is_pickup": true,
     "pickup_name": "Jedi Archives",
-    "is_online": false
+    "is_online": false,
+    "allow_request": true
   }
 ]

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -55,6 +55,7 @@ from .modules.documents.api import Document
 from .modules.holdings.api import Holding
 from .modules.item_types.api import ItemType
 from .modules.items.api import Item
+from .modules.items.models import ItemCirculationAction
 from .modules.items.permissions import can_create_item_factory, \
     can_update_delete_item_factory
 from .modules.libraries.api import Library
@@ -1705,6 +1706,18 @@ CIRCULATION_POLICIES = dict(
         can_be_requested=can_be_requested
     )
 )
+
+CIRCULATION_ACTIONS_VALIDATION = {
+    ItemCirculationAction.REQUEST: [
+        Location.allow_request,
+        Item.can_request,
+        CircPolicy.allow_request,
+        Patron.can_request
+    ],
+    ItemCirculationAction.EXTEND: [
+        Item.can_extend
+    ]
+}
 
 WEBPACKEXT_PROJECT = 'rero_ils.webpack:project'
 

--- a/rero_ils/modules/items/models.py
+++ b/rero_ils/modules/items/models.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import
 
+from enum import Enum
+
 from invenio_db import db
 from invenio_pidstore.models import RecordIdentifier
 from invenio_records.models import RecordMetadataBase
@@ -52,3 +54,12 @@ class ItemStatus(object):
     IN_TRANSIT = 'in_transit'
     EXCLUDED = 'excluded'
     MISSING = 'missing'
+
+
+class ItemCirculationAction(Enum):
+    """Enum class to list all possible action about an item."""
+
+    CHECKOUT = 'checkout'
+    CHECKIN = 'checkin'
+    REQUEST = 'request'
+    EXTEND = 'extend'

--- a/rero_ils/modules/loans/cli.py
+++ b/rero_ils/modules/loans/cli.py
@@ -271,7 +271,7 @@ def create_loan(barcode, transaction_type, loanable_items, verbose=False,
                     transaction_user_pid=user_pid,
                     transaction_date=transaction_date,
                     pickup_location_pid=get_random_pickup_location(
-                        requested_patron.pid),
+                        requested_patron.pid, item),
                     document_pid=item.replace_refs()['document']['pid'],
                 )
                 loan.create_notification(notification_type='recall')
@@ -315,7 +315,7 @@ def create_request(barcode, transaction_type, loanable_items, verbose=False,
                     transaction_user_pid=user_pid,
                     transaction_date=transaction_date,
                     pickup_location_pid=get_random_pickup_location(
-                        rank_1_patron.pid),
+                        rank_1_patron.pid, item),
                     document_pid=item.replace_refs()['document']['pid'],
                 )
         transaction_date = datetime.now(timezone.utc).isoformat()
@@ -326,7 +326,7 @@ def create_request(barcode, transaction_type, loanable_items, verbose=False,
             transaction_location_pid=user_location,
             transaction_user_pid=user_pid,
             transaction_date=transaction_date,
-            pickup_location_pid=get_random_pickup_location(patron.pid),
+            pickup_location_pid=get_random_pickup_location(patron.pid, item),
             document_pid=item.replace_refs()['document']['pid'],
         )
         return item['barcode']
@@ -373,9 +373,12 @@ def get_loanable_items(patron_type_pid):
                         yield item
 
 
-def get_random_pickup_location(patron_pid):
+def get_random_pickup_location(patron_pid, item):
     """Find a qualified pickup location."""
-    pickup_locations_pids = list(Location.get_pickup_location_pids(patron_pid))
+    pickup_locations_pids = list(Location.get_pickup_location_pids(
+        patron_pid=patron_pid,
+        item_pid=item.pid
+    ))
     return random.choice(pickup_locations_pids)
 
 

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -9,14 +9,19 @@
     "pid",
     "code",
     "name",
-    "library"
+    "library",
+    "allow_request"
   ],
   "propertiesOrder": [
     "name",
     "code",
     "is_online",
     "is_pickup",
-    "pickup_name"
+    "pickup_name",
+    "allow_request",
+    "send_notification",
+    "notification_email",
+    "restrict_pickup_to"
   ],
   "properties": {
     "$schema": {
@@ -125,6 +130,85 @@
           "title": "Library URI",
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/libraries/.*?$"
+        }
+      }
+    },
+    "allow_request": {
+      "title": "Allow request",
+      "type": "boolean",
+      "description": "If enabled, it allows requests for items linked to this location.",
+      "default": true
+    },
+    "send_notification": {
+      "title": "Send notification",
+      "description": "Send a email notification when an item of the location has been requested.",
+      "type": "boolean",
+      "default": false,
+      "form": {
+        "hideExpression": "model.allow_request === false",
+        "expressionProperties": {
+          "templateOptions.required": "model.allow_request === true"
+        }
+      }
+    },
+    "notification_email": {
+      "title": "Notification email",
+      "description": "Specify a generic email address used for notification.",
+      "type": "string",
+      "format": "email",
+      "pattern": "^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,})+$",
+      "minLength": 6,
+      "form": {
+        "hideExpression": "model.allow_request === false || model.send_notification === false",
+        "expressionProperties": {
+          "templateOptions.required": "model.send_notification === true && model.allow_request === true"
+        },
+        "templateOptions": {
+          "addonLeft": {
+            "class": "fa fa-at"
+          }
+        },
+        "validation": {
+          "messages": {
+            "pattern": "Email should have at least one <code>@</code> and one <code>.</code>"
+          }
+        }
+      }
+    },
+    "restrict_pickup_to": {
+      "title": "Restrict pickup to",
+      "description": "Select locations where items linked to the current location could be requested.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "title": "Location",
+        "properties": {
+          "$ref": {
+            "title": "Location URI",
+            "type": "string",
+            "pattern": "^https://ils.rero.ch/api/locations/.*?$",
+            "form": {
+              "remoteOptions": {
+                "type": "locations",
+                "query": "is_pickup:true",
+                "labelField": "pickup_name"
+              }
+            }
+          }
+        }
+      },
+      "form": {
+        "wrappers": [
+          "toggle-switch"
+        ],
+        "templateOptions": {
+          "label": "",
+          "toggle-switch": {
+            "label": "Restrict pickup to",
+            "description": "If enabled, restrict pickup to specific pickup locations."
+          }
         }
       }
     }

--- a/rero_ils/modules/locations/mappings/v6/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/mappings/v6/locations/location-v0.0.1.json
@@ -44,6 +44,19 @@
             }
           }
         },
+        "notification_email": {
+          "type": "keyword"
+        },
+        "allow_request": {
+          "type": "boolean"
+        },
+        "restrict_pickup_to": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
         "_created": {
           "type": "date"
         },

--- a/rero_ils/modules/notifications/dispatcher.py
+++ b/rero_ils/modules/notifications/dispatcher.py
@@ -26,46 +26,44 @@ from invenio_mail.tasks import send_email as task_send_email
 from ..locations.api import Location
 
 
-class Dispatcher():
+class Dispatcher:
     """Dispatcher notifications class."""
-
-    def __init__(self):
-        """Init dispatcher."""
-        self.channels_function = {
-            'email': self.send_email,
-            'sms': self.send_sms,
-            'whatsapp': self.send_whatsapp,
-            'mail': self.send_mail
-        }
 
     def dispatch_notification(self, notification=None, verbose=False):
         """Dispatch the notification."""
+
+        def not_yet_implemented(*args):
+            """Do nothing placeholder for a notification."""
+            return
+
         if notification:
             data = notification.replace_pids_and_refs()
-            communication_channel = \
-                data['loan']['patron']['communication_channel']
-            if communication_channel not in self.channels_function:
-                raise ValueError(
-                    'Unknown communication channel: {channel}'.format(
-                        channel=communication_channel
-                    )
-                )
-            # call the function from channels_function
-            self.channels_function.get(communication_channel)(data)
+            communication_switcher = {
+                'email': Dispatcher.send_mail,
+                #  'sms': not_yet_implemented
+                #  'telepathy': self.madness_mind
+                #  ...
+            }
+            dispatcher_function = communication_switcher.get(
+                data['loan']['patron']['communication_channel'],
+                not_yet_implemented
+            )
+            dispatcher_function(data)
             notification = notification.update_process_date()
             if verbose:
                 current_app.logger.info(
                     ('Notification: {pid} chanel: {chanel} type:'
                      '{type} loan: {lpid}').format(
                         pid=notification['pid'],
-                        chanel=communication_channel,
+                        chanel=data['loan']['patron']['communication_channel'],
                         type=notification['notification_type'],
                         lpid=data['loan']['pid']
                     )
                 )
         return notification
 
-    def send_email(self, data):
+    @staticmethod
+    def send_mail(data):
         """Send the notification by email."""
         notification_type = data.get('notification_type')
         language = data['loan']['patron']['communication_language']
@@ -89,19 +87,4 @@ class Dispatcher():
         text = msg.body.split('\n')
         msg.subject = text[0]
         msg.body = '\n'.join(text[1:])
-        try:
-            task_send_email.run(msg.__dict__)
-        except Exception as error:
-            raise(error)
-
-    def send_sms(self, data):
-        """Send the notification by sms."""
-        # TODO: add send sms code
-
-    def send_whatsapp(self, data):
-        """Send the notification by whatsapp."""
-        # TODO: add send whatsapp code
-
-    def send_mail(self, data):
-        """Send the notification by mail."""
-        # TODO: add send mail code
+        task_send_email.run(msg.__dict__)

--- a/rero_ils/modules/notifications/templates/email/others/location_notification.txt
+++ b/rero_ils/modules/notifications/templates/email/others/location_notification.txt
@@ -1,0 +1,14 @@
+The item [{{ item.barcode }}] has been requested
+An item has been requested. See below for information about this item.
+
+Pickup location  : {{ pickup_location.library.name }} -- {{ pickup_location.name }}
+Request date     : {{ loan.transaction_date }}
+Item barcode     : {{ item.barcode }}
+Item call number : {{ item.call_number }}
+Item type        : {{ item.item_type.name }}
+Document title   : {{ document.title_text }} / {{ document.responsibility_statement }}
+
+
+Patron name      : {{ patron.formatted_name }}
+Patron email     : {{ patron.email }}
+Patron barcode   : {{ patron.get('barcode') }}

--- a/rero_ils/modules/notifications/utils.py
+++ b/rero_ils/modules/notifications/utils.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Notification utils."""
+from datetime import timezone
+
+import ciso8601
+from flask_security.utils import config_value
+from invenio_mail.api import TemplatedMessage
+from invenio_mail.tasks import send_email
+
+from rero_ils.modules.documents.api import Document
+from rero_ils.modules.documents.views import create_title_responsibilites
+from rero_ils.modules.item_types.api import ItemType
+from rero_ils.modules.items.api import Item
+from rero_ils.modules.locations.api import Location
+from rero_ils.modules.patrons.api import Patron
+
+
+def _build_notification_email_context(loan, item, location):
+    """Build the context used by the send_notification_to_location function.
+
+    :param loan : the loan for which build context
+    :param item : the item for which build context
+    :param location : the item location
+    """
+    document_pid = Item.get_document_pid_by_item_pid(loan.item_pid)
+    document = Document.get_record_by_pid(document_pid)
+    pickup_location = Location.get_record_by_pid(
+        loan.get('pickup_location_pid')
+    )
+    patron = Patron.get_record_by_pid(loan.patron_pid)
+    ctx = {
+        'loan': loan.replace_refs().dumps(),
+        'item': item.replace_refs().dumps(),
+        'document': document.replace_refs().dumps(),
+        'pickup_location': pickup_location,
+        'item_location': location.dumps(),
+        'patron': patron
+    }
+    library = pickup_location.get_library()
+    ctx['pickup_location']['library'] = library
+    ctx['item']['item_type'] = \
+        ItemType.get_record_by_pid(item.item_type_pid)
+    titles = [title for title in ctx['document'].get('title', [])
+              if title['type'] == 'bf:Title']
+    ctx['document']['title_text'] = \
+        next(iter(titles or []), {}).get('_text')
+    responsibility_statement = create_title_responsibilites(
+        document.get('responsibilityStatement', [])
+    )
+    ctx['document']['responsibility_statement'] = \
+        next(iter(responsibility_statement or []), '')
+    trans_date = ciso8601.parse_datetime(loan.get('transaction_date'))
+    trans_date = trans_date\
+        .replace(tzinfo=timezone.utc)\
+        .astimezone(tz=library.get_timezone())
+    ctx['loan']['transaction_date'] = \
+        trans_date.strftime("%d.%m.%Y - %H:%M:%S")
+    return ctx
+
+
+def send_notification_to_location(loan, item, location):
+    """Send a notification to the location defined email.
+
+    :param loan: the loan to be parsed
+    :param item: the requested item
+    :param location: the location to inform
+    """
+    if not location.get('send_notification', False) \
+            or not location.get('notification_email'):
+        return
+    template = 'email/others/location_notification.txt'
+    recipient = location.get('notification_email')
+    msg = TemplatedMessage(
+        template_body=template,
+        sender=config_value('EMAIL_SENDER'),
+        recipients=[recipient],
+        ctx=_build_notification_email_context(loan, item, location)
+    )
+    text = msg.body.split('\n')
+    msg.subject = text[0]
+    msg.body = '\n'.join(text[1:])
+    send_email.run(msg.__dict__)

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -22,84 +22,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "الفرنسية"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "الألمانية"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "الايطالية"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "مرحباً بك في RERO-ILS"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "تصنبف المستند"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "الشبكة"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "المكتبة"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "اللغة"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "الموضوع"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "الحالة"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "مهام"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "الميزانية"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "المصادر"
 
@@ -286,13 +286,13 @@ msgstr "مخطط JSON للحساب"
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -316,7 +316,7 @@ msgstr "رقم الحساب"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -366,9 +366,9 @@ msgstr "المبلغ المخصص لحساب التزويد"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "مكتبة"
@@ -377,9 +377,9 @@ msgstr "مكتبة"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "URI للمكتبة"
 
@@ -566,7 +566,7 @@ msgstr "مختلفة"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "المبلغ"
 
@@ -895,7 +895,7 @@ msgid "Patron + Item types links"
 msgstr "روابط تصنيفات المستخدم + النسخة"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "تصنيف المستخدم"
 
@@ -912,21 +912,21 @@ msgid "Item type URI"
 msgstr "URI لتصنيف النسخة"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "متاح"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "غيرمتاح"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "مستحق الى"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "مطلوب"
 
@@ -6421,12 +6421,12 @@ msgstr "اختيار مكان الإستلام"
 msgid "Export Formats"
 msgstr "تنسيقات التصدير"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "مقتنيات"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "مخطط JSON لتدقيق تسجيلات المقتنيات"
 
@@ -6457,11 +6457,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "مكان"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "URI للمكان"
 
@@ -6616,7 +6618,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "باركود"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "يوجد تصنيف نسخة آخر في هذه الشبكة"
@@ -6728,7 +6730,7 @@ msgid "JSON schema for a library"
 msgstr "مخطط JSON للمكتبة"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6741,7 +6743,7 @@ msgid "Library ID"
 msgstr "رقم المكتبة"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "رمز"
@@ -6897,11 +6899,11 @@ msgid ""
 "state"
 msgstr "اسم الإجراء الصريح الذي أدى إلى الانتقال إلى الحالة الحالية"
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "يوجد مكان مباشر آخر في هذه المكتبة"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "مكان الإستلام إجباري"
 
@@ -6909,57 +6911,100 @@ msgstr "مكان الإستلام إجباري"
 msgid "JSON schema for an location"
 msgstr "مخطط JSON للمكان"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "رقم المكان"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "رمز المكان"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "الرمز مأخوذ بالفعل."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "إسم المكان"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "هل مكان إستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "تحديد المكان كمكان إستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "هل مكان مباشر"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "تحديد المكان كمكان مباشر"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr "يوجد مكان مباشر آخر في هذه المكتبة"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "إسم مكان الإستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr "إسم مكان الإستلام إذا كان مختلف عن إسم المكان."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
 msgstr "اسم مكان الإستلام محجوز"
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
+msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:73
@@ -7067,7 +7112,7 @@ msgstr "مصدر مباشر محصود"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "مصدر مباشر محصود كما تم اعداده للكتاب الالكتروني"
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7092,7 +7137,7 @@ msgid "Parent patron transaction"
 msgstr "اصل معاملة المستخدم"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "URI لمعاملة المستخدم"
 
@@ -7112,7 +7157,7 @@ msgstr "أمين المكتبة"
 msgid "Operator patron URI"
 msgstr "URI لأمين المكتبة"
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7189,15 +7234,15 @@ msgstr "اسم تصنيف المستخدم محجوز"
 msgid "The description of the patron type."
 msgstr "وصف تصنيف المستخدم"
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7230,6 +7275,11 @@ msgstr "خطأ في تجديد النسخة %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7314,8 +7364,8 @@ msgstr "تصنيف المستخدم"
 msgid "Patron type in terms of circulation policy."
 msgstr "تصنيف المستخدم لسياسة الإعارة "
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "URI ل تصنيف مستخدم"
 
@@ -7369,49 +7419,49 @@ msgstr "لغة الاتصال"
 msgid "English"
 msgstr "الانجليزية"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Peter Weber <peter.weber@rero.ch>, 2020\n"
 "Language: de\n"
@@ -27,84 +27,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Französisch"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Deutsch"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italienisch"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "Willkommen zu RERO ILS!"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "Dokumenttyp"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "Bibliothek"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "Autor"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "Autor"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "Autor"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "Autor"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "Sprache"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "Schlagwort"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "Status"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "Rollen"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "Budget"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "Quellen"
 
@@ -291,13 +291,13 @@ msgstr "JSON Schema für Konto"
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -321,7 +321,7 @@ msgstr "ID  des Kontos"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -371,9 +371,9 @@ msgstr "Zugewiesener Betrag"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "Bibliothek"
@@ -382,9 +382,9 @@ msgstr "Bibliothek"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "URI der Bibliothek"
 
@@ -571,7 +571,7 @@ msgstr "Sonstiges"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Betrag"
 
@@ -902,7 +902,7 @@ msgid "Patron + Item types links"
 msgstr "Links Lesertypen + Exemplartypen"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "Lesertyp"
 
@@ -919,21 +919,21 @@ msgid "Item type URI"
 msgstr "URI des Exemplartypen"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "verfügbar"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "nicht verfügbar"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "Fällig am"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "Bestellt"
 
@@ -6443,12 +6443,12 @@ msgstr "Abholort wählen"
 msgid "Export Formats"
 msgstr "Exportformate"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "Bestand"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "JSON Schema für einen Bestand."
 
@@ -6479,11 +6479,13 @@ msgstr "URI der Ausleihkategorie"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "Standort"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "URI des Standortes"
 
@@ -6653,7 +6655,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "Strichcode"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Ein anderer Exemplartyp \"online\" existiert bereits in Organisation"
@@ -6765,7 +6767,7 @@ msgid "JSON schema for a library"
 msgstr "JSON Schema für eine Bibliothek"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6778,7 +6780,7 @@ msgid "Library ID"
 msgstr "ID der Bibliothek"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "Code"
@@ -6936,11 +6938,11 @@ msgstr ""
 "Der Name der expliziten Aktion, die die Transition zum aktuellen Zustand "
 "ausgelöst hat."
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Ein anderer Online-Standort existiert bereits für diese Bibliothek"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "Abholename Feld ist erforderlich."
 
@@ -6948,59 +6950,102 @@ msgstr "Abholename Feld ist erforderlich."
 msgid "JSON schema for an location"
 msgstr "JSON Schema für einen Standort"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "ID des Standorts"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "Standortcode"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "Der Code ist bereits vergeben."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "Name des Standortes"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "Ist Abholort"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "Diesen Standort als Abholort definieren"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "Ist Online-Standort"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "Diesen Standort als Online-Standort definieren"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr "Es gibt bereits einen Online-Standort für diese Bibliothek."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "Abholortname"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Angezeigter Name des Abholortes, falls vom Namen des Standortes "
 "unterschiedlich"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
 msgstr "Der Name des Abhole-Standortes ist bereits vergeben."
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
+msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:73
@@ -7108,7 +7153,7 @@ msgstr "Online gesammelte Quelle"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Online gesammelte Quelle, wie im Ebook-Server eingestellt."
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr "Anfangsladung"
 
@@ -7133,7 +7178,7 @@ msgid "Parent patron transaction"
 msgstr "Übergeordnete Transaktion"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "URI der Transaktion"
 
@@ -7153,7 +7198,7 @@ msgstr "Betreiber"
 msgid "Operator patron URI"
 msgstr ""
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr "Abonnement für '{Name}' von {Beginn} bis {Ende}"
 
@@ -7230,17 +7275,17 @@ msgstr "Der Name des Lesertypen ist bereits vergeben."
 msgid "The description of the patron type."
 msgstr "Die Beschreibung des Lesertypen."
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 "Jährlich fälliger Betrag für Leser, die mit diesem Type von Leser "
 "verbunden sind."
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr "Jährliches Abonnement"
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 "Aktivierung der Abonnementsgebühren für Leser, die mit diesem Typ "
@@ -7276,6 +7321,11 @@ msgstr "Fehler bei der Verlängerung des Exemplares %(item_id)s."
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
 msgstr "Sie haben eine ausstehende Abonnementsgebühr."
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
+msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
@@ -7359,8 +7409,8 @@ msgstr "Lesertyp"
 msgid "Patron type in terms of circulation policy."
 msgstr "Lesertyp in Bezug auf Ausleihpolitik."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "URI des Lesertypen"
 
@@ -7414,49 +7464,49 @@ msgstr "Kommunikationssprache"
 msgid "English"
 msgstr "Englisch"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr "Abonnements"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr "Abonnement"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr "Startdatum des Abonnements"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr "Das Startdatum des Abonnements (einschließlich des ausgewählten Datums)."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr "Enddatum des Abonnements"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr "Das Enddatum des Abonnements (ausgewähltes Datum ausgeschlossen)."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr "Leser-Transaktion"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: en\n"
@@ -27,84 +27,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "French"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "German"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italian"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "Welcome to RERO-ILS!"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "document type"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "library"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "author"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "author"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "author"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "author"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "language"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "subject"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "roles"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "sources"
 
@@ -291,13 +291,13 @@ msgstr "JSON schema for an account"
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -321,7 +321,7 @@ msgstr "Account ID"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -371,9 +371,9 @@ msgstr "Allocated amount."
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "Library"
@@ -382,9 +382,9 @@ msgstr "Library"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "Library URI"
 
@@ -571,7 +571,7 @@ msgstr "Miscellaneous"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Amount"
 
@@ -900,7 +900,7 @@ msgid "Patron + Item types links"
 msgstr "Patron + Item types links"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "Patron type"
 
@@ -917,21 +917,21 @@ msgid "Item type URI"
 msgstr "Item type URI"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "available"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "not available"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "due until"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "requested"
 
@@ -6432,12 +6432,12 @@ msgstr "Select a Pickup Location"
 msgid "Export Formats"
 msgstr "Export Formats"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "Holding"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "JSON schema for holdings."
 
@@ -6468,11 +6468,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "Location"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "Location URI"
 
@@ -6627,7 +6629,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "Barcode"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Another online item type exists in this organisation"
@@ -6739,7 +6741,7 @@ msgid "JSON schema for a library"
 msgstr "JSON schema for a library"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6752,7 +6754,7 @@ msgid "Library ID"
 msgstr "Library ID"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "Code"
@@ -6910,11 +6912,11 @@ msgstr ""
 "The name of the explicit action that triggered the transition to current "
 "state"
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Another online location exists in this library"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr "Pickup name field is required."
 
@@ -6922,57 +6924,100 @@ msgstr "Pickup name field is required."
 msgid "JSON schema for an location"
 msgstr "JSON schema for an location"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "Location ID"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "Code of the location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "The code is already taken."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "Name of the location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "Is pickup location"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "Qualify this location as a pickup location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr "There is already one pickup location in this library."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "Is online location"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "Qualify this location as an online location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr "There is already one online location in this library."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "Pickup location name"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr "Displayed pickup location name, if different from the location name."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
 msgstr "The pickup location name is already taken."
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
+msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:73
@@ -7080,7 +7125,7 @@ msgstr "Online harvested source"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Online harvested source as configured in ebooks server."
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7105,7 +7150,7 @@ msgid "Parent patron transaction"
 msgstr "Parent fee"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "Fee URI"
 
@@ -7125,7 +7170,7 @@ msgstr "Operator"
 msgid "Operator patron URI"
 msgstr "Operator patron URI"
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7202,15 +7247,15 @@ msgstr "The patron type name is already taken."
 msgid "The description of the patron type."
 msgstr "The description of the patron type."
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7243,6 +7288,11 @@ msgstr "Error during the renewal of the item %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7327,8 +7377,8 @@ msgstr "Patron Type"
 msgid "Patron type in terms of circulation policy."
 msgstr "Patron type in terms of circulation policy."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "Patron Type URI"
 
@@ -7382,49 +7432,49 @@ msgstr "Communication language"
 msgid "English"
 msgstr "English"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -23,84 +23,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Francés"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Alemán"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italiano"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "RERO-ILS"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "¡Bienvenido en RERO-ILS!"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "Tipo de documento"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "organización"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "Autores"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "Autores"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "Autores"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "Autores"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "idioma"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "sujeto"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "estado"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "funcciones"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "presupuesto"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "fuentes"
 
@@ -287,13 +287,13 @@ msgstr ""
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -317,7 +317,7 @@ msgstr "Mi cuenta"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -367,9 +367,9 @@ msgstr "Monto asignado para la cuenta."
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "Biblioteca"
@@ -378,9 +378,9 @@ msgstr "Biblioteca"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "URI de la biblioteca"
 
@@ -567,7 +567,7 @@ msgstr "Miscelánea"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Monto"
 
@@ -900,7 +900,7 @@ msgid "Patron + Item types links"
 msgstr "Enlaces de los tipos de usuario y de ejemplar"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "Tipo de usuario"
 
@@ -917,21 +917,21 @@ msgid "Item type URI"
 msgstr "URI del tipo de ejemplar"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "disponible"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "no disponible"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "Para devolver el"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "Reservado"
 
@@ -6437,12 +6437,12 @@ msgstr "Seleccione un lugar de recogida"
 msgid "Export Formats"
 msgstr "Formatos de exportación"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "Existencia"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "Esquema JSON para existencias"
 
@@ -6473,11 +6473,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "Depósito"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "URI del depósito"
 
@@ -6632,7 +6634,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "Código de barras"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Existe otro tipo de ejemplar en línea en esta organización"
@@ -6744,7 +6746,7 @@ msgid "JSON schema for a library"
 msgstr "Esquema JSON para una biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6757,7 +6759,7 @@ msgid "Library ID"
 msgstr "Identificador de la biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "Código"
@@ -6913,11 +6915,11 @@ msgid ""
 "state"
 msgstr "El nombre de la acción que desencadenó la transición al estado actual"
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Otra ubicación en línea existe en biblioteca"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 
@@ -6925,58 +6927,101 @@ msgstr ""
 msgid "JSON schema for an location"
 msgstr "Esquema JSON para un depósito"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "ID del depósito"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "Código del depósito"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "El código está utilizado."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "Nombre del depósito"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "Es un lugar de recogida"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "Califique este depósito como lugar de recogida."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "Es una ubicación en línea"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "Califique esta ubicación como una ubicación en línea."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "Nombre del lugar de recogida"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nombre del lugar de recogida expuesto si es diferente del nombre del "
 "depósito."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
 msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
@@ -7085,7 +7130,7 @@ msgstr "Fuente recolectada en línea"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Fuente recolectada en línea como configurada en el servidor de ebooks."
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7110,7 +7155,7 @@ msgid "Parent patron transaction"
 msgstr "Tasa"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "Tasa URI"
 
@@ -7130,7 +7175,7 @@ msgstr "Operador"
 msgid "Operator patron URI"
 msgstr "Usuario operador URI"
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7207,15 +7252,15 @@ msgstr "El nombre para el tipo de usuario está utilizado."
 msgid "The description of the patron type."
 msgstr "La descripción del tipo de usuario."
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7248,6 +7293,11 @@ msgstr "Error durante la renovación del ejemplar %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7332,8 +7382,8 @@ msgstr "Tipo de usuario"
 msgid "Patron type in terms of circulation policy."
 msgstr "Tipo de usuario en términos de política de circulación."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "URI del tipo de usuario"
 
@@ -7387,49 +7437,49 @@ msgstr "Idioma para comunicar"
 msgid "English"
 msgstr "Inglés"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -30,84 +30,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Français"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Allemand"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italien"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "Bienvenue sur RERO-ILS!"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "Type de document"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "organisation"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "bibliothèque"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "auteur"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "auteur"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "auteur"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "auteur"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "langue"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "sujet"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "statut"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "rôles"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "sources"
 
@@ -294,13 +294,13 @@ msgstr "Schéma JSON d'un compte"
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -324,7 +324,7 @@ msgstr "Mon compte"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -374,9 +374,9 @@ msgstr "Montant alloué"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "Bibliothèque"
@@ -385,9 +385,9 @@ msgstr "Bibliothèque"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "URI de la bibliothèque"
 
@@ -574,7 +574,7 @@ msgstr "Divers"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "montant"
 
@@ -905,7 +905,7 @@ msgid "Patron + Item types links"
 msgstr "Liens des types d'exemplaire et de lecteur"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "Type de lecteur"
 
@@ -922,21 +922,21 @@ msgid "Item type URI"
 msgstr "URI du type d'exemplaire"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "disponible"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "non disponible"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "à rendre le"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "demandé"
 
@@ -6445,12 +6445,12 @@ msgstr "Choisir un lieu de retrait"
 msgid "Export Formats"
 msgstr "Formats d'export"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "État de collection"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "Schéma JSON d'un état de collection"
 
@@ -6481,11 +6481,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "Localisation"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "URI de la localisation"
 
@@ -6640,7 +6642,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "Code-barre"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Un autre type d'exemplaire \"en ligne\" existe dans cette organisation."
@@ -6752,7 +6754,7 @@ msgid "JSON schema for a library"
 msgstr "Schéma JSON d'une bibliothèque"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6765,7 +6767,7 @@ msgid "Library ID"
 msgstr "ID de la bibliothèque."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "Code"
@@ -6921,11 +6923,11 @@ msgid ""
 "state"
 msgstr "Le nom de l'action qui a déclenché la transition vers l'état actuel"
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Une autre localisation en ligne existe dans cette bibliothèque"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 
@@ -6933,59 +6935,102 @@ msgstr ""
 msgid "JSON schema for an location"
 msgstr "Schéma JSON d'une localisation"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "ID de la localisation"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "Code de la localisation."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "Le code est déjà utilisé."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "Nom de la localisation."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "Est un bureau de prêt"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "Définir cette localisation comme lieu de retrait."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "Est une localisation en ligne"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "Définir cette localisation comme localisation en ligne"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr "Le type d'exemplaire \"en ligne\" doit être unique par bibliothèque"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "Nom du lieu de retrait"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nom du lieu de retrait affiché s'il est différent du nom de la "
 "localisation."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
 msgstr "Le nom du lieu de retrait doit être unique dans votre bibliothèque."
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
+msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:73
@@ -7093,7 +7138,7 @@ msgstr "Source moissonnée en ligne"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Source moissonnée en ligne, comme configuré dans le serveur d'ebooks."
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7118,7 +7163,7 @@ msgid "Parent patron transaction"
 msgstr "Frais parents"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "URI des frais"
 
@@ -7138,7 +7183,7 @@ msgstr "Opérateur"
 msgid "Operator patron URI"
 msgstr ""
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7215,15 +7260,15 @@ msgstr "Le nom du type de lecteur est déjà utilisé."
 msgid "The description of the patron type."
 msgstr "La description du type de lecteur"
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7256,6 +7301,11 @@ msgstr "Erreur lors de la prolongation de l'exemplaire %(item_id)s. "
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7340,8 +7390,8 @@ msgstr "Type de lecteur"
 msgid "Patron type in terms of circulation policy."
 msgstr "Type de lecteur en termes de politique de circulation."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "URI du type de lecteur"
 
@@ -7395,49 +7445,49 @@ msgstr "Langue de communication"
 msgid "English"
 msgstr "Anglais"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: it\n"
@@ -29,84 +29,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Francese"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Tedesco"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "italiano"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "Benvenuti su RERO ILS!"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "tipo di documento"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "Ente"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "autore"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "autore"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "autore"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "autore"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "lingua"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "oggetto"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "stato"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "ruoli"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "bilancio"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "fonti"
 
@@ -293,13 +293,13 @@ msgstr ""
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -323,7 +323,7 @@ msgstr "ID del conto"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -373,9 +373,9 @@ msgstr "L'importo stanziato al conto."
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "Biblioteca"
@@ -384,9 +384,9 @@ msgstr "Biblioteca"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "URI della biblioteca"
 
@@ -573,7 +573,7 @@ msgstr "Varie"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Importo"
 
@@ -904,7 +904,7 @@ msgid "Patron + Item types links"
 msgstr "Link tipo di lettore + tipo di esemplare"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "Tipo di lettore"
 
@@ -921,21 +921,21 @@ msgid "Item type URI"
 msgstr "URI del tipo di esemplare"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "disponibile"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "indisponibile"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "in scadenza fino al"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "richiesto"
 
@@ -6443,12 +6443,12 @@ msgstr "Selezionare un punto di ritiro"
 msgid "Export Formats"
 msgstr "Formati di esportazione"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "posseduto"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "JSON schema per un posseduto"
 
@@ -6479,11 +6479,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "Localizzazione"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "URI della localizzazione"
 
@@ -6638,7 +6640,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "Codice a barre"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Un'altro tipo di esemplare online esiste in questa organizzazione"
@@ -6750,7 +6752,7 @@ msgid "JSON schema for a library"
 msgstr "JSON schema per una biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6763,7 +6765,7 @@ msgid "Library ID"
 msgstr "ID della biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "Codice"
@@ -6919,11 +6921,11 @@ msgid ""
 "state"
 msgstr "Il nome dell'azione che ha innescato la transizione verso lo stato attuale"
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Un'altra localizzazione online esiste in questa biblioteca"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 
@@ -6931,58 +6933,101 @@ msgstr ""
 msgid "JSON schema for an location"
 msgstr "JSON schema per una localizzazione"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "ID della localizzazione"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "Nome della localizzazione"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "Il codice è già utilizzato."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "Nome della collocazione"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "È punto di ritiro"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "Definire questa localizzazione come punto di ritiro."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "È una localizzazione online"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "Definire questa localizzazione come localizzazione online."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "Nome del punto di ritiro"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nome del punto di ritiro visualizzato, se diverso del nome della "
 "localizzazione."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
 msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
@@ -7091,7 +7136,7 @@ msgstr "Fonte raccolta online"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Fonte raccolta online, come configurato nel server di ebooks"
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7116,7 +7161,7 @@ msgid "Parent patron transaction"
 msgstr "Transazione del lettore madre"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "URI del tassa"
 
@@ -7136,7 +7181,7 @@ msgstr "Operatore"
 msgid "Operator patron URI"
 msgstr "Operatore Lettore URI"
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7213,15 +7258,15 @@ msgstr "Il nome del tipo di lettore è già utilizzato."
 msgid "The description of the patron type."
 msgstr "La descrizione del tipo di lettore."
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7254,6 +7299,11 @@ msgstr "Errore durante la proroga dell'esemplare %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7338,8 +7388,8 @@ msgstr "Tipo di lettore"
 msgid "Patron type in terms of circulation policy."
 msgstr "Tipo di lettore in termini di politica di prestito."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "URI del tipo di lettore"
 
@@ -7393,49 +7443,49 @@ msgstr "Lingua di comunicazione"
 msgid "English"
 msgstr "Inglese"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -3,9 +3,11 @@
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
+msgid ""
+msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:31+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,84 +16,84 @@
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr ""
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr ""
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr ""
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr ""
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr ""
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr ""
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr ""
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr ""
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr ""
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr ""
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr ""
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr ""
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr ""
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr ""
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr ""
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr ""
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr ""
 
@@ -278,13 +280,13 @@ msgstr ""
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -308,7 +310,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -358,9 +360,9 @@ msgstr ""
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr ""
@@ -369,9 +371,9 @@ msgstr ""
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr ""
 
@@ -558,7 +560,7 @@ msgstr ""
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr ""
 
@@ -887,7 +889,7 @@ msgid "Patron + Item types links"
 msgstr ""
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr ""
 
@@ -904,21 +906,21 @@ msgid "Item type URI"
 msgstr ""
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr ""
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr ""
 
@@ -6405,12 +6407,12 @@ msgstr ""
 msgid "Export Formats"
 msgstr ""
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr ""
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr ""
 
@@ -6441,11 +6443,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr ""
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr ""
 
@@ -6600,7 +6604,7 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr ""
@@ -6712,7 +6716,7 @@ msgid "JSON schema for a library"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6725,7 +6729,7 @@ msgid "Library ID"
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr ""
@@ -6881,11 +6885,11 @@ msgid ""
 "state"
 msgstr ""
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr ""
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 
@@ -6893,56 +6897,99 @@ msgstr ""
 msgid "JSON schema for an location"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
 msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
@@ -7051,7 +7098,7 @@ msgstr ""
 msgid "Online harvested source as configured in ebooks server."
 msgstr ""
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7076,7 +7123,7 @@ msgid "Parent patron transaction"
 msgstr ""
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr ""
 
@@ -7096,7 +7143,7 @@ msgstr ""
 msgid "Operator patron URI"
 msgstr ""
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7173,15 +7220,15 @@ msgstr ""
 msgid "The description of the patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7214,6 +7261,11 @@ msgstr ""
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7298,8 +7350,8 @@ msgstr ""
 msgid "Patron type in terms of circulation policy."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr ""
 
@@ -7353,47 +7405,49 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-06 16:32+0200\n"
+"POT-Creation-Date: 2020-05-13 15:18+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -22,84 +22,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:120
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
+#: rero_ils/config.py:121
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:259
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Frans"
 
-#: rero_ils/config.py:121
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
+#: rero_ils/config.py:122
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:267
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Duits"
 
-#: rero_ils/config.py:122
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
+#: rero_ils/config.py:123
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:271
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italiaans"
 
-#: rero_ils/config.py:173 rero_ils/config.py:177
+#: rero_ils/config.py:174 rero_ils/config.py:178
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:224
+#: rero_ils/config.py:225
 msgid "Welcome to RERO-ILS!"
 msgstr "Welkom bij RERO-ILS!"
 
-#: rero_ils/config.py:1182
+#: rero_ils/config.py:1183
 msgid "document_type"
 msgstr "type van document"
 
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1184
 msgid "organisation"
 msgstr "organisatie"
 
-#: rero_ils/config.py:1186 rero_ils/config.py:1230 rero_ils/config.py:1252
-#: rero_ils/config.py:1274
+#: rero_ils/config.py:1187 rero_ils/config.py:1231 rero_ils/config.py:1253
+#: rero_ils/config.py:1275
 msgid "library"
 msgstr "bibliotheek"
 
-#: rero_ils/config.py:1187
+#: rero_ils/config.py:1188
 msgid "author__en"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1188
+#: rero_ils/config.py:1189
 msgid "author__fr"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1189
+#: rero_ils/config.py:1190
 msgid "author__de"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1190
+#: rero_ils/config.py:1191
 msgid "author__it"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1191
+#: rero_ils/config.py:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
 msgid "language"
 msgstr "taal"
 
-#: rero_ils/config.py:1192
+#: rero_ils/config.py:1193
 msgid "subject"
 msgstr "onderwerp"
 
-#: rero_ils/config.py:1193 rero_ils/config.py:1253 rero_ils/config.py:1275
+#: rero_ils/config.py:1194 rero_ils/config.py:1254 rero_ils/config.py:1276
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1209
+#: rero_ils/config.py:1210
 msgid "roles"
 msgstr "rollen"
 
-#: rero_ils/config.py:1231
+#: rero_ils/config.py:1232
 msgid "budget"
 msgstr "begroting"
 
-#: rero_ils/config.py:1291
+#: rero_ils/config.py:1292
 msgid "sources"
 msgstr "bron"
 
@@ -286,13 +286,13 @@ msgstr ""
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:28
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:15
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:16
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:15
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:17
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:20
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:34
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:36
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:15
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:27
 msgid "Schema"
@@ -316,7 +316,7 @@ msgstr "Account ID"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:270
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:54
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:27
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:32
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:28
@@ -366,9 +366,9 @@ msgstr "Het toegekende bedrag voor de account."
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:163
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
 msgid "Library"
 msgstr "Bibliotheek"
@@ -377,9 +377,9 @@ msgstr "Bibliotheek"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library URI"
 msgstr "URI van de bibliotheek"
 
@@ -566,7 +566,7 @@ msgstr "Diversen"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:43
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:66
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Bedrag"
 
@@ -899,7 +899,7 @@ msgid "Patron + Item types links"
 msgstr "Links voor de type van lezer + exemplaar"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:141
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:308
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:310
 msgid "Patron type"
 msgstr "Lezerstype"
 
@@ -916,21 +916,21 @@ msgid "Item type URI"
 msgstr "URI van de type van kopie"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:363
+#: rero_ils/modules/documents/views.py:355
 msgid "available"
 msgstr "beschikbaar"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:365
+#: rero_ils/modules/documents/views.py:357
 msgid "not available"
 msgstr "niet beschikbaar"
 
-#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:364 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "verschuldigd tot"
 
-#: rero_ils/modules/documents/views.py:374
+#: rero_ils/modules/documents/views.py:366
 msgid "requested"
 msgstr "gereserveerd"
 
@@ -6438,12 +6438,12 @@ msgstr "Selecteer een afhaallocatie"
 msgid "Export Formats"
 msgstr "Export formaten"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:3
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:153
 msgid "Holding"
 msgstr "Holding"
 
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:4
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:5
 msgid "JSON schema for holdings."
 msgstr "JSON-schema voor holdings."
 
@@ -6474,11 +6474,13 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:186
 msgid "Location"
 msgstr "Locatie"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:67
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:68
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:189
 msgid "Location URI"
 msgstr "Locatie URI"
 
@@ -6633,7 +6635,7 @@ msgstr "ID"
 msgid "Barcode"
 msgstr "Barcode"
 
-#: rero_ils/modules/item_types/api.py:72
+#: rero_ils/modules/item_types/api.py:73
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Een ander online type van exemplaar bestaat in deze organisatie "
@@ -6745,7 +6747,7 @@ msgid "JSON schema for a library"
 msgstr "JSON-schema voor een bibliotheek"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:17
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:24
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:29
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:17
 #: rero_ils/modules/persons/jsonschemas/persons/person-v0.0.1.json:16
 msgid "Schema to validate organisation records against."
@@ -6758,7 +6760,7 @@ msgid "Library ID"
 msgstr "Bibliotheek ID"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:34
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code"
 msgstr "Code"
@@ -6916,11 +6918,11 @@ msgstr ""
 "De naam van de actie die de overgang naar de huidige toestand in gang "
 "heeft gezet."
 
-#: rero_ils/modules/locations/api.py:69
+#: rero_ils/modules/locations/api.py:75
 msgid "Another online location exists in this library"
 msgstr "Een andere online locatie bestaat in deze bibliotheek"
 
-#: rero_ils/modules/locations/api.py:72
+#: rero_ils/modules/locations/api.py:78
 msgid "Pickup name field is required."
 msgstr ""
 
@@ -6928,58 +6930,101 @@ msgstr ""
 msgid "JSON schema for an location"
 msgstr "JSON-schema voor een lokatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:30
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
 msgid "Location ID"
 msgstr "Locatie ID"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:35
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:40
 msgid "Code of the location."
 msgstr "Code van de lokatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:43
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:48
 msgid "The code is already taken."
 msgstr "De code is al bezet."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:50
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:55
 msgid "Name of the location."
 msgstr "Naam van de lokatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:58
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:63
 msgid "Is pickup location"
 msgstr "is een afhaallocatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:61
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:66
 msgid "Qualify this location as a pickup location."
 msgstr "Definieer deze locatie als een afhaallocatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:78
 msgid "There is already one pickup location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:84
 msgid "Is online location"
 msgstr "Is online locatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
 msgid "Qualify this location as an online location."
 msgstr "Defineer deze locatie als een online locatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:99
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:105
 msgid "Pickup location name"
 msgstr "Naam van de afhaallocatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:107
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Weergegeven naam van de afhaallocatie, indien verschillend van de "
 "locatienaam."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:120
 msgid "The pickup location name is already taken."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:137
+msgid "Allow request"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:139
+msgid "If enabled, it allows requests for items linked to this location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:143
+msgid "Send notification"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:144
+msgid "Send a email notification when an item of the location has been requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:155
+msgid "Notification email"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:156
+msgid "Specify a generic email address used for notification."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
+msgid "Restrict pickup to"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:180
+msgid ""
+"Select locations where items linked to the current location could be "
+"requested."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:196
+msgid "pickup_name"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:210
+msgid "If enabled, restrict pickup to specific pickup locations."
 msgstr ""
 
 #: rero_ils/modules/notifications/jsonschemas/notifications/notification-v0.0.1.json:4
@@ -7088,7 +7133,7 @@ msgstr "Online geoogste bron"
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Online geoogste bron zoals geconfigureerd in de ebookserver."
 
-#: rero_ils/modules/patron_transaction_events/api.py:98
+#: rero_ils/modules/patron_transaction_events/api.py:114
 msgid "Initial charge"
 msgstr ""
 
@@ -7113,7 +7158,7 @@ msgid "Parent patron transaction"
 msgstr "Kosten"
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:31
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:329
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:331
 msgid "Patron transaction URI"
 msgstr "Kosten URI"
 
@@ -7133,7 +7178,7 @@ msgstr "Operator"
 msgid "Operator patron URI"
 msgstr "Operator lezer URI"
 
-#: rero_ils/modules/patron_transactions/api.py:228
+#: rero_ils/modules/patron_transactions/api.py:238
 msgid "Subscription for '{name}' from {start} to {end}"
 msgstr ""
 
@@ -7210,15 +7255,15 @@ msgstr "De naam van het lezerstype is al genomen"
 msgid "The description of the patron type."
 msgstr "Beschrijving van het lezerstype"
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:68
 msgid "Yearly amount due by patrons linked to this patron type."
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:78
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
 msgid "Yearly subscription"
 msgstr ""
 
-#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:79
+#: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:80
 msgid "Activation of subscription fees for patrons linked to this type."
 msgstr ""
 
@@ -7251,6 +7296,11 @@ msgstr "Fout bij de verlenging van de exemplaar %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:146
 msgid "You have a pending subscription fee."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:155
+#, python-format
+msgid "Your account is currently blocked. Reason: %(reason)s"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
@@ -7335,8 +7385,8 @@ msgstr "Lezerstype"
 msgid "Patron type in terms of circulation policy."
 msgstr "Lezerstype in termen van circulatiebeleid."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:124
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:315
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:126
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:317
 msgid "Patron Type URI"
 msgstr "Lezerstype URI"
 
@@ -7390,49 +7440,49 @@ msgstr "Communicatietaal"
 msgid "English"
 msgstr "Engels"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:280
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
 msgid "Subscriptions"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:284
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:286
 msgid "Subscription"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:294
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:296
 msgid "Subscription start date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:295
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:297
 msgid "The subscription start date (selected date included)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:301
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:303
 msgid "Subscription end date"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:302
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:304
 msgid "The subscription end date (selected date excluded)."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:324
 msgid "Patron transaction"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:341
 msgid "Blocking"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:342
 msgid ""
 "A patron with a blocked account cannot request and borrow items, but can "
 "still renew and check in items."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:346
 msgid "Reason"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:348
 msgid ""
 "The reason is displayed in the circulation module and is visible by the "
 "patron in his account."

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -15,23 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+"""Tests availability."""
+
+from copy import deepcopy
+
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
+from rero_ils.modules.documents.views import can_request
 from rero_ils.modules.holdings.api import Holding
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
 from rero_ils.modules.items.views import item_availability_text
 from rero_ils.modules.loans.api import LoanAction
+from rero_ils.modules.locations.api import Location
+from rero_ils.modules.utils import get_ref_for_pid
 
 
 def test_item_can_request(
         client, document, holding_lib_martigny, item_lib_martigny,
         librarian_martigny_no_email, lib_martigny,
         patron_martigny_no_email, circulation_policies,
-        patron_type_children_martigny):
+        patron_type_children_martigny, loc_public_martigny_data,
+        system_librarian_martigny_no_email, item_lib_martigny_data):
     """Test item can request API."""
     # test no logged user
     res = client.get(
@@ -43,6 +51,9 @@ def test_item_can_request(
         )
     )
     assert res.status_code == 401
+
+    result = can_request(item_lib_martigny)
+    assert not result
 
     login_user_via_session(client, librarian_martigny_no_email.user)
     # valid test
@@ -56,7 +67,20 @@ def test_item_can_request(
     )
     assert res.status_code == 200
     data = get_json(res)
-    assert data.get('can_request')
+    assert data.get('can')
+
+    # test no valid -- patron doesn't have correct role
+    res = client.get(
+        url_for(
+            'api_item.can_request',
+            item_pid=item_lib_martigny.pid,
+            library_pid=lib_martigny.pid,
+            patron_barcode=system_librarian_martigny_no_email.get('barcode')
+        )
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert not data.get('can')
 
     # test no valid item
     res = client.get(
@@ -67,9 +91,7 @@ def test_item_can_request(
             patron_barcode=patron_martigny_no_email.get('barcode')
         )
     )
-    assert res.status_code == 200
-    data = get_json(res)
-    assert not data.get('can_request')
+    assert res.status_code == 404
 
     # test no valid library
     res = client.get(
@@ -80,9 +102,7 @@ def test_item_can_request(
             patron_barcode=patron_martigny_no_email.get('barcode')
         )
     )
-    assert res.status_code == 200
-    data = get_json(res)
-    assert not data.get('can_request')
+    assert res.status_code == 404
 
     # test no valid patron
     res = client.get(
@@ -93,9 +113,7 @@ def test_item_can_request(
             patron_barcode='no_barcode'
         )
     )
-    assert res.status_code == 200
-    data = get_json(res)
-    assert not data.get('can_request')
+    assert res.status_code == 404
 
     # test no valid item status
     item_lib_martigny['status'] = ItemStatus.MISSING
@@ -110,9 +128,47 @@ def test_item_can_request(
     )
     assert res.status_code == 200
     data = get_json(res)
-    assert not data.get('can_request')
+    assert not data.get('can')
     item_lib_martigny['status'] = ItemStatus.ON_SHELF
     item_lib_martigny.update(item_lib_martigny, dbcommit=True, reindex=True)
+
+    # Location :: allow_request == false
+    #   create a new location and set 'allow_request' to false. Assign a new
+    #   item to this location. Chek if this item can be requested : it couldn't
+    #   with 'Item location doesn't allow request' reason.
+    new_location = deepcopy(loc_public_martigny_data)
+    del new_location['pid']
+    new_location['allow_request'] = False
+    new_location = Location.create(new_location, dbcommit=True, reindex=True)
+    assert new_location
+    new_item = deepcopy(item_lib_martigny_data)
+    del new_item['pid']
+    new_item['barcode'] = 'dummy_barcode_allow_request'
+    new_item['location']['$ref'] = get_ref_for_pid(Location, new_location.pid)
+    new_item = Item.create(new_item, dbcommit=True, reindex=True)
+    assert new_item
+
+    res = client.get(url_for('api_item.can_request', item_pid=new_item.pid))
+    assert res.status_code == 200
+    data = get_json(res)
+    assert not data.get('can')
+
+    # remove created data
+    item_url = url_for(
+        'invenio_records_rest.item_item',
+        pid_value=new_item.pid
+    )
+    hold_url = url_for(
+        'invenio_records_rest.hold_item',
+        pid_value=new_item.holding_pid
+    )
+    loc_url = url_for(
+        'invenio_records_rest.loc_item',
+        pid_value=new_location.pid
+    )
+    client.delete(item_url)
+    client.delete(hold_url)
+    client.delete(loc_url)
 
 
 def test_item_holding_document_availability(
@@ -121,7 +177,8 @@ def test_item_holding_document_availability(
         item_lib_martigny, item2_lib_martigny,
         librarian_martigny_no_email, librarian_saxon_no_email,
         patron_martigny_no_email, patron2_martigny_no_email,
-        loc_public_saxon, circulation_policies):
+        loc_public_saxon, circulation_policies, ebook_1_data,
+        item_lib_martigny_data):
     """Test item, holding and document availability."""
     assert item_availablity_status(
         client, item_lib_martigny.pid, librarian_martigny_no_email.user)
@@ -132,7 +189,7 @@ def test_item_holding_document_availability(
         client, holding_lib_martigny.pid, librarian_martigny_no_email.user)
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert document.is_available(view_code='global')
-    assert document_availablity_status(
+    assert document_availability_status(
         client, document.pid, librarian_martigny_no_email.user)
 
     # login as patron
@@ -169,7 +226,7 @@ def test_item_holding_document_availability(
         client, holding_lib_martigny.pid, librarian_martigny_no_email.user)
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert document.is_available('global')
-    assert document_availablity_status(
+    assert document_availability_status(
         client, document.pid, librarian_martigny_no_email.user)
 
     # validate request
@@ -194,7 +251,7 @@ def test_item_holding_document_availability(
         client, holding_lib_martigny.pid, librarian_martigny_no_email.user)
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert document.is_available('global')
-    assert document_availablity_status(
+    assert document_availability_status(
         client, document.pid, librarian_martigny_no_email.user)
     login_user_via_session(client, librarian_saxon_no_email.user)
     # receive
@@ -219,7 +276,7 @@ def test_item_holding_document_availability(
         client, holding_lib_martigny.pid, librarian_saxon_no_email.user)
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert document.is_available('global')
-    assert document_availablity_status(
+    assert document_availability_status(
         client, document.pid, librarian_martigny_no_email.user)
     # checkout
     res, _ = postdata(
@@ -242,7 +299,7 @@ def test_item_holding_document_availability(
         client, holding_lib_martigny.pid, librarian_saxon_no_email.user)
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert document.is_available('global')
-    assert document_availablity_status(
+    assert document_availability_status(
         client, document.pid, librarian_martigny_no_email.user)
 
     # test can not request item already checked out to patron
@@ -306,7 +363,7 @@ def test_item_holding_document_availability(
         client, holding_lib_martigny.pid, librarian_martigny_no_email.user)
     assert holding_lib_martigny.get_holding_loan_conditions() == 'standard'
     assert not document.is_available('global')
-    assert not document_availablity_status(
+    assert not document_availability_status(
         client, document.pid, librarian_martigny_no_email.user)
 
 
@@ -338,7 +395,7 @@ def holding_availablity_status(client, pid, user):
     return data.get('availability')
 
 
-def document_availablity_status(client, pid, user):
+def document_availability_status(client, pid, user):
     """Returns document availability."""
     login_user_via_session(client, user)
     res = client.get(
@@ -351,3 +408,55 @@ def document_availablity_status(client, pid, user):
     assert res.status_code == 200
     data = get_json(res)
     return data.get('availability')
+
+
+def test_availability_cipo_allow_request(
+        client, librarian_martigny_no_email, item_lib_martigny,
+        item_type_standard_martigny, patron_martigny_no_email,
+        circ_policy_short_martigny):
+    """Test availability is cipo disallow request."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+
+    # update the cipo to disallow request
+    cipo = circ_policy_short_martigny
+    cipo['allow_requests'] = False
+    cipo.update(cipo.dumps(), dbcommit=True, reindex=True)
+
+    res = client.get(
+        url_for(
+            'api_item.can_request',
+            item_pid=item_lib_martigny.pid,
+            patron_barcode=patron_martigny_no_email.get('barcode')
+        )
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert not data.get('can')
+
+    # reset the cipo
+    cipo['allow_requests'] = True
+    cipo.update(cipo.dumps(), dbcommit=True, reindex=True)
+
+
+def test_document_availability_failed(client, librarian2_martigny_no_email):
+    """Test document availability with dummy data should failed."""
+    login_user_via_session(client, librarian2_martigny_no_email.user)
+    res = client.get(
+        url_for(
+            'api_documents.document_availability',
+            document_pid='dummy_pid'
+        )
+    )
+    assert res.status_code == 404
+
+
+def test_item_availability_failed(client, librarian2_martigny_no_email):
+    """Test item availability with dummy data should failed."""
+    login_user_via_session(client, librarian2_martigny_no_email.user)
+    res = client.get(
+        url_for(
+            'api_item.item_availability',
+            item_pid='dummy_pid'
+        )
+    )
+    assert res.status_code == 404

--- a/tests/api/test_items_rest_views.py
+++ b/tests/api/test_items_rest_views.py
@@ -752,3 +752,27 @@ def test_update_loan_pickup_location(
         )
     )
     assert res.status_code == 403
+
+
+def test_item_pickup_location(
+        client, librarian_martigny_no_email, item2_lib_martigny):
+    """Test get item pickup locations."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    # test with dummy data will return 404
+    res = client.get(
+        url_for(
+            'api_item.get_pickup_locations',
+            item_pid='dummy_pid'
+        )
+    )
+    assert res.status_code == 404
+    # test with an existing item
+    res = client.get(
+        url_for(
+            'api_item.get_pickup_locations',
+            item_pid=item2_lib_martigny.pid
+        )
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'locations' in data

--- a/tests/api/test_patrons_rest.py
+++ b/tests/api/test_patrons_rest.py
@@ -43,6 +43,7 @@ def test_patrons_shortcuts(
     del new_patron['patron_type']
     assert not new_patron.patron_type_pid
     assert not new_patron.organisation_pid
+    assert new_patron.formatted_name == "Roduit, Louis"
 
 
 def test_filtered_patrons_get(

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -533,7 +533,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/lib1"
     },
     "is_pickup": true,
-    "pickup_name": "MARTIGNY-PUBLIC: Public Space"
+    "pickup_name": "MARTIGNY-PUBLIC: Public Space",
+    "allow_request": true
   },
   "loc2": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -542,7 +543,8 @@
     "pid": "loc2",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib1"
-    }
+    },
+    "allow_request": true
   },
   "loc3": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -553,7 +555,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/lib2"
     },
     "is_pickup": true,
-    "pickup_name": "SAXON-PUBLIC: Public Space"
+    "pickup_name": "SAXON-PUBLIC: Public Space",
+    "allow_request": true
   },
   "loc4": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -562,7 +565,8 @@
     "pid": "loc4",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib2"
-    }
+    },
+    "allow_request": true
   },
   "loc5": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -573,7 +577,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/lib3"
     },
     "is_pickup": true,
-    "pickup_name": "FULLY-PUBLIC: Public Space"
+    "pickup_name": "FULLY-PUBLIC: Public Space",
+    "allow_request": true
   },
   "loc6": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -582,7 +587,8 @@
     "pid": "loc6",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib3"
-    }
+    },
+    "allow_request": true
   },
   "loc7": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -593,7 +599,8 @@
       "$ref": "https://ils.rero.ch/api/libraries/lib4"
     },
     "is_pickup": true,
-    "pickup_name": "SION-PUBLIC: Public Space"
+    "pickup_name": "SION-PUBLIC: Public Space",
+    "allow_request": true
   },
   "loc8": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -602,7 +609,8 @@
     "pid": "loc8",
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib4"
-    }
+    },
+    "allow_request": true
   },
   "loc9": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -612,7 +620,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib1"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   "loc10": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -622,7 +631,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib2"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   "loc11": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -632,7 +642,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib3"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   "loc12": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -642,7 +653,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib4"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   "loc13": {
     "$schema": "https://ils.rero.ch/schema/locations/location-v0.0.1.json",
@@ -652,7 +664,8 @@
     "library": {
       "$ref": "https://ils.rero.ch/api/libraries/lib5"
     },
-    "is_online": true
+    "is_online": true,
+    "allow_request": true
   },
   "itty1": {
     "$schema": "https://ils.rero.ch/schema/item_types/item_type-v0.0.1.json",
@@ -2092,7 +2105,8 @@
     "roles": [
       "system_librarian",
       "librarian"
-    ]
+    ],
+    "barcode": "sys_ptrn1"
   },
   "ptrn2": {
     "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",

--- a/tests/fixtures/organisations.py
+++ b/tests/fixtures/organisations.py
@@ -248,6 +248,24 @@ def loc_online_aproz_data(data):
 
 
 @pytest.fixture(scope="module")
+def locations(loc_public_martigny, loc_restricted_martigny,
+              loc_public_saxon, loc_restricted_saxon,
+              loc_public_fully, loc_restricted_fully,
+              loc_public_sion, loc_restricted_sion,
+              loc_online_martigny, loc_online_saxon,
+              loc_online_fully, loc_online_sion, loc_online_aproz):
+    """Create all locations."""
+    return [
+        loc_public_martigny, loc_restricted_martigny,
+        loc_public_saxon, loc_restricted_saxon,
+        loc_public_fully, loc_restricted_fully,
+        loc_public_sion, loc_restricted_sion,
+        loc_online_martigny, loc_online_saxon,
+        loc_online_fully, loc_online_sion, loc_online_aproz
+    ]
+
+
+@pytest.fixture(scope="module")
 def loc_public_martigny(app, lib_martigny, loc_public_martigny_data):
     """Create public space location for Martigny ville."""
     loc = Location.create(

--- a/tests/ui/notifications/test_notifications_api.py
+++ b/tests/ui/notifications/test_notifications_api.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, print_function
 
 from copy import deepcopy
 
-import pytest
 from utils import get_mapping
 
 from rero_ils.modules.notifications.api import Notification, \
@@ -129,6 +128,4 @@ def test_notification_dispatch(app, mailbox):
     Dispatcher().dispatch_notification(notification=notification, verbose=True)
 
     notification = DummyNotification('XXXX')
-    with pytest.raises(ValueError):
-        Dispatcher().dispatch_notification(notification=notification,
-                                           verbose=True)
+    Dispatcher().dispatch_notification(notification=notification, verbose=True)

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -110,6 +110,12 @@ def test_patrons_logged_user(client, librarian_martigny_no_email):
     assert not data.get('metadata')
     assert data.get('settings').get('language')
 
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res = client.get(url_for('patrons.logged_user', resolve=1))
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'organisation' in data['metadata']['library']
+
     class current_i18n:
         class locale:
             language = 'fr'


### PR DESCRIPTION
This commit implements tasks relative to UCL paging request in closed stack.
It allows to limit request for items belonging to specific location.
It also allows to restrict the pickup destination to some pickup locations
instead of all pickups locations of the organisation.
If an item of a "paging" location is requested, it also allows to send
a notification to notify a manager.



## how to test

Nee to test with RERO-ILS-UI : https://github.com/rero/rero-ils-ui/pull/171

* logged as a librarian, create a new location into your library. First step is to set the flag "allow_request" to false.
* create a new item an link it to this new location
* On an other browser, logged as a patron and try to request this item. The "request" button shouldn't be displayed
----
* on your first browser (logged as librarian) edit the new location : set "allow request" to true, and restrict pickup location to one or more (not all) possible pickups locations.
* on the second browser (logged as patron) refresh your page and try to request the item. The request select bow should only contains pickups locations that you select as possible pickups locations.
----
* on librarian browser : edit the location and set "send_notification" to true and set an email address into the "contact_email" field.
* on the patron browser : place a request on the newly created item. In your RERO-ILS console your should see than an email is send to location email address.
----
* Into the professional interface, all "request" button/select should follow the same behavior.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
