### PR TITLE
acquisition: link order line to a document

### DIFF
--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -6,7 +6,7 @@
   "additionalProperties": false,
   "propertiesOrder": [
     "acq_account",
-    "description",
+    "document",
     "order_line_status",
     "quantity",
     "amount",
@@ -19,8 +19,8 @@
     "pid",
     "acq_account",
     "acq_order",
-    "amount",
-    "description"
+    "document",
+    "amount"
   ],
   "properties": {
     "$schema": {
@@ -32,11 +32,6 @@
     },
     "pid": {
       "title": "AcqOrderLine ID",
-      "type": "string",
-      "minLength": 1
-    },
-    "description": {
-      "title": "Description",
       "type": "string",
       "minLength": 1
     },
@@ -128,9 +123,7 @@
           "pattern": "^https://ils.rero.ch/api/acq_accounts/.*?$",
           "form": {
             "focus": true,
-            "remoteOptions": {
-              "type": "acq_accounts"
-            },
+            "fieldMap": "acq_account",
             "placeholder": "Choose an account",
             "templateOptions": {
               "label": ""
@@ -147,6 +140,24 @@
           "title": "Acquisition order URI",
           "type": "string",
           "pattern": "^https://ils.rero.ch/api/acq_orders/.*?$"
+        }
+      }
+    },
+    "document": {
+      "title": "Document",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Document URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/documents/.+?$",
+          "form": {
+            "validation": {
+              "messages": {
+                "pattern": "Should be in the following format: https://ils.rero.ch/api/documents/<PID>"
+              }
+            }
+          }
         }
       }
     },

--- a/rero_ils/modules/acq_order_lines/mappings/v6/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/mappings/v6/acq_order_lines/acq_order_line-v0.0.1.json
@@ -29,6 +29,13 @@
             }
           }
         },
+        "document": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
         "organisation": {
           "properties": {
             "pid": {
@@ -36,11 +43,8 @@
             }
           }
         },
-        "line_order_status": {
+        "order_line_status": {
           "type": "keyword"
-        },
-        "description": {
-          "type": "text"
         },
         "quantity": {
           "type": "integer"

--- a/tests/api/test_acq_order_lines_rest.py
+++ b/tests/api/test_acq_order_lines_rest.py
@@ -26,8 +26,8 @@ from utils import VerifyRecordPermissionPatch, get_json, postdata, \
     to_relative_url
 
 
-def test_acq_orders_lines_permissions(client, acq_order_line_fiction_martigny,
-                                      json_header):
+def test_acq_orders_lines_permissions(
+        client, document, acq_order_line_fiction_martigny, json_header):
     """Test record retrieval."""
     item_url = url_for('invenio_records_rest.acol_item', pid_value='acol1')
 
@@ -114,7 +114,7 @@ def test_acq_order_lines_post_put_delete(
 
     # Update record/PUT
     data = acq_order_line_fiction_saxon
-    data['description'] = 'Test Name'
+    data['note'] = 'Test update note'
     res = client.put(
         item_url,
         data=json.dumps(data),
@@ -124,19 +124,19 @@ def test_acq_order_lines_post_put_delete(
 
     # Check that the returned record matches the given data
     data = get_json(res)
-    assert data['metadata']['description'] == 'Test Name'
+    assert data['metadata']['note'] == 'Test update note'
 
     res = client.get(item_url)
     assert res.status_code == 200
 
     data = get_json(res)
-    assert data['metadata']['description'] == 'Test Name'
+    assert data['metadata']['note'] == 'Test update note'
 
     res = client.get(list_url)
     assert res.status_code == 200
 
     data = get_json(res)['hits']['hits'][0]
-    assert data['metadata']['description'] == 'Test Name'
+    assert data['metadata']['note'] == 'Test update note'
 
     # Delete record/DELETE
     res = client.delete(item_url)
@@ -155,6 +155,15 @@ def test_acq_order_lines_can_delete(client, acq_order_line_fiction_martigny):
 
     reasons = acq_order_line_fiction_martigny.reasons_not_to_delete()
     assert not reasons
+
+
+def test_acq_order_lines_document_can_delete(
+        client, document, acq_order_line_fiction_martigny):
+    """Test can delete a document with a linked acquisition order line."""
+    assert not document.can_delete
+
+    reasons = document.reasons_not_to_delete()
+    assert reasons['links']['acq_order_lines']
 
 
 def test_acq_order_line_secure_api(client, json_header,
@@ -244,7 +253,7 @@ def test_acq_order_line_secure_api_update(client,
     record_url = url_for('invenio_records_rest.acol_item',
                          pid_value=acq_order_line_fiction_sion.pid)
     data = acq_order_line_fiction_sion
-    data['description'] = 'Test description'
+    data['note'] = 'Test update note'
     res = client.put(
         record_url,
         data=json.dumps(data),

--- a/tests/data/acquisition.json
+++ b/tests/data/acquisition.json
@@ -284,7 +284,9 @@
     "acq_order": {
       "$ref": "https://ils.rero.ch/api/acq_orders/acor1"
     },
-    "description": "Ligne de commande fictive 1",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
     "order_line_status": "pending",
     "quantity": 1,
     "amount": 1000,
@@ -300,7 +302,9 @@
     "acq_order": {
       "$ref": "https://ils.rero.ch/api/acq_orders/acor1"
     },
-    "description": "Ligne de commande fictive 2",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc2"
+    },
     "order_line_status": "pending",
     "quantity": 1,
     "amount": 500,
@@ -316,7 +320,9 @@
     "acq_order": {
       "$ref": "https://ils.rero.ch/api/acq_orders/acor2"
     },
-    "description": "Ligne de commande fictive 1",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
     "order_line_status": "pending",
     "quantity": 1,
     "amount": 1000,
@@ -332,7 +338,9 @@
     "acq_order": {
       "$ref": "https://ils.rero.ch/api/acq_orders/acor3"
     },
-    "description": "Ligne de commande fictive 1",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
     "order_line_status": "pending",
     "quantity": 2,
     "amount": 500,

--- a/tests/ui/acq_order_lines/test_acq_order_lines_jsonresolver.py
+++ b/tests/ui/acq_order_lines/test_acq_order_lines_jsonresolver.py
@@ -22,7 +22,8 @@ from invenio_records.api import Record
 from jsonref import JsonRefError
 
 
-def test_acq_order_lines_jsonresolver(acq_order_line_fiction_martigny):
+def test_acq_order_lines_jsonresolver(
+        document, acq_order_line_fiction_martigny):
     """Acquisition order lines resolver tests."""
     rec = Record.create({
         'acq_order_line': {

--- a/tests/ui/acq_order_lines/test_acq_order_lines_mapping.py
+++ b/tests/ui/acq_order_lines/test_acq_order_lines_mapping.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Aquisition order line Record tests."""
+
+from utils import get_mapping
+
+from rero_ils.modules.acq_order_lines.api import \
+    AcqOrderLine, AcqOrderLinesSearch
+
+
+def test_acq_order_lines_es_mapping(
+        es_clear, db, document, acq_account_fiction_martigny,
+        acq_order_fiction_martigny, acq_order_line_fiction_martigny_data):
+    """Test aquisition order line elasticsearch mapping."""
+    search = AcqOrderLinesSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    AcqOrderLine.create(
+        acq_order_line_fiction_martigny_data,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)


### PR DESCRIPTION
* Adds a link between order line and document.
* Removes description field in order line resource

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/task/1276?kanban-status=1224894

## How to test?

- Should be tested with https://github.com/rero/rero-ils-ui/pull/124

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
