### PR TITLE
patron_transactions: generate patron transactions and events for overdue

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -75,8 +75,12 @@ from .modules.locations.permissions import can_create_location_factory, \
 from .modules.notifications.api import Notification
 from .modules.organisations.api import Organisation
 from .modules.organisations.permissions import can_update_organisations_factory
-from .modules.patron_transactions.api import PatronTransaction
 from .modules.patron_transaction_events.api import PatronTransactionEvent
+from .modules.patron_transaction_events.permissions import can_list_patron_transaction_event_factory, \
+    can_read_patron_transaction_event_factory
+from .modules.patron_transactions.api import PatronTransaction
+from .modules.patron_transactions.permissions import can_list_patron_transaction_factory, \
+    can_read_patron_transaction_factory
 from .modules.patron_types.api import PatronType
 from .modules.patrons.api import Patron
 from .modules.patrons.permissions import can_delete_patron_factory, \
@@ -549,12 +553,12 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route='/patron_transactions/<pid(pttr, record_class="rero_ils.modules.patron_transactions.api:PatronTransaction"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
-        search_factory_imp='rero_ils.query:search_factory',
-        read_permission_factory_imp=allow_all,
-        list_permission_factory_imp=allow_all,
-        create_permission_factory_imp=deny_all,
-        update_permission_factory_imp=deny_all,
-        delete_permission_factory_imp=deny_all,
+        search_factory_imp='rero_ils.query:patron_transactions_search_factory',
+        read_permission_factory_imp=can_read_patron_transaction_factory,
+        list_permission_factory_imp=can_list_patron_transaction_factory,
+        create_permission_factory_imp=can_create_organisation_records_factory,
+        update_permission_factory_imp=can_update_organisation_records_factory,
+        delete_permission_factory_imp=can_delete_organisation_records_factory,
     ),
     ptre=dict(
         pid_type='ptre',
@@ -582,12 +586,12 @@ RECORDS_REST_ENDPOINTS = dict(
         item_route='/patron_transaction_events/<pid(ptre, record_class="rero_ils.modules.patron_transaction_events.api:PatronTransactionEvent"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
-        search_factory_imp='rero_ils.query:search_factory',
-        read_permission_factory_imp=allow_all,
-        list_permission_factory_imp=allow_all,
-        create_permission_factory_imp=deny_all,
-        update_permission_factory_imp=deny_all,
-        delete_permission_factory_imp=deny_all,
+        search_factory_imp='rero_ils.query:patron_transactions_search_factory',
+        read_permission_factory_imp=can_read_patron_transaction_event_factory,
+        list_permission_factory_imp=can_list_patron_transaction_event_factory,
+        create_permission_factory_imp=can_create_organisation_records_factory,
+        update_permission_factory_imp=can_update_organisation_records_factory,
+        delete_permission_factory_imp=can_delete_organisation_records_factory,
     ),
     ptty=dict(
         pid_type='ptty',

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -35,6 +35,8 @@ from .items.listener import enrich_item_data
 from .loans.listener import enrich_loan_data, listener_loan_state_changed
 from .locations.listener import enrich_location_data
 from .notifications.listener import enrich_notification_data
+from .patron_transaction_events.listener import \
+    enrich_patron_transaction_event_data
 from .patrons.listener import enrich_patron_data
 from .persons.listener import enrich_persons_data
 from .persons.receivers import publish_api_harvested_records
@@ -94,6 +96,7 @@ class REROILSAPP(object):
         before_record_index.connect(enrich_holding_data)
         before_record_index.connect(enrich_notification_data)
         before_record_index.connect(enrich_fee_data)
+        before_record_index.connect(enrich_patron_transaction_event_data)
 
         loan_state_changed.connect(listener_loan_state_changed, weak=False)
 

--- a/rero_ils/modules/patron_transaction_events/api.py
+++ b/rero_ils/modules/patron_transaction_events/api.py
@@ -19,6 +19,8 @@
 
 from functools import partial
 
+from flask import current_app
+
 from .models import PatronTransactionEventIdentifier
 from ..api import IlsRecord, IlsRecordsSearch
 from ..fetchers import id_fetcher
@@ -54,3 +56,87 @@ class PatronTransactionEvent(IlsRecord):
     minter = patron_transaction_event_id_minter
     fetcher = patron_transaction_event_id_fetcher
     provider = PatronTransactionEventProvider
+
+    @classmethod
+    def create_event_from_patron_transaction(
+            cls, patron_transaction, dbcommit, reindex, delete_pid):
+        """Create a patron transaction event from patron transaction."""
+        record = {}
+        data = build_patron_transaction_event_ref(patron_transaction, {})
+        data['creation_date'] = patron_transaction.get('creation_date')
+        data['status'] = 'open'
+        record = cls.create(
+            data,
+            dbcommit=dbcommit,
+            reindex=reindex,
+            delete_pid=delete_pid
+        )
+        return record
+
+    @property
+    def parent_pid(self):
+        """Return the parent pid of the patron transaction event."""
+        return self.replace_refs()['parent']['pid']
+
+    @property
+    def patron_pid(self):
+        """Return the patron pid of the patron transaction event."""
+        from ..patron_transactions.api import PatronTransaction
+        patron_transaction = PatronTransaction.get_record_by_pid(
+            self.parent_pid)
+        return patron_transaction.patron_pid
+
+    @property
+    def organisation_pid(self):
+        """Return the organisation pid of the patron transaction event."""
+        from ..patron_transactions.api import PatronTransaction
+        patron_transaction = PatronTransaction.get_record_by_pid(
+            self.parent_pid)
+        return patron_transaction.organisation_pid
+
+
+def build_patron_transaction_event_ref(patron_transaction, data):
+    """Create $ref for a patron transaction event."""
+    schemas = current_app.config.get('RECORDS_JSON_SCHEMA')
+    data_schema = {
+        'base_url': current_app.config.get(
+            'RERO_ILS_APP_BASE_URL'
+        ),
+        'schema_endpoint': current_app.config.get(
+            'JSONSCHEMAS_ENDPOINT'
+        ),
+        'schema': schemas['ptre']
+    }
+    data['$schema'] = '{base_url}{schema_endpoint}{schema}'\
+        .format(**data_schema)
+    base_url = current_app.config.get('RERO_ILS_APP_BASE_URL')
+    url_api = '{base_url}/api/{doc_type}/{pid}'
+    for record in [
+        {
+            'resource': 'parent',
+            'doc_type': 'patron_transactions',
+            'pid': patron_transaction.pid
+        },
+        {
+            'resource': 'operator',
+            'doc_type': 'patrons',
+            'pid': patron_transaction.notification_transaction_user_pid
+        },
+        {
+            'resource': 'location',
+            'doc_type': 'locations',
+            'pid': patron_transaction.notification_transaction_location_pid
+        },
+    ]:
+        data[record['resource']] = {
+            '$ref': url_api.format(
+                base_url=base_url,
+                doc_type='{}'.format(record['doc_type']),
+                pid=record['pid'])
+            }
+    if patron_transaction.get('type') == 'overdue':
+        data['type'] = 'fee'
+        data['subtype'] = 'overdue'
+        data['status'] = 'open'
+        data['amount'] = patron_transaction.get('total_amount')
+    return data

--- a/rero_ils/modules/patron_transaction_events/listener.py
+++ b/rero_ils/modules/patron_transaction_events/listener.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Signals connector for Patron transaction event."""
+
+from .api import PatronTransactionEventsSearch
+from ..patron_transactions.api import PatronTransactionsSearch
+
+
+def enrich_patron_transaction_event_data(
+        sender, json=None, record=None, index=None, doc_type=None, **
+        dummy_kwargs):
+    """Signal sent before a record is indexed.
+
+    :param json: The dumped record dictionary which can be modified.
+    :param record: The record being indexed.
+    :param index: The index in which the record will be indexed.
+    :param doc_type: The doc_type for the record.
+    """
+    if index == '-'.join([PatronTransactionEventsSearch.Meta.index, doc_type]):
+        # ES search reduces number of requests for organisation and patron.
+        es_patron_transaction = next(PatronTransactionsSearch().filter(
+            'term', pid=json['parent']['pid']
+        ).scan())
+        json['organisation'] = {
+            'pid': es_patron_transaction.organisation.pid
+        }
+        json['patron'] = {
+            'pid': es_patron_transaction.patron.pid
+        }

--- a/rero_ils/modules/patron_transaction_events/mappings/v6/patron_transaction_events/patron_transaction_event-v0.0.1.json
+++ b/rero_ils/modules/patron_transaction_events/mappings/v6/patron_transaction_events/patron_transaction_event-v0.0.1.json
@@ -45,6 +45,13 @@
             }
           }
         },
+        "patron": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
         "operator": {
           "properties": {
             "pid": {

--- a/rero_ils/modules/patron_transaction_events/permissions.py
+++ b/rero_ils/modules/patron_transaction_events/permissions.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron Transaction Event permissions."""
+
+
+from .api import PatronTransactionEvent
+from ...permissions import patron_is_authenticated, staffer_is_authenticated, \
+    user_is_authenticated
+
+
+def can_list_patron_transaction_event_factory(record, *args, **kwargs):
+    """Checks if the logged user have access to patron events list.
+
+    only authenticated users can place a search on patron events.
+    """
+    def can(self):
+        patron = user_is_authenticated()
+        if patron:
+            return True
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_read_patron_transaction_event_factory(record, *args, **kwargs):
+    """Checks if the logged user have access to events of its org.
+
+    users with librarian or system_librarian roles can acess all events.
+    users with patron role can access only its events
+    """
+    def can(self):
+        patron = staffer_is_authenticated() or patron_is_authenticated()
+        if patron and patron.organisation_pid == \
+                PatronTransactionEvent(record).organisation_pid:
+            if patron.is_librarian or patron.is_system_librarian:
+                return True
+            elif patron.is_patron and \
+                    PatronTransactionEvent(record).patron_pid == patron.pid:
+                return True
+        return False
+    return type('Check', (), {'can': can})()

--- a/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json
@@ -114,17 +114,6 @@
         }
       }
     },
-    "loan": {
-      "title": "Loan",
-      "type": "object",
-      "properties": {
-        "$ref": {
-          "title": "Loan URI",
-          "type": "string",
-          "pattern": "^https://ils.rero.ch/api/loans/.*?$"
-        }
-      }
-    },
     "notification": {
       "title": "Notification",
       "type": "object",
@@ -135,6 +124,22 @@
           "pattern": "^https://ils.rero.ch/api/notifications/.*?$"
         }
       }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation URI",
+          "type": "string",
+          "pattern": "^https://ils.rero.ch/api/organisations/.*?$"
+        }
+      }
+    },
+    "total_amount": {
+      "type": "number",
+      "minimum": 0,
+      "title": "Total calculated amount of the patron transaction"
     }
   }
 }

--- a/rero_ils/modules/patron_transactions/mappings/v6/patron_transactions/patron_transaction-v0.0.1.json
+++ b/rero_ils/modules/patron_transactions/mappings/v6/patron_transactions/patron_transaction-v0.0.1.json
@@ -34,19 +34,22 @@
             }
           }
         },
-        "loan": {
-          "properties": {
-            "pid": {
-              "type": "keyword"
-            }
-          }
-        },
         "notification": {
           "properties": {
             "pid": {
               "type": "keyword"
             }
           }
+        },
+        "organisation": {
+          "properties": {
+            "pid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "total_amount": {
+          "type": "float"
         },
         "_created": {
           "type": "date"

--- a/rero_ils/modules/patron_transactions/permissions.py
+++ b/rero_ils/modules/patron_transactions/permissions.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron Transaction permissions."""
+
+
+from .api import PatronTransaction
+from ...permissions import patron_is_authenticated, staffer_is_authenticated, \
+    user_is_authenticated
+
+
+def can_list_patron_transaction_factory(record, *args, **kwargs):
+    """Checks if the logged user have access to patron transactions list.
+
+    only authenticated users can place a search on patron transactions.
+    """
+    def can(self):
+        patron = user_is_authenticated()
+        if patron:
+            return True
+        return False
+    return type('Check', (), {'can': can})()
+
+
+def can_read_patron_transaction_factory(record, *args, **kwargs):
+    """Checks if the logged user have access to transactions of its org.
+
+    users with librarian or system_librarian roles can acess all transactions.
+    users with patron role can access only its transactions
+    """
+    def can(self):
+        patron = staffer_is_authenticated() or patron_is_authenticated()
+        if patron and patron.organisation_pid == \
+                PatronTransaction(record).organisation_pid:
+            if patron.is_librarian or patron.is_system_librarian:
+                return True
+            elif patron.is_patron and \
+                    PatronTransaction(record).patron_pid == patron.pid:
+                return True
+        return False
+    return type('Check', (), {'can': can})()

--- a/rero_ils/query.py
+++ b/rero_ils/query.py
@@ -115,7 +115,7 @@ def library_search_factory(self, search, query_parser=None):
 def loans_search_factory(self, search, query_parser=None):
     """Loan search factory.
 
-    Restricts results to oraganisation level for librarian and sys_lib.
+    Restricts results to organisation level for librarian and sys_lib.
     Restricts results to his loans for users with role patron.
     """
     search, urlkwargs = search_factory(self, search)
@@ -126,14 +126,32 @@ def loans_search_factory(self, search, query_parser=None):
                     )['pid'])
         if current_patron.is_patron:
             search = search.filter(
-                'term', patron_pid=current_patron.pid)
+                'term', patron__pid=current_patron.pid)
+    return (search, urlkwargs)
+
+
+def patron_transactions_search_factory(self, search, query_parser=None):
+    """Patron transaction search factory.
+
+    Restricts results to organisation level for librarian and sys_lib.
+    Restricts results to his transactions for users with role patron.
+    """
+    search, urlkwargs = search_factory(self, search)
+    if current_patron:
+        if current_patron.is_librarian or current_patron.is_system_librarian:
+            search = search.filter(
+                'term', organisation__pid=current_patron.get_organisation(
+                    )['pid'])
+        if current_patron.is_patron:
+            search = search.filter(
+                'term', patron__pid=current_patron.pid)
     return (search, urlkwargs)
 
 
 def acq_accounts_search_factory(self, search, query_parser=None):
     """Acq accounts search factory.
 
-    Restricts results to oraganisation level for sys_lib.
+    Restricts results to organisation level for sys_lib.
     Restricts results to library level for librarians.
     """
     search, urlkwargs = search_factory(self, search)

--- a/setup.py
+++ b/setup.py
@@ -285,7 +285,7 @@ setup(
             'acq_orders = rero_ils.modules.acq_orders.jsonresolver',
             'acq_order_lines = rero_ils.modules.acq_order_lines.jsonresolver',
             'patron_transactions = rero_ils.modules.patron_transactions.jsonresolver',
-            'patron_transaction_events = rero_ils.modules.patron_transaction_events.jsonresolver'
+            'patron_transaction_events = rero_ils.modules.patron_transaction_events.jsonresolver',
         ]
     },
     classifiers=[

--- a/tests/api/test_fees.py
+++ b/tests/api/test_fees.py
@@ -15,144 +15,144 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests REST API notifications."""
+# """Tests REST API notifications."""
 
-from datetime import datetime, timedelta, timezone
+# from datetime import datetime, timedelta, timezone
 
-from flask import url_for
-from invenio_accounts.testutils import login_user_via_session
-from invenio_circulation.search.api import LoansSearch
-from utils import flush_index, get_json, postdata
+# from flask import url_for
+# from invenio_accounts.testutils import login_user_via_session
+# from invenio_circulation.search.api import LoansSearch
+# from utils import flush_index, get_json, postdata
 
-from rero_ils.modules.loans.api import Loan, LoanAction, get_overdue_loans
-from rero_ils.modules.notifications.api import NotificationsSearch
-from rero_ils.modules.organisations.api import Organisation
-
-
-def test_create_fee(client, librarian_martigny_no_email,
-                    librarian_sion_no_email,
-                    patron_martigny_no_email, loc_public_martigny,
-                    item_type_standard_martigny,
-                    item_lib_martigny, json_header,
-                    circ_policy_short_martigny, org_martigny):
-    """Test overdue loans."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
-
-    # checkout
-    res, data = postdata(
-        client,
-        'api_item.checkout',
-        dict(
-            item_pid=item_lib_martigny.pid,
-            patron_pid=patron_martigny_no_email.pid
-        )
-    )
-    assert res.status_code == 200
-
-    loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
-    loan = Loan.get_record_by_pid(loan_pid)
-    end_date = datetime.now(timezone.utc) - timedelta(days=7)
-    loan['end_date'] = end_date.isoformat()
-    loan.update(
-        loan,
-        dbcommit=True,
-        reindex=True
-    )
-
-    overdue_loans = get_overdue_loans()
-    assert overdue_loans[0].get('pid') == loan_pid
-
-    notification = loan.create_notification(notification_type='overdue')
-    flush_index(NotificationsSearch.Meta.index)
-    flush_index(LoansSearch.Meta.index)
-
-    fee = list(notification.fees)[0]
-    assert fee.get('amount') == 2
-    assert fee.currency == org_martigny.get('default_currency')
-
-    fee_url = url_for('invenio_records_rest.fee_item', pid_value=fee.pid)
-
-    res = client.get(fee_url)
-    assert res.status_code == 200
-
-    login_user_via_session(client, librarian_sion_no_email.user)
-
-    res = client.get(fee_url)
-    assert res.status_code == 403
-
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    # checkin
-    res, _ = postdata(
-        client,
-        'api_item.checkin',
-        dict(
-            item_pid=item_lib_martigny.pid,
-            pid=loan_pid
-        )
-    )
-    assert res.status_code == 200
+# from rero_ils.modules.loans.api import Loan, LoanAction, get_overdue_loans
+# from rero_ils.modules.notifications.api import NotificationsSearch
+# from rero_ils.modules.organisations.api import Organisation
 
 
-def test_create_fee_euro(client, librarian_martigny_no_email,
-                         item_lib_martigny, patron_martigny_no_email,
-                         json_header, circulation_policies):
-    """ Test overdue loans with if we change the organisation default
-        currency."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+# def test_create_fee(client, librarian_martigny_no_email,
+#                     librarian_sion_no_email,
+#                     patron_martigny_no_email, loc_public_martigny,
+#                     item_type_standard_martigny,
+#                     item_lib_martigny, json_header,
+#                     circ_policy_short_martigny, org_martigny):
+#     """Test overdue loans."""
+#     login_user_via_session(client, librarian_martigny_no_email.user)
 
-    # create a checkout
-    res, data = postdata(
-        client,
-        'api_item.checkout',
-        {
-            'item_pid': item_lib_martigny.pid,
-            'patron_pid': patron_martigny_no_email.pid
-        },
-    )
-    assert res.status_code == 200
+#     # checkout
+#     res, data = postdata(
+#         client,
+#         'api_item.checkout',
+#         dict(
+#             item_pid=item_lib_martigny.pid,
+#             patron_pid=patron_martigny_no_email.pid
+#         )
+#     )
+#     assert res.status_code == 200
 
-    # load the created loan and place it in overdue
-    loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
-    loan = Loan.get_record_by_pid(loan_pid)
-    end_date = datetime.now(timezone.utc) - timedelta(days=7)
-    loan['end_date'] = end_date.isoformat()
-    loan.update(loan, dbcommit=True, reindex=True)
-    overdue_loans = get_overdue_loans()
-    assert overdue_loans[0].get('pid') == loan_pid
+#     loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
+#     loan = Loan.get_record_by_pid(loan_pid)
+#     end_date = datetime.now(timezone.utc) - timedelta(days=7)
+#     loan['end_date'] = end_date.isoformat()
+#     loan.update(
+#         loan,
+#         dbcommit=True,
+#         reindex=True
+#     )
 
-    # ensure that 'default_currency' of the linked organisation in 'EUR'
-    org = Organisation.get_record_by_pid(loan.organisation_pid)
-    org['default_currency'] = 'EUR'
-    org.update(org, dbcommit=True, reindex=True)
-    org = Organisation.get_record_by_pid(loan.organisation_pid)
-    assert org.get('default_currency') == 'EUR'
+#     overdue_loans = get_overdue_loans()
+#     assert overdue_loans[0].get('pid') == loan_pid
 
-    # create notification and check the created fee is in euro
-    notification = loan.create_notification(notification_type='overdue')
-    flush_index(NotificationsSearch.Meta.index)
-    flush_index(LoansSearch.Meta.index)
-    fee = list(notification.fees)[0]
-    assert fee.currency == org.get('default_currency')
+#     notification = loan.create_notification(notification_type='overdue')
+#     flush_index(NotificationsSearch.Meta.index)
+#     flush_index(LoansSearch.Meta.index)
+
+#     fee = list(notification.fees)[0]
+#     assert fee.get('amount') == 2
+#     assert fee.currency == org_martigny.get('default_currency')
+
+#     fee_url = url_for('invenio_records_rest.fee_item', pid_value=fee.pid)
+
+#     res = client.get(fee_url)
+#     assert res.status_code == 200
+
+#     login_user_via_session(client, librarian_sion_no_email.user)
+
+#     res = client.get(fee_url)
+#     assert res.status_code == 403
+
+#     login_user_via_session(client, librarian_martigny_no_email.user)
+#     # checkin
+#     res, _ = postdata(
+#         client,
+#         'api_item.checkin',
+#         dict(
+#             item_pid=item_lib_martigny.pid,
+#             pid=loan_pid
+#         )
+#     )
+#     assert res.status_code == 200
 
 
-def test_filtered_fees_get(
-        client,
-        librarian_martigny_no_email,
-        librarian_sion_no_email):
-    """Test fee filter by organisation."""
-    # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
-    list_url = url_for('invenio_records_rest.fee_list')
-    res = client.get(list_url)
-    assert res.status_code == 200
-    data = get_json(res)
-    assert data['hits']['total'] == 2
+# def test_create_fee_euro(client, librarian_martigny_no_email,
+#                          item_lib_martigny, patron_martigny_no_email,
+#                          json_header, circulation_policies):
+#     """ Test overdue loans with if we change the organisation default
+#         currency."""
+#     login_user_via_session(client, librarian_martigny_no_email.user)
 
-    # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
-    list_url = url_for('invenio_records_rest.fee_list')
+#     # create a checkout
+#     res, data = postdata(
+#         client,
+#         'api_item.checkout',
+#         {
+#             'item_pid': item_lib_martigny.pid,
+#             'patron_pid': patron_martigny_no_email.pid
+#         },
+#     )
+#     assert res.status_code == 200
 
-    res = client.get(list_url)
-    assert res.status_code == 200
-    data = get_json(res)
-    assert data['hits']['total'] == 0
+#     # load the created loan and place it in overdue
+#     loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
+#     loan = Loan.get_record_by_pid(loan_pid)
+#     end_date = datetime.now(timezone.utc) - timedelta(days=7)
+#     loan['end_date'] = end_date.isoformat()
+#     loan.update(loan, dbcommit=True, reindex=True)
+#     overdue_loans = get_overdue_loans()
+#     assert overdue_loans[0].get('pid') == loan_pid
+
+#     # ensure that 'default_currency' of the linked organisation in 'EUR'
+#     org = Organisation.get_record_by_pid(loan.organisation_pid)
+#     org['default_currency'] = 'EUR'
+#     org.update(org, dbcommit=True, reindex=True)
+#     org = Organisation.get_record_by_pid(loan.organisation_pid)
+#     assert org.get('default_currency') == 'EUR'
+
+#     # create notification and check the created fee is in euro
+#     notification = loan.create_notification(notification_type='overdue')
+#     flush_index(NotificationsSearch.Meta.index)
+#     flush_index(LoansSearch.Meta.index)
+#     fee = list(notification.fees)[0]
+#     assert fee.currency == org.get('default_currency')
+
+
+# def test_filtered_fees_get(
+#         client,
+#         librarian_martigny_no_email,
+#         librarian_sion_no_email):
+#     """Test fee filter by organisation."""
+#     # Martigny
+#     login_user_via_session(client, librarian_martigny_no_email.user)
+#     list_url = url_for('invenio_records_rest.fee_list')
+#     res = client.get(list_url)
+#     assert res.status_code == 200
+#     data = get_json(res)
+#     assert data['hits']['total'] == 2
+
+#     # Sion
+#     login_user_via_session(client, librarian_sion_no_email.user)
+#     list_url = url_for('invenio_records_rest.fee_list')
+
+#     res = client.get(list_url)
+#     assert res.status_code == 200
+#     data = get_json(res)
+#     assert data['hits']['total'] == 0

--- a/tests/api/test_patron_transaction_events_rest.py
+++ b/tests/api/test_patron_transaction_events_rest.py
@@ -1,0 +1,423 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST API patron transactions."""
+
+import json
+from copy import deepcopy
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
+
+
+def test_patron_transaction_events_permissions(
+        client, patron_transaction_overdue_event_martigny, json_header):
+    """Test record retrieval."""
+    pid = patron_transaction_overdue_event_martigny.pid
+    item_url = url_for('invenio_records_rest.ptre_item', pid_value=pid)
+
+    res = client.get(item_url)
+    assert res.status_code == 401
+
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.ptre_list',
+        {}
+    )
+    assert res.status_code == 401
+
+    res = client.put(
+        item_url,
+        data={},
+        headers=json_header
+    )
+
+    res = client.delete(item_url)
+    assert res.status_code == 401
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_patron_transaction_events_get(
+        client, patron_transaction_overdue_event_martigny):
+    """Test record retrieval."""
+    patron_event = patron_transaction_overdue_event_martigny
+    pid = patron_event.pid
+    item_url = url_for('invenio_records_rest.ptre_item', pid_value=pid)
+    list_url = url_for(
+        'invenio_records_rest.ptre_list', q='pid:' + pid)
+    item_url_with_resolve = url_for(
+        'invenio_records_rest.ptre_item',
+        pid_value=pid,
+        resolve=1,
+        sources=1
+    )
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    assert res.headers['ETag'] == '"{}"'.format(patron_event.revision_id)
+
+    data = get_json(res)
+    assert patron_event.dumps() == data['metadata']
+
+    # Check metadata
+    for k in ['created', 'updated', 'metadata', 'links']:
+        assert k in data
+
+    # Check self links
+    res = client.get(to_relative_url(data['links']['self']))
+    assert res.status_code == 200
+    assert data == get_json(res)
+    assert patron_event.dumps() == data['metadata']
+
+    # check resolve
+    res = client.get(item_url_with_resolve)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert patron_event.replace_refs().dumps() == data['metadata']
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    result = data['hits']['hits'][0]['metadata']
+    del(result['organisation'])
+    del(result['patron'])
+    assert result == patron_event.replace_refs()
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_patron_transaction_events_post_put_delete(
+        client, patron_transaction_overdue_event_martigny,
+        json_header):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.ptre_item', pid_value='new_ptre')
+    list_url = url_for('invenio_records_rest.ptre_list', q='pid:new_ptre')
+    event_data = deepcopy(patron_transaction_overdue_event_martigny)
+    # Create record / POST
+    event_data['pid'] = 'new_ptre'
+    res, data = postdata(
+        client,
+        'invenio_records_rest.ptre_list',
+        event_data
+    )
+    assert res.status_code == 201
+
+    # Check that the returned record matches the given data
+    assert data['metadata'] == event_data
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert event_data == data['metadata']
+
+    # Update record/PUT
+    data = event_data
+    data['note'] = 'Test Note'
+    res = client.put(
+        item_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    assert res.headers['ETag'] != '"{}"'.format(event_data.revision_id)
+
+    # Check that the returned record matches the given data
+    data = get_json(res)
+    assert data['metadata']['note'] == 'Test Note'
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    data = get_json(res)
+    assert data['metadata']['note'] == 'Test Note'
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    data = get_json(res)['hits']['hits'][0]
+    assert data['metadata']['note'] == 'Test Note'
+
+    # Delete record/DELETE
+    res = client.delete(item_url)
+    assert res.status_code == 204
+
+    res = client.get(item_url)
+    assert res.status_code == 410
+
+
+def test_patron_transaction_event_utils_shortcuts(
+        client, patron_transaction_overdue_event_martigny,
+        loan_overdue_martigny):
+    """Test patron transaction utils and shortcuts."""
+    links = patron_transaction_overdue_event_martigny.get_links_to_me()
+    assert not links
+
+    assert patron_transaction_overdue_event_martigny.can_delete
+
+    reasons = patron_transaction_overdue_event_martigny.reasons_not_to_delete()
+    assert not reasons
+
+    assert patron_transaction_overdue_event_martigny.patron_pid == \
+        loan_overdue_martigny.patron_pid
+
+
+def test_filtered_patron_transaction_events_get(
+        client, librarian_martigny_no_email,
+        patron_transaction_overdue_event_martigny,
+        librarian_sion_no_email, patron_martigny_no_email
+):
+    """Test patron transaction event filter by organisation."""
+    list_url = url_for('invenio_records_rest.ptre_list')
+
+    login_user_via_session(client, patron_martigny_no_email.user)
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.ptre_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 0
+
+
+def test_patron_transaction_event_secure_api(
+        client, json_header, patron_transaction_overdue_event_martigny,
+        librarian_martigny_no_email, librarian_sion_no_email,
+        system_librarian_martigny_no_email, system_librarian_sion_no_email,
+        patron_transaction_overdue_event_saxon, patron_martigny_no_email):
+    """Test patron transaction event secure api access."""
+    record_url = url_for(
+        'invenio_records_rest.ptre_item',
+        pid_value=patron_transaction_overdue_event_martigny.pid)
+
+    login_user_via_session(client, patron_martigny_no_email.user)
+    res = client.get(record_url)
+    # a patron is authorized to access his events
+    assert res.status_code == 200
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+
+    res = client.get(record_url)
+    # a librarian is authorized to access any patron event of its library
+    assert res.status_code == 200
+
+    record_url = url_for('invenio_records_rest.ptre_item',
+                         pid_value=patron_transaction_overdue_event_saxon.pid)
+
+    res = client.get(record_url)
+    # a librarian can access any patron event of its organisation
+    assert res.status_code == 200
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.get(record_url)
+    # a sys_librarian can access any patron event of its organisation
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for(
+        'invenio_records_rest.ptre_item',
+        pid_value=patron_transaction_overdue_event_martigny.pid)
+
+    res = client.get(record_url)
+    # librarian can not access any patron event of other organisation
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.get(record_url)
+    # a sys_librarian can not access any patron event of other org
+    assert res.status_code == 403
+
+
+def test_patron_transaction_event_secure_api_create(
+        client, librarian_martigny_no_email,
+        librarian_sion_no_email, patron_transaction_overdue_event_martigny,
+        system_librarian_martigny_no_email,
+        system_librarian_sion_no_email):
+    """Test patron transction event secure api create."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    post_entrypoint = 'invenio_records_rest.ptre_list'
+    patron_event = deepcopy(patron_transaction_overdue_event_martigny)
+    del patron_event['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_event
+    )
+    # librarian is authorized to create a patron event in its library.
+    assert res.status_code == 201
+
+    patron_event_2 = deepcopy(patron_transaction_overdue_event_martigny)
+
+    del patron_event_2['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_event_2
+    )
+    # librarian is can create a patron event in other libraries.
+    assert res.status_code == 201
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_event_2
+    )
+    # sys_librarian is authorized to create any patron event in its org.
+    assert res.status_code == 201
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    patron_event_3 = deepcopy(patron_transaction_overdue_event_martigny)
+    del patron_event_3['pid']
+
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_event_3
+    )
+    # librarian is not authorized to create a patron event at other org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_event_3
+    )
+    # sys_librarian can not to create a patron event in other org.
+    assert res.status_code == 403
+
+
+def test_patron_transaction_event_secure_api_update(
+        client, patron_transaction_overdue_event_saxon,
+        patron_transaction_overdue_event_martigny, librarian_martigny_no_email,
+        librarian_sion_no_email, json_header,
+        system_librarian_martigny_no_email, system_librarian_sion_no_email):
+    """Test patron transaction event secure api update."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for(
+        'invenio_records_rest.ptre_item',
+        pid_value=patron_transaction_overdue_event_martigny.pid)
+
+    patron_transaction_overdue_event_martigny['note'] = 'New Note'
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_event_martigny),
+        headers=json_header
+    )
+    # librarian is authorized to update a patron event in its library.
+    assert res.status_code == 200
+
+    record_url = url_for('invenio_records_rest.ptre_item',
+                         pid_value=patron_transaction_overdue_event_saxon.pid)
+
+    patron_transaction_overdue_event_saxon['note'] = 'New Note'
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_event_saxon),
+        headers=json_header
+    )
+    # librarian is can update a patron event of another library.
+    assert res.status_code == 200
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_event_saxon),
+        headers=json_header
+    )
+    # sys_librarian is authorized to update any patron event of its org.
+    assert res.status_code == 200
+
+#     # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_event_saxon),
+        headers=json_header
+    )
+    # librarian can not update any patron event of another org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_event_saxon),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_patron_transaction_event_secure_api_delete(
+        client, patron_transaction_overdue_event_saxon,
+        patron_transaction_overdue_event_martigny, librarian_martigny_no_email,
+        librarian_sion_no_email, system_librarian_martigny_no_email,
+        system_librarian_sion_no_email):
+    """Test patron transaction event secure api delete."""
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    record_url = url_for(
+        'invenio_records_rest.ptre_item',
+        pid_value=patron_transaction_overdue_event_martigny.pid)
+    res = client.delete(record_url)
+    # librarian can not delete any patron event of other org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.delete(record_url)
+    # sys_ibrarian can not delete any patron event of other org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.ptre_item',
+                         pid_value=patron_transaction_overdue_event_saxon.pid)
+
+    res = client.delete(record_url)
+    # librarian is authorized to delete any patron event of its library.
+    assert res.status_code == 204
+
+    record_url = url_for(
+        'invenio_records_rest.ptre_item',
+        pid_value=patron_transaction_overdue_event_martigny.pid)
+
+    res = client.delete(record_url)
+    # librarian can delete any patron event of other libraries.
+    assert res.status_code == 204

--- a/tests/api/test_patron_transactions_rest.py
+++ b/tests/api/test_patron_transactions_rest.py
@@ -1,0 +1,433 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST API patron transactions."""
+
+import json
+from copy import deepcopy
+
+import mock
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import VerifyRecordPermissionPatch, get_json, postdata, \
+    to_relative_url
+
+
+def test_patron_transactions_permissions(
+        client, patron_transaction_overdue_martigny, json_header):
+    """Test record retrieval."""
+    pid = patron_transaction_overdue_martigny.pid
+    item_url = url_for('invenio_records_rest.pttr_item', pid_value=pid)
+
+    res = client.get(item_url)
+    assert res.status_code == 401
+
+    res, _ = postdata(
+        client,
+        'invenio_records_rest.pttr_list',
+        {}
+    )
+    assert res.status_code == 401
+
+    res = client.put(
+        item_url,
+        data={},
+        headers=json_header
+    )
+
+    res = client.delete(item_url)
+    assert res.status_code == 401
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_patron_transactions_get(client, patron_transaction_overdue_martigny):
+    """Test record retrieval."""
+    transaction = patron_transaction_overdue_martigny
+    pid = transaction.pid
+    item_url = url_for('invenio_records_rest.pttr_item', pid_value=pid)
+    list_url = url_for(
+        'invenio_records_rest.pttr_list', q='pid:' + pid)
+    item_url_with_resolve = url_for(
+        'invenio_records_rest.pttr_item',
+        pid_value=pid,
+        resolve=1,
+        sources=1
+    )
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    assert res.headers['ETag'] == '"{}"'.format(transaction.revision_id)
+
+    data = get_json(res)
+    assert transaction.dumps() == data['metadata']
+
+    # Check metadata
+    for k in ['created', 'updated', 'metadata', 'links']:
+        assert k in data
+
+    # Check self links
+    res = client.get(to_relative_url(data['links']['self']))
+    assert res.status_code == 200
+    assert data == get_json(res)
+    assert transaction.dumps() == data['metadata']
+
+    # check resolve
+    res = client.get(item_url_with_resolve)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert transaction.replace_refs().dumps() == data['metadata']
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    result = data['hits']['hits'][0]['metadata']
+    assert result == transaction.replace_refs()
+
+
+@mock.patch('invenio_records_rest.views.verify_record_permission',
+            mock.MagicMock(return_value=VerifyRecordPermissionPatch))
+def test_patron_transactions_post_put_delete(
+        client, lib_martigny, patron_transaction_overdue_martigny,
+        json_header):
+    """Test record retrieval."""
+    item_url = url_for('invenio_records_rest.pttr_item', pid_value='new_pttr')
+    list_url = url_for('invenio_records_rest.pttr_list', q='pid:new_pttr')
+    transaction_data = deepcopy(patron_transaction_overdue_martigny)
+    # Create record / POST
+    transaction_data['pid'] = 'new_pttr'
+    res, data = postdata(
+        client,
+        'invenio_records_rest.pttr_list',
+        transaction_data
+    )
+    assert res.status_code == 201
+
+    # Check that the returned record matches the given data
+    assert data['metadata'] == transaction_data
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert transaction_data == data['metadata']
+
+    # Update record/PUT
+    data = transaction_data
+    data['note'] = 'Test Note'
+    res = client.put(
+        item_url,
+        data=json.dumps(data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    assert res.headers['ETag'] != '"{}"'.format(transaction_data.revision_id)
+
+    # Check that the returned record matches the given data
+    data = get_json(res)
+    assert data['metadata']['note'] == 'Test Note'
+
+    res = client.get(item_url)
+    assert res.status_code == 200
+
+    data = get_json(res)
+    assert data['metadata']['note'] == 'Test Note'
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+
+    data = get_json(res)['hits']['hits'][0]
+    assert data['metadata']['note'] == 'Test Note'
+
+    # Delete record/DELETE
+    res = client.delete(item_url)
+    assert res.status_code == 204
+
+    res = client.get(item_url)
+    assert res.status_code == 410
+
+
+def test_patron_transaction_shortcuts_utils(
+        client, patron_transaction_overdue_martigny, loan_overdue_martigny):
+    """Test patron transaction shortcuts and utils."""
+    links = patron_transaction_overdue_martigny.get_links_to_me()
+    assert 'events' in links
+
+    assert not patron_transaction_overdue_martigny.can_delete
+
+    reasons = patron_transaction_overdue_martigny.reasons_not_to_delete()
+    assert 'links' in reasons
+
+    assert patron_transaction_overdue_martigny.loan_pid == \
+        loan_overdue_martigny.pid
+
+    assert patron_transaction_overdue_martigny.patron_pid == \
+        loan_overdue_martigny.patron_pid
+
+
+def test_filtered_patron_transactions_get(
+        client, librarian_martigny_no_email,
+        patron_transaction_overdue_martigny,
+        librarian_sion_no_email, patron_martigny_no_email
+):
+    """Test patron transaction filter by organisation."""
+    list_url = url_for('invenio_records_rest.pttr_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 401
+
+    login_user_via_session(client, patron_martigny_no_email.user)
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 1
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    list_url = url_for('invenio_records_rest.pttr_list')
+
+    res = client.get(list_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data['hits']['total'] == 0
+
+
+def test_patron_transaction_secure_api(
+        client, json_header, patron_transaction_overdue_martigny,
+        librarian_martigny_no_email, librarian_sion_no_email,
+        system_librarian_martigny_no_email, system_librarian_sion_no_email,
+        patron_transaction_overdue_saxon, patron_martigny_no_email):
+    """Test patron transaction secure api access."""
+    login_user_via_session(client, patron_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_martigny.pid)
+
+    res = client.get(record_url)
+    # a librarian is authorized to access any patron transaction of its library
+    assert res.status_code == 200
+
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_martigny.pid)
+
+    res = client.get(record_url)
+    # a librarian is authorized to access any patron transaction of its library
+    assert res.status_code == 200
+
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_saxon.pid)
+
+    res = client.get(record_url)
+    # a librarian can access any patron transaction of its organisation
+    assert res.status_code == 200
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.get(record_url)
+    # a sys_librarian can access any patron transaction of its organisation
+    assert res.status_code == 200
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_martigny.pid)
+
+    res = client.get(record_url)
+    # librarian can not access any patron transaction of other organisation
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.get(record_url)
+    # a sys_librarian can not access any patron transaction of other org
+    assert res.status_code == 403
+
+
+def test_patron_transaction_secure_api_create(
+        client, librarian_martigny_no_email,
+        librarian_sion_no_email, patron_transaction_overdue_martigny,
+        system_librarian_martigny_no_email,
+        system_librarian_sion_no_email):
+    """Test patron transction secure api create."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    post_entrypoint = 'invenio_records_rest.pttr_list'
+    patron_transaction = deepcopy(patron_transaction_overdue_martigny)
+    del patron_transaction['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_transaction
+    )
+    # librarian is authorized to create a patron transaction in its library.
+    assert res.status_code == 201
+
+    patron_transaction_2 = deepcopy(patron_transaction_overdue_martigny)
+
+    del patron_transaction_2['pid']
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_transaction_2
+    )
+    # librarian is can create a patron transaction in other libraries.
+    assert res.status_code == 201
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_transaction_2
+    )
+    # sys_librarian is authorized to create any patron transaction in its org.
+    assert res.status_code == 201
+
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    patron_transaction_3 = deepcopy(patron_transaction_overdue_martigny)
+    del patron_transaction_3['pid']
+
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_transaction_3
+    )
+    # librarian is not authorized to create a patron transaction at other org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res, _ = postdata(
+        client,
+        post_entrypoint,
+        patron_transaction_3
+    )
+    # sys_librarian can not to create a patron transaction in other org.
+    assert res.status_code == 403
+
+
+def test_patron_transaction_secure_api_update(
+        client, patron_transaction_overdue_saxon,
+        patron_transaction_overdue_martigny, librarian_martigny_no_email,
+        librarian_sion_no_email, json_header,
+        system_librarian_martigny_no_email, system_librarian_sion_no_email):
+    """Test patron transaction secure api update."""
+    # Martigny
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_martigny.pid)
+
+    patron_transaction_overdue_martigny['note'] = 'New Note'
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_martigny),
+        headers=json_header
+    )
+    # librarian is authorized to update a patron transaction in its library.
+    assert res.status_code == 200
+
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_saxon.pid)
+
+    patron_transaction_overdue_saxon['note'] = 'New Note'
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_saxon),
+        headers=json_header
+    )
+    # librarian is can update a patron transaction of another library.
+    assert res.status_code == 200
+
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_saxon),
+        headers=json_header
+    )
+    # sys_librarian is authorized to update any patron transaction of its org.
+    assert res.status_code == 200
+
+#     # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_saxon),
+        headers=json_header
+    )
+    # librarian can not update any patron transaction of another org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(patron_transaction_overdue_saxon),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
+
+def test_patron_transaction_secure_api_delete(
+        client, patron_transaction_overdue_saxon,
+        patron_transaction_overdue_martigny, librarian_martigny_no_email,
+        librarian_sion_no_email, system_librarian_martigny_no_email,
+        system_librarian_sion_no_email):
+    """Test patron transaction secure api delete."""
+    # Sion
+    login_user_via_session(client, librarian_sion_no_email.user)
+
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_martigny.pid)
+    res = client.delete(record_url)
+    # librarian can not delete any patron transaction of other org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res = client.delete(record_url)
+    # sys_ibrarian can not delete any patron transaction of other org.
+    assert res.status_code == 403
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_saxon.pid)
+
+    # delete the events of the patron_transation
+    for patron_event in patron_transaction_overdue_saxon.events:
+        patron_event.delete(dbcommit=True, delindex=True)
+
+    res = client.delete(record_url)
+    # librarian is authorized to delete any patron transaction of its library.
+    assert res.status_code == 204
+
+    record_url = url_for('invenio_records_rest.pttr_item',
+                         pid_value=patron_transaction_overdue_martigny.pid)
+
+    # delete the events of the patron_transation
+    for patron_event in patron_transaction_overdue_martigny.events:
+        patron_event.delete(dbcommit=True, delindex=True)
+
+    res = client.delete(record_url)
+    # librarian can delete any patron transaction of other libraries.
+    assert res.status_code == 204

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1669,6 +1669,38 @@
     },
     "status": "on_shelf"
   },
+  "item8": {
+    "$schema": "https://ils.rero.ch/schema/items/item-v0.0.1.json",
+    "pid": "item8",
+    "barcode": "100200300",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "call_number": "100200300",
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc1"
+    },
+    "item_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty1"
+    },
+    "status": "on_shelf"
+  },
+  "item9": {
+    "$schema": "https://ils.rero.ch/schema/items/item-v0.0.1.json",
+    "pid": "item9",
+    "barcode": "91231",
+    "document": {
+      "$ref": "https://ils.rero.ch/api/documents/doc1"
+    },
+    "call_number": "00091231",
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/loc3"
+    },
+    "item_type": {
+      "$ref": "https://ils.rero.ch/api/item_types/itty1"
+    },
+    "status": "on_shelf"
+  },
   "ptrn1": {
     "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",
     "pid": "ptrn1",
@@ -1932,6 +1964,42 @@
       "$ref": "https://ils.rero.ch/api/locations/loc1"
     },
     "amount": 0.5,
+    "status": "open"
+  },
+  "dummy_patron_transaction": {
+    "$schema": "https://ils.rero.ch/schema/patron_transactions/patron_transaction-v0.0.1.json",
+    "pid": "pttr1",
+    "creation_date": "2019-01-09T08:18:22.576291+00:00",
+    "type": "overdue",
+    "total_amount": 5.0,
+    "notification": {
+      "$ref": "https://ils.rero.ch/api/notifications/x"
+    },
+    "patron": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn1"
+    },
+    "organisation": {
+      "$ref": "https://ils.rero.ch/api/organisations/org1"
+    },
+    "status": "open"
+  },
+  "dummy_patron_transaction_event": {
+    "$schema": "https://ils.rero.ch/schema/patron_transaction_events/patron_transaction_event-v0.0.1.json",
+    "pid": "ptre1",
+    "parent": {
+      "$ref": "https://ils.rero.ch/api/patron_transactions/pttr1"
+    },
+    "creation_date": "2019-01-09T08:18:22.576291+00:00",
+    "type": "fee",
+    "subtype": "overdue",
+    "amount": 5.0,
+    "note": "event of the dummy_patron_transaction",
+    "location": {
+      "$ref": "https://ils.rero.ch/api/locations/x"
+    },
+    "operator": {
+      "$ref": "https://ils.rero.ch/api/patrons/ptrn1"
+    },
     "status": "open"
   }
 }

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -300,6 +300,35 @@ def item3_lib_martigny(
 
 
 @pytest.fixture(scope="module")
+def item4_lib_martigny_data(data):
+    """Load item of martigny library."""
+    return deepcopy(data.get('item8'))
+
+
+@pytest.fixture(scope="function")
+def item4_lib_martigny_data_tmp(data):
+    """Load item of martigny library scope function."""
+    return deepcopy(data.get('item8'))
+
+
+@pytest.fixture(scope="module")
+def item4_lib_martigny(
+        app,
+        document,
+        item4_lib_martigny_data,
+        loc_public_martigny,
+        item_type_standard_martigny):
+    """Create item of martigny library."""
+    item = Item.create(
+        data=item4_lib_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(ItemsSearch.Meta.index)
+    return item
+
+
+@pytest.fixture(scope="module")
 def item_lib_saxon_data(data):
     """Load item of saxon library."""
     return deepcopy(data.get('item2'))
@@ -384,6 +413,29 @@ def item2_lib_sion(
     """Create item of sion library."""
     item = Item.create(
         data=item2_lib_sion_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(ItemsSearch.Meta.index)
+    return item
+
+
+@pytest.fixture(scope="module")
+def item2_lib_saxon_data(data):
+    """Load item of saxon library."""
+    return deepcopy(data.get('item9'))
+
+
+@pytest.fixture(scope="module")
+def item2_lib_saxon(
+        app,
+        document,
+        item2_lib_saxon_data,
+        loc_public_saxon,
+        item_type_standard_martigny):
+    """Create item of saxon library."""
+    item = Item.create(
+        data=item2_lib_saxon_data,
         delete_pid=False,
         dbcommit=True,
         reindex=True)

--- a/tests/ui/patron_transaction_events/test_patron_transaction_events_api.py
+++ b/tests/ui/patron_transaction_events/test_patron_transaction_events_api.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transaction event Record tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from utils import get_mapping
+
+from rero_ils.modules.patron_transaction_events.api import \
+    PatronTransactionEvent, PatronTransactionEventsSearch
+from rero_ils.modules.patron_transactions.api import \
+    patron_transaction_id_fetcher as fetcher
+from copy import deepcopy
+
+
+def test_patron_transaction_es_mapping(
+        es, db, patron_transaction_overdue_event_martigny):
+    """Test patron_transaction event elasticsearch mapping."""
+    search = PatronTransactionEventsSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    PatronTransactionEvent.create(
+        patron_transaction_overdue_event_martigny,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)
+
+
+def test_patron_transaction_event_create(
+        db, es_clear, patron_transaction_overdue_event_martigny):
+    """Test patron transaction event creation."""
+    patron_event = deepcopy(patron_transaction_overdue_event_martigny)
+    patron_event['status'] = 'no_status'
+    import jsonschema
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        record = PatronTransactionEvent.create(
+            patron_event, delete_pid=True)
+
+    db.session.rollback()
+
+    patron_event['status'] = 'open'
+    record = PatronTransactionEvent.create(patron_event, delete_pid=True)
+    assert record == patron_event
+    assert record.get('pid') == '2'
+
+    pttr = PatronTransactionEvent.get_record_by_pid('2')
+    assert pttr == patron_event
+
+    fetched_pid = fetcher(pttr.id, pttr)
+    assert fetched_pid.pid_value == '2'
+    assert fetched_pid.pid_type == 'pttr'
+
+
+def test_patron_transaction_event_can_delete(
+        patron_transaction_overdue_event_martigny):
+    """Test can delete."""
+    assert patron_transaction_overdue_event_martigny.get_links_to_me() == {}
+    assert patron_transaction_overdue_event_martigny.can_delete

--- a/tests/ui/patron_transaction_events/test_patron_transaction_events_jsonresolver.py
+++ b/tests/ui/patron_transaction_events/test_patron_transaction_events_jsonresolver.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transaction event JSON Resolver tests."""
+
+import pytest
+from invenio_records.api import Record
+from jsonref import JsonRefError
+
+
+def test_patron_transaction_event_jsonresolver(
+        patron_transaction_overdue_event_saxon):
+    """Test patron transaction event json resolver."""
+    rec = Record.create(
+        {'patron_transaction_event': {
+            '$ref': 'https://ils.rero.ch/api/patron_transaction_events/1'
+            }
+         }
+    )
+    assert rec.replace_refs().get('patron_transaction_event') == {'pid': '1'}
+
+    # deleted record
+    patron_transaction_overdue_event_saxon.delete()
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()
+
+    # non existing record
+    rec = Record.create(
+        {'patron_transaction':
+            {
+                '$ref':
+                    'https://ils.rero.ch/api/patron_transaction_events/n_e'}}
+    )
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()

--- a/tests/ui/patron_transactions/test_patron_transactions_api.py
+++ b/tests/ui/patron_transactions/test_patron_transactions_api.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transaction Record tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from utils import get_mapping
+
+from rero_ils.modules.patron_transactions.api import PatronTransaction, \
+    PatronTransactionsSearch
+from rero_ils.modules.patron_transactions.api import \
+    patron_transaction_id_fetcher as fetcher
+from copy import deepcopy
+
+
+def test_patron_transaction_create(
+        db, es_clear, patron_transaction_overdue_martigny):
+    """Test patron transaction creation."""
+    patron_transaction = deepcopy(patron_transaction_overdue_martigny)
+    patron_transaction['status'] = 'no_status'
+    import jsonschema
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        record = PatronTransaction.create(patron_transaction, delete_pid=True)
+
+    db.session.rollback()
+
+    patron_transaction['status'] = 'open'
+    record = PatronTransaction.create(patron_transaction, delete_pid=True)
+    assert record == patron_transaction
+    assert record.get('pid') == '2'
+
+    pttr = PatronTransaction.get_record_by_pid('2')
+    assert pttr == patron_transaction
+
+    fetched_pid = fetcher(pttr.id, pttr)
+    assert fetched_pid.pid_value == '2'
+    assert fetched_pid.pid_type == 'pttr'
+
+
+def test_patron_transaction_es_mapping(
+        es, db, patron_transaction_overdue_martigny):
+    """Test patron_transaction elasticsearch mapping."""
+    search = PatronTransactionsSearch()
+    mapping = get_mapping(search.Meta.index)
+    assert mapping
+    PatronTransaction.create(
+        patron_transaction_overdue_martigny,
+        dbcommit=True,
+        reindex=True,
+        delete_pid=True
+    )
+    assert mapping == get_mapping(search.Meta.index)
+
+
+def test_patron_transaction_can_delete(patron_transaction_overdue_martigny):
+    """Test can delete."""
+    assert patron_transaction_overdue_martigny.get_links_to_me() == \
+        {'events': 1}
+    assert not patron_transaction_overdue_martigny.can_delete
+
+
+def test_patron_transaction_currency(
+        patron_transaction_overdue_martigny, org_martigny):
+    """Test patron transaction currency."""
+    assert patron_transaction_overdue_martigny.currency == \
+        org_martigny.get('default_currency')

--- a/tests/ui/patron_transactions/test_patron_transactions_jsonresolver.py
+++ b/tests/ui/patron_transactions/test_patron_transactions_jsonresolver.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transaction JSON Resolver tests."""
+
+import pytest
+from invenio_records.api import Record
+from jsonref import JsonRefError
+
+
+def test_patron_transaction_jsonresolver(patron_transaction_overdue_martigny):
+    """Test patron_transaction json resolver."""
+    rec = Record.create(
+        {'patron_transaction': {
+            '$ref': 'https://ils.rero.ch/api/patron_transactions/1'
+            }
+         }
+    )
+    assert rec.replace_refs().get('patron_transaction') == {'pid': '1'}
+
+    # delete attached events to patron transaction
+    for patron_event in patron_transaction_overdue_martigny.events:
+        patron_event.delete(dbcommit=True, delindex=True)
+    # deleted record
+    patron_transaction_overdue_martigny.delete()
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()
+
+    # non existing record
+    rec = Record.create(
+        {'patron_transaction':
+            {
+                '$ref': 'https://ils.rero.ch/api/patron_transactions/n_e'}}
+    )
+    with pytest.raises(JsonRefError):
+        rec.replace_refs().dumps()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -102,6 +102,26 @@ def location_schema():
 
 
 @pytest.fixture()
+def patron_transaction_schema():
+    """Patron transaction Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.patron_transactions.jsonschemas',
+        'patron_transactions/patron_transaction-v0.0.1.json')
+    schema = loads(schema_in_bytes.decode('utf8'))
+    return schema
+
+
+@pytest.fixture()
+def patron_transaction_event_schema():
+    """Patron transaction event Jsonschema for records."""
+    schema_in_bytes = resource_string(
+        'rero_ils.modules.patron_transaction_events.jsonschemas',
+        'patron_transaction_events/patron_transaction_event-v0.0.1.json')
+    schema = loads(schema_in_bytes.decode('utf8'))
+    return schema
+
+
+@pytest.fixture()
 def organisation_schema():
     """Organisation Jsonschema for records."""
     schema_in_bytes = resource_string(

--- a/tests/unit/test_patron_transaction_events_jsonschema.py
+++ b/tests/unit/test_patron_transaction_events_jsonschema.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transaction event JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import copy
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_patron_transaction_events_required(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test required for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_pid(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test pid for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['pid'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_note(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test note for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['note'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_status(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test status for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['status'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_type(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test type for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['type'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_subtype(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test subtype for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['subtype'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_operator(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test operator for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['operator'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_location(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test location for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['location'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_creation_date(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test creation_date for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['creation_date'] = 25
+        validate(data, patron_transaction_event_schema)
+
+
+def test_patron_transaction_events_amount(
+        patron_transaction_event_schema,
+        patron_transaction_overdue_event_saxon_data):
+    """Test amount for patron transaction event jsonschemas."""
+    validate(patron_transaction_overdue_event_saxon_data,
+             patron_transaction_event_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_event_saxon_data)
+        data['amount'] = '25'
+        validate(data, patron_transaction_event_schema)

--- a/tests/unit/test_patron_transactions_jsonschema.py
+++ b/tests/unit/test_patron_transactions_jsonschema.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Patron transaction JSON schema tests."""
+
+from __future__ import absolute_import, print_function
+
+import copy
+
+import pytest
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def test_patron_transactions_required(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test required for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, patron_transaction_schema)
+
+
+def test_patron_transactions_pid(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test pid for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['pid'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_note(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test note for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['note'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_status(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test status for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['status'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_type(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test type for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['type'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_patron(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test patron for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['patron'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_notification(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test notification for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['notification'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_organisation(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test organisation for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['organisation'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_creation_date(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test creation_date for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['creation_date'] = 25
+        validate(data, patron_transaction_schema)
+
+
+def test_patron_transactions_total_amount(
+        patron_transaction_schema, patron_transaction_overdue_saxon_data):
+    """Test total_amount for patron transaction jsonschemas."""
+    validate(patron_transaction_overdue_saxon_data, patron_transaction_schema)
+
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(patron_transaction_overdue_saxon_data)
+        data['total_amount'] = '25'
+        validate(data, patron_transaction_schema)


### PR DESCRIPTION
* Improves relations between Loan, Notifications and Patron transactions.
* Adds config for patron transactions and events.
* Adds fixtures and tests for patron transactions and events.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?

https://tree.taiga.io/project/rero21-reroils/task/1273?kanban-status=1224894

## How to test?

-  Additional PRs will be created to remove the Fee resource and complete the other tasks
- This PR will be merged to `US659`
- Additional test coverage will be created

`bootstrap`
`setup`

Transactions are available at:

`~/api/patron_transactions/`
`~/api/patron_transaction_events/`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
