### PR TITLE
public interface: request deletion by patron

### DIFF
--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -113,6 +113,11 @@
           {{ _('Renewals') }}
         </th>
         {% endif %}
+        {% if type == 'requests'%}
+        <th class="col-md-1 border-top-0" scope="col">
+          {{ _('Cancel') }}
+        </th>
+        {% endif %}
       </tr>
     </thead>
     <tbody>
@@ -148,14 +153,28 @@
           {{ loan.extension_count }}
         </td>
         <td>
-            {% if loan.can_renew %}
-            {%- with form = can_renew_form %}
-              <form action="{{ url_for('patrons.profile') }}" method="POST" name="can_renew_form">
-                <input type="hidden" name="loan_pid" value="{{ loan.pid }}">  
-                <button type="submit" class="btn btn btn-primary btn-bg">{{_('Renew')}}</button>
-              </form>
-            {%- endwith %}
-            {% endif %}
+          {% if loan.can_renew %}
+          {%- with form = can_renew_form %}
+            <form action="{{ url_for('patrons.profile') }}" method="POST" name="can_renew_form">
+              <input type="hidden" name="type" value="renew">
+              <input type="hidden" name="loan_pid" value="{{ loan.pid }}">
+              <button type="submit" class="btn btn btn-primary btn-bg">{{_('Renew')}}</button>
+            </form>
+          {%- endwith %}
+          {% endif %}
+        </td>
+        {% endif %}
+        {% if type == 'requests' %}
+        <td>
+          {% if loan.state == 'PENDING' %}
+            <form action="{{ url_for('patrons.profile') }}" method="POST" name="cancel_loan">
+              <input type="hidden" name="type" value="cancel">
+              <input type="hidden" name="loan_pid" value="{{ loan.pid }}">
+              <button type="submit" class="btn btn btn-primary btn-bg">{{_('Cancel')}}</button>
+            </form>
+          {% else %}
+            &nbsp;
+          {% endif %}
         </td>
         {% endif %}
       </tr>

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -106,18 +106,28 @@ def profile(viewcode):
     if request.method == 'POST':
         loan = Loan.get_record_by_pid(request.values.get('loan_pid'))
         item = Item.get_record_by_pid(loan.get('item_pid'))
-        data = {
-            'item_pid': item.pid,
-            'pid': request.values.get('loan_pid'),
-            'transaction_location_pid': item.location_pid
-        }
-        try:
-            item.extend_loan(**data)
-            flash(_('The item %(item_id)s has been renewed.',
-                    item_id=item.pid), 'success')
-        except Exception:
-            flash(_('Error during the renewal of the item %(item_id)s.',
-                    item_id=item.pid), 'danger')
+        if request.form.get('type') == 'cancel':
+            data = loan
+            try:
+                item.cancel_loan(**data)
+                flash(_('The request for item %(item_id)s has been canceled.',
+                        item_id=item.pid), 'success')
+            except Exception:
+                flash(_('Error during the cancellation of the request of \
+                item %(item_id)s.', item_id=item.pid), 'danger')
+        elif request.form.get('type') == 'renew':
+            data = {
+                'item_pid': item.pid,
+                'pid': request.values.get('loan_pid'),
+                'transaction_location_pid': item.location_pid
+            }
+            try:
+                item.extend_loan(**data)
+                flash(_('The item %(item_id)s has been renewed.',
+                        item_id=item.pid), 'success')
+            except Exception:
+                flash(_('Error during the renewal of the item %(item_id)s.',
+                        item_id=item.pid), 'danger')
 
     checkouts, requests, history = patron_profile_loans(patron.pid)
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-02-17 15:11+0100\n"
+"POT-Creation-Date: 2020-02-17 17:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -70,7 +70,7 @@ msgstr ""
 msgid "author__it"
 msgstr ""
 
-#: rero_ils/config.py:1014
+#: rero_ils/config.py:1013
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "language"
@@ -6697,12 +6697,24 @@ msgstr ""
 msgid "%(icon)s Profile"
 msgstr ""
 
+#: rero_ils/modules/patrons/views.py:113
+#, python-format
+msgid "The request for item %(item_id)s has been canceled."
+msgstr ""
+
 #: rero_ils/modules/patrons/views.py:116
+#, python-format
+msgid ""
+"Error during the cancellation of the request of                 item "
+"%(item_id)s."
+msgstr ""
+
+#: rero_ils/modules/patrons/views.py:126
 #, python-format
 msgid "The item %(item_id)s has been renewed."
 msgstr ""
 
-#: rero_ils/modules/patrons/views.py:119
+#: rero_ils/modules/patrons/views.py:129
 #, python-format
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr ""
@@ -6894,7 +6906,12 @@ msgstr ""
 msgid "Renewals"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:148
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+msgid "Cancel"
+msgstr ""
+
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
 msgid "Renew"
 msgstr ""
 


### PR DESCRIPTION
* Adds an action button to allow cancellation for patrons.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Task 1315 of US1068
https://tree.taiga.io/project/rero21-reroils/task/1315?kanban-status=1224894

## How to test?

1. Login as a patron.
2. Go to profile, pending tab.
3. Cancel a request.

Requests that are ready for pickup can't be cancelled.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
