### PR TITLE
loans: add parameter to sort pending loans

### DIFF
--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -215,12 +215,14 @@ def extend_loan(item, data):
 @check_authentication
 @jsonify_error
 def requested_loans(library_pid):
-    """HTTP GET request for requested loans for a library."""
-    items_loans = Item.get_requests_to_validate(library_pid)
+    """HTTP GET request for sorted requested loans for a library."""
+    sort_by = flask_request.args.get('sort')
+    items_loans = Item.get_requests_to_validate(
+        library_pid=library_pid, sort_by=sort_by)
     metadata = []
     for item, loan in items_loans:
         metadata.append({
-            'item': item.dumps_for_circulation(),
+            'item': item.dumps_for_circulation(sort_by=sort_by),
             'loan': loan.dumps_for_circulation()
         })
     return jsonify({
@@ -235,11 +237,13 @@ def requested_loans(library_pid):
 @check_authentication
 @jsonify_error
 def loans(patron_pid):
-    """HTTP GET request for requested loans for a library."""
-    items_loans = Item.get_checked_out_items(patron_pid)
+    """HTTP GET request for sorted loans for a patron pid."""
+    sort_by = flask_request.args.get('sort')
+    items_loans = Item.get_checked_out_items(
+        patron_pid=patron_pid, sort_by=sort_by)
     metadata = []
     for item, loan in items_loans:
-        item_dumps = item.dumps_for_circulation()
+        item_dumps = item.dumps_for_circulation(sort_by=sort_by)
         metadata.append({
             'item': item_dumps,
             'loan': loan.dumps_for_circulation()

--- a/rero_ils/modules/notifications/tasks.py
+++ b/rero_ils/modules/notifications/tasks.py
@@ -29,17 +29,17 @@ def create_over_and_due_soon_notifications(overdue=True, due_soon=True):
     """Creates due_soon and overdue notifications."""
     no_over_due_loans = 0
     no_due_soon_loans = 0
+    if due_soon:
+        due_soon_loans = get_due_soon_loans()
+        for loan in due_soon_loans:
+            loan.create_notification(notification_type='due_soon')
+            no_due_soon_loans += 1
     if overdue:
         over_due_loans = get_overdue_loans()
 
         for loan in over_due_loans:
             loan.create_notification(notification_type='overdue')
             no_over_due_loans += 1
-    if due_soon:
-        due_soon_loans = get_due_soon_loans()
-        for loan in due_soon_loans:
-            loan.create_notification(notification_type='due_soon')
-            no_due_soon_loans += 1
 
     return 'created {no_over_due_loans} overdue loans, '\
         '{no_due_soon_loans} due soon loans'.format(

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1653,6 +1653,22 @@
     },
     "status": "on_shelf"
   },
+  "item7": {
+    "$schema": "https://ils.rero.ch/schema/items/item-v0.0.1.json",
+    "pid": "item7",
+    "barcode": "789123",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "call_number": "0000155",
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc1"
+    },
+    "item_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty1"
+    },
+    "status": "on_shelf"
+  },
   "ptrn1": {
     "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",
     "pid": "ptrn1",

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -273,13 +273,13 @@ def item2_lib_martigny(
 @pytest.fixture(scope="module")
 def item3_lib_martigny_data(data):
     """Load item of martigny library."""
-    return deepcopy(data.get('item1'))
+    return deepcopy(data.get('item7'))
 
 
 @pytest.fixture(scope="function")
 def item3_lib_martigny_data_tmp(data):
     """Load item of martigny library scope function."""
-    return deepcopy(data.get('item1'))
+    return deepcopy(data.get('item7'))
 
 
 @pytest.fixture(scope="module")
@@ -292,7 +292,7 @@ def item3_lib_martigny(
     """Create item3 of martigny library."""
     item = Item.create(
         data=item3_lib_martigny_data,
-        delete_pid=True,
+        delete_pid=False,
         dbcommit=True,
         reindex=True)
     flush_index(ItemsSearch.Meta.index)


### PR DESCRIPTION
* Adds sort order parameter to the item.requested_loans.library_pid api.
* Improves notification fixtures to have due_soon and recall records.
* Adds sort order parameter to the item.loans.patron_barcode api.
* Fixes item fixtures problem.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/task/1263?kanban-status=1224894

## How to test?

`./script/setup`
- sort loans by transaction_date asc:
https://localhost:5000/api/item/requested_loans/1?sort=transaction_date

- sort loans by transaction_date desc:
https://localhost:5000/api/item/requested_loans/1?sort=-transaction_date

- sort checked out items by transaction_date desc:
https://localhost:5000/api/item/loans/<patron_barcode>?sort=-transaction_date

- due_soon and recall notifications are created
https://localhost:5000/api/notifications/

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
