### PR TITLE
items: can request api for an item

### DIFF
--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -29,6 +29,7 @@ from invenio_circulation.errors import CirculationException
 from werkzeug.exceptions import NotFound
 
 from .api import Item
+from .utils import is_librarian_can_request_item_for_patron
 from ..circ_policies.api import CircPolicy
 from ..libraries.api import Library
 from ..loans.api import Loan
@@ -323,3 +324,16 @@ def item_availability(item_pid):
     return jsonify({
         'availability': item.available
     })
+
+
+@api_blueprint.route(
+    '/<item_pid>/can_request/<library_pid>/<patron_barcode>', methods=['GET'])
+@check_authentication
+@jsonify_error
+def can_request(item_pid, library_pid, patron_barcode):
+    """HTTP request to check if a librarian can request an item for a patron.
+
+    required_parameters: item_pid, library_pid, patron_barcode
+    """
+    return is_librarian_can_request_item_for_patron(
+        item_pid, library_pid, patron_barcode)

--- a/rero_ils/modules/items/utils.py
+++ b/rero_ils/modules/items/utils.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Item utils."""
+
+from flask import jsonify
+from flask_babelex import gettext as _
+
+from .api import Item, ItemStatus
+from ..libraries.api import Library
+from ..loans.api import Loan
+from ..loans.utils import can_be_requested
+from ..patrons.api import Patron
+
+
+def jsonify_response(response=False, reason=None):
+    """Jsonify api response."""
+    return jsonify({
+        'can_request': response,
+        'reason': reason
+    })
+
+
+def is_librarian_can_request_item_for_patron(
+        item_pid, library_pid, patron_barcode):
+    """Check if a librarian can request an item for a patron.
+
+    required_parameters: item_pid, library_pid, patron_barcode
+    """
+    item = Item.get_record_by_pid(item_pid)
+    if not item:
+        return jsonify_response(reason=_('Item not found.'))
+    patron = Patron.get_patron_by_barcode(patron_barcode)
+    if not patron:
+        return jsonify_response(reason=_('Patron not found.'))
+    library = Library.get_record_by_pid(library_pid)
+    if not library:
+        return jsonify_response(reason=_('Library not found.'))
+    # Create a loan
+    loan = Loan({
+        'patron_pid': patron.pid, 'item_pid': item.pid,
+        'library_pid': library_pid})
+    if not can_be_requested(loan):
+        return jsonify_response(
+            reason=_(
+                'Circulation policies do not allow request on this item.'))
+    if item.status != ItemStatus.MISSING:
+        loaned_to_patron = item.is_loaned_to_patron(patron_barcode)
+        if loaned_to_patron:
+            return jsonify_response(
+                reason=_(
+                    'Item is already checked-out or requested by patron.'))
+        return jsonify_response(
+            response=True, reason=_('Request is possible.'))
+    else:
+        return jsonify_response(
+            reason=_('Item status does not allow requests.'))

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -408,24 +408,6 @@ def system_librarian_sion_no_email(
 
 # ------------ Org: Sion, Lib: Sion, Librarian ----------
 @pytest.fixture(scope="module")
-@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
-def patron_martigny_no_email(
-        app,
-        roles,
-        patron_type_children_martigny,
-        patron_martigny_data):
-    """Create Martigny patron without sending reset password instruction."""
-    ptrn = Patron.create(
-        data=patron_martigny_data,
-        delete_pid=False,
-        dbcommit=True,
-        reindex=True)
-    flush_index(PatronsSearch.Meta.index)
-    return ptrn
-
-
-# ------------ Org: Sion, Lib: Sion, Librarian ----------
-@pytest.fixture(scope="module")
 def librarian_sion_data(data):
     """Load sion librarian data."""
     return deepcopy(data.get('ptrn9'))


### PR DESCRIPTION
* Removes duplicate fixtures function.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>


## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/us/657?milestone=254793

## How to test?

- To check if an item can be requested for a given patron barcode and a transaction library PID

`~/item/<item_pid>/can_request/<library_pid>/<patron_barcode>`
API response in this format:
`can_request`: True or False
`reason`:  the reason why the item can not be requested

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
