### PR TITLE
documents: Add pickup location names for the item request button

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -265,7 +265,7 @@
                     {% for location in locations %}
                     <a class="dropdown-item"
                       href="{{ url_for('item.patron_request', viewcode=viewcode, item_pid=item.pid, pickup_location_pid=location.pid)}}">
-                      {{ location.get_library().name }}
+                      {{ location.pickup_name }}
                     </a>
                     {% endfor %}
                   </div>

--- a/tests/api/test_items_rest_views.py
+++ b/tests/api/test_items_rest_views.py
@@ -300,6 +300,7 @@ def test_auto_checkin_else(client, librarian_martigny_no_email, lib_martigny,
 
     record, actions = item.automatic_checkin()
     assert 'no' in actions
+    assert actions['no']['pid'] == loan_pid
 
     item.cancel_loan(pid=loan_pid)
     assert item.status == ItemStatus.ON_SHELF


### PR DESCRIPTION
* Adds the pickup location names into options of the item request button
* Closes #777

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Log as user with 'patron' role
- Search about a item that could be requested
- Expand options of the request button

![image](https://user-images.githubusercontent.com/10031585/74912154-5dc05980-53be-11ea-9762-8efab293778e.png)

