### PR TITLE
documents: update schemas about abstract field

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
@@ -636,7 +636,13 @@
       "items": {
         "title": "Abstract",
         "type": "string",
-        "minLength": 2
+        "minLength": 2,
+        "form": {
+          "type": "textarea",
+          "templateOptions": {
+            "rows": 5
+          }
+        }
       },
       "form": {
         "hide": true

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -636,7 +636,13 @@
       "items": {
         "title": "Abstract",
         "type": "string",
-        "minLength": 2
+        "minLength": 2,
+        "form": {
+          "type": "textarea",
+          "templateOptions": {
+            "rows": 5
+          }
+        }
       },
       "form": {
         "hide": true


### PR DESCRIPTION
* Updates JSON schemas to allow abstract fields to be edited as a textarea.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Closes Bug#36 from https://github.com/rero/rero-ils-ui/issues/108

## How to test?

- ./scripts/boostrap
- Go to professional UI, into document editor
- Display "abstract" field group. Each abstract should be now a textarea with default 5 rows height

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
