### PR TITLE
ui: Search input takes now all the header area

### DIFF
--- a/rero_ils/templates/rero_ils/header.html
+++ b/rero_ils/templates/rero_ils/header.html
@@ -23,7 +23,7 @@
       <div class="container">
         {%- block navbar_brand %}
           {%- if config.THEME_LOGO %}
-            <div class="align-self-center d-flex w-100 justify-content-between">
+            <div class="align-self-center d-flex justify-content-between">
               <a href="/{% if viewcode != config.RERO_ILS_SEARCH_GLOBAL_VIEW_CODE %}{{ viewcode }}{% endif %}" class="navbar-brand pr-2">
                 <img class="rero-ils-logo navbar-brand" src="{{ url_for('static', filename=config.THEME_LOGO)}}" alt="{{_(config.THEME_SITENAME)}} logo">
                 <div id="{{ viewcode }}-logo"></div>


### PR DESCRIPTION
* fixes the issues 108 of rero-ils-ui, point 11

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

https://github.com/rero/rero-ils-ui/issues/108, point 11: `Search input does not take all the width in the header in the public view.`

## How to test?

* Run server locally
* Do a search in search bar
* Check that the current view have a search bar that takes all the remaining place after the logo

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
