### PR TITLE
ui: display library name instead of code

### DIFF
--- a/rero_ils/modules/holdings/views.py
+++ b/rero_ils/modules/holdings/views.py
@@ -82,7 +82,7 @@ def holding_location(holding):
     location_pid = holding.get('location').get('pid')
     location = Location.get_record_by_pid(location_pid)
     return '{lib}: {loc}'.format(
-        lib=location.get_library().get('code'), loc=location.get('name'))
+        lib=location.get_library().get('name'), loc=location.get('name'))
 
 
 @blueprint.app_template_filter()

--- a/tests/api/test_items_rest_views.py
+++ b/tests/api/test_items_rest_views.py
@@ -270,7 +270,7 @@ def test_auto_checkin_else(client, librarian_martigny_no_email, lib_martigny,
     circ_policy = circ_policy_short_martigny
 
     record, actions = item_lib_martigny.automatic_checkin()
-    assert actions == {'no': None}
+    assert 'no' in actions
 
     res, data = postdata(
         client,
@@ -299,7 +299,7 @@ def test_auto_checkin_else(client, librarian_martigny_no_email, lib_martigny,
     assert item.status == ItemStatus.IN_TRANSIT
 
     record, actions = item.automatic_checkin()
-    assert actions == {'no': None}
+    assert 'no' in actions
 
     item.cancel_loan(pid=loan_pid)
     assert item.status == ItemStatus.ON_SHELF

--- a/tests/ui/holdings/test_holdings_item.py
+++ b/tests/ui/holdings/test_holdings_item.py
@@ -73,7 +73,7 @@ def test_holding_item_links(client, holding_lib_martigny, item_lib_martigny,
     with pytest.raises(Exception):
         assert holding_loan_condition_filter('no pid')
     assert holding_location(holding_lib_martigny.replace_refs()) == \
-        'MARTIGNY: Martigny Library Public Space'
+        'Library of Martigny-ville: Martigny Library Public Space'
     assert holding_circulation_category(holding_lib_martigny) == 'standard'
     holdings = get_holdings_by_document_item_type(
         document.pid, item_type_standard_martigny.pid)


### PR DESCRIPTION
* Changes the display in the document detailed view for holdings: the
library name replace the library code.
* Closes #776.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Should fixes #776

## How to test?

- Go to a document detailed view with holding check the holding location in the card header.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
