### PR TITLE
security: authorize unsafe-eval param on script-src

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -304,6 +304,7 @@ APP_DEFAULT_SECURE_HEADERS = {
         ],
         'script-src': [
             "'self'",
+            "'unsafe-eval'",
             "'unsafe-inline'",
             # '*.rero.ch',
             'https://www.googletagmanager.com',


### PR DESCRIPTION
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

