### PR TITLE
framework: update to Invenio 3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ before_install:
 
 install:
   - "./scripts/bootstrap --ci $REQUIREMENTS"
+  - "pipenv run pip list"  # To have details about installed libs (isort, pytest, etc.)
 
 before_script:
   # https://docs.travis-ci.com/user/gui-and-headless-browsers/

--- a/Pipfile
+++ b/Pipfile
@@ -37,18 +37,19 @@ name = "pypi"
 Babel = ">=2.4.0"
 Flask-BabelEx = ">=0.9.3"
 ## Third party invenio modules used by RERO ILS
-invenio-oaiharvester = {editable = true,ref = "v1.0.0a4",git = "https://github.com/inveniosoftware/invenio-oaiharvester.git"}
-invenio-circulation = {editable = true,git = "https://github.com/inveniosoftware/invenio-circulation.git",ref = "v1.0.0a16"}
-## Invenio base modules used by RERO ILS
+invenio-oaiharvester = {editable = true, ref = "v1.0.0a4", git = "https://github.com/inveniosoftware/invenio-oaiharvester.git"}
+invenio-circulation = {editable = true, ref = "v1.0.0a16", git = "https://github.com/inveniosoftware/invenio-circulation.git"}
+## Invenio 3.2.1 base modules used by RERO ILS
 # same as invenio metadata extras without invenio-search-ui
-invenio-indexer = ">=1.0.1,<1.1.0"
-invenio-jsonschemas = ">=1.0.0,<1.1.0"
-invenio-oaiserver = ">=1.0.3,<1.1.0"
-invenio-pidstore = ">=1.0.0,<1.1.0"
-invenio-records-rest = ">=1.4.0,<1.5.0"
+invenio-indexer = ">=1.1.1,<1.2.0"
+invenio-jsonschemas = ">=1.0.1,<1.1.0"
+invenio-oaiserver = ">=1.1.1,<1.2.0"
+invenio-pidstore = ">=1.1.0,<1.2.0"
+invenio-records-rest = ">=1.6.4,<1.7.0"
 invenio-records-ui = ">=1.0.1,<1.1.0"
+invenio-records = ">=1.3.0,<1.4.0"
 ## Default from Invenio
-invenio = {version = "~=3.1.0",extras = ["base", "postgresql", "auth", "elasticsearch6"]}
+invenio = {version = "==3.2.1", extras = ["base", "postgresql", "auth", "elasticsearch6" ]}
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
@@ -57,8 +58,6 @@ uwsgi-tools = ">=1.1.1"
 invenio-accounts = "<=1.1.2"
 # TODO: remove when DynamicPermission will be solved
 invenio-access = "<1.2.0"
-# separate tables
-invenio-records = ">=1.3.0"
 ## RERO ILS specific python modules
 PyYAML = ">=3.13"
 dateparser = ">=0.7.0"
@@ -85,14 +84,14 @@ lxml = ">=3.5.0,<4.2.6"
 Flask-Debugtoolbar = ">=0.10.1"
 Sphinx = ">=1.5.1"
 check-manifest = ">=0.35"
-coverage = ">=4.4.1"
+coverage = ">=4.5.3"
 isort = ">=4.3"
 mock = ">=2.0.0"
 marshmallow = ">=2.15.1,<3.0.0"
-pydocstyle = ">=2.0.0"
-pytest = ">=3.3.1"
-pytest-cov = ">=2.5.1"
-pytest-invenio = ">=1.0.2,<1.1.0"
+pydocstyle = ">=3.0.0"
+pytest = ">=4.6.4"
+pytest-cov = ">=2.7.1"
+pytest-invenio = ">=1.2.1,<1.3.0"
 pytest-mock = ">=1.6.0"
 pytest-pep8 = ">=1.0.6"
 pytest-random-order = ">=0.5.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "56497cb8b32de8c09eeebf33b5ce4d6825f3aa32a69a1859fd0016f024e2be70"
+            "sha256": "565dd4329eb029eceb139d64c29a9580c90f4da0b42b537d14cc3600f919e8aa"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -65,18 +65,18 @@
             ],
             "version": "==0.1.0"
         },
+        "base32-lib": {
+            "hashes": [
+                "sha256:470d1f318a3632397d091bb2773500e484489a473f2001df5c0675e72730ddd3",
+                "sha256:ebbf80687ef9791580135f372db1c0a09a1a5d02089d57a8a49bf5ef3330221f"
+            ],
+            "version": "==1.0.1"
+        },
         "billiard": {
             "hashes": [
                 "sha256:42d9a227401ac4fba892918bba0a0c409def5435c4b483267ebfe821afaaba0e"
             ],
             "version": "==3.5.0.5"
-        },
-        "binaryornot": {
-            "hashes": [
-                "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061",
-                "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"
-            ],
-            "version": "==0.4.4"
         },
         "bleach": {
             "hashes": [
@@ -150,6 +150,7 @@
             "hashes": [
                 "sha256:bdbb5b366058b1c87735603b23060962c439ac9be66f1ae91e8c7dbd7d59e262"
             ],
+            "index": "pypi",
             "version": "==2.1.3"
         },
         "click": {
@@ -158,13 +159,6 @@
                 "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
             "version": "==7.1.1"
-        },
-        "cookiecutter": {
-            "hashes": [
-                "sha256:479997e1c26c51bbbaf04097ef7d82b1d91cfb03f570cb5fb5ca265c88db04ae",
-                "sha256:910e6c423da42c45c2614d6676485d4872c4ed1bd9531cfff59280977f98fbf5"
-            ],
-            "version": "==1.7.0"
         },
         "cryptography": {
             "hashes": [
@@ -307,10 +301,10 @@
         },
         "flask-limiter": {
             "hashes": [
-                "sha256:d984a57ef37acb6eee29edc864ff22cd4cf090845f06968c015093ffd91e96f1",
-                "sha256:db2a069402977927282b0fcf650753bfcb50488028def9f5b2398e1d525f2f9f"
+                "sha256:905c35cd87bf60c92fd87922ae23fe27aa5fb31980bab31fc00807adee9f5a55",
+                "sha256:9087984ae7eeb862f93bf5b18477a5e5b1e0c907647ae74fba1c7e3f1de63d6f"
             ],
-            "version": "==1.2.1"
+            "version": "==1.1.0"
         },
         "flask-login": {
             "hashes": [
@@ -407,10 +401,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.7"
+            "version": "==2.9"
         },
         "importlib-metadata": {
             "hashes": [
@@ -434,27 +428,25 @@
         },
         "invenio": {
             "hashes": [
-                "sha256:d6be8948deea14bc06b29051d3bf192b4d9b120cc47bbfed7aba1a83fc25e409",
-                "sha256:f0128f92e36d43a6d5b2f0154a37db3f51536205229ef689dcb43a87e3299b38"
+                "sha256:ba5badc4635670348df31610af028d98626b8bb62e2dc306de0241def79ac8cd",
+                "sha256:deff48c8f390182c348edcfaac96452b75e0b9a000875d3bfe4a0311fc7d2f98"
             ],
             "index": "pypi",
-            "version": "==3.1.2"
+            "version": "==3.2.1"
         },
         "invenio-access": {
             "hashes": [
-                "sha256:1e7439bfdb1c9a697fa41dccc79969af445baa0ddb6248f9cadc1046a2bed36f",
-                "sha256:430225aa095e4ad11401a84fdf449566498f0e69b8b5c74e77239c1446b9e4da"
+                "sha256:5bb743c0bf269c6fd5542ccc01a6c0987a496910aa0f4cf3e66523db962c61cc",
+                "sha256:8a7272447429c5d05ecebc332709a376d29117f1988827295d804bff6784021c"
             ],
-            "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==1.3.1"
         },
         "invenio-accounts": {
             "hashes": [
-                "sha256:57c1b0e262096ff9bea24dbc1724d2f201f824cc567cc74cfdb9f5a2316c1d01",
-                "sha256:5bc175f51d61857333548ff8044b116d8c1ec614e0c350b5452038ff57ddc188"
+                "sha256:499a40e07daae6ff1d5a5f13bf3fa6bde38efb978dfce78605d32e64a5238cd9",
+                "sha256:ff978d1c1248d7270021b108353103a894e6537a3364a944758b02c71b10a64f"
             ],
-            "index": "pypi",
-            "version": "==1.1.2"
+            "version": "==1.1.3"
         },
         "invenio-admin": {
             "hashes": [
@@ -465,10 +457,10 @@
         },
         "invenio-app": {
             "hashes": [
-                "sha256:a77aee57118d06909d2187a3e25f3d0a299189e06bb43b4d7404a689119ae75a",
-                "sha256:df15a9ef65758f82f75f8b392456793c2fc36e9984d15113c852a7d8fd2c52dd"
+                "sha256:2b850b112d14db1c2eeedfe95128ae9ce139097fbcaf06ff8c26dda6681aed58",
+                "sha256:e92f565a069a8ca93129ec1b7cab2cc6ca6b506491bbdb20499aab041f572107"
             ],
-            "version": "==1.1.1"
+            "version": "==1.2.5"
         },
         "invenio-assets": {
             "hashes": [
@@ -479,10 +471,10 @@
         },
         "invenio-base": {
             "hashes": [
-                "sha256:6e532854a43e4f54fc7d9b1cbda720ce4ce6383b00cee6ba5f7e86ef78f12fe2",
-                "sha256:f972e10b69a68a80c342f0bcf6b3b02a6a67af4fb6e8e347ce8b482fcb47e973"
+                "sha256:2b49e941d474fba3990543e0c231d865c75bb4b95c06b78c26231a030f17d8a8",
+                "sha256:9ae5d1db2865386ec755f39d8e0f4c0b318770af541b0807a02fad59882a038d"
             ],
-            "version": "==1.0.2"
+            "version": "==1.2.2"
         },
         "invenio-cache": {
             "hashes": [
@@ -493,10 +485,10 @@
         },
         "invenio-celery": {
             "hashes": [
-                "sha256:22cda704fa8abaa885a327539899887a939832beda7de0d1f1d5d84b4ac153b1",
-                "sha256:d102dcf3e94cfa11b0973626852f5fd6cac8fa3ba364c42fcec8ecc0b533d838"
+                "sha256:66160115ff49f625b4273e35c4b31599098dac255baa60c5a95e60b66edb22b6",
+                "sha256:808f244fa15465703436244a91ca039c6302eb755b873dbb454d65a36e419df4"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.3"
         },
         "invenio-circulation": {
             "editable": true,
@@ -533,10 +525,10 @@
         },
         "invenio-indexer": {
             "hashes": [
-                "sha256:ca8c705813eb1256625f3c6d1550a0610be693676d4929f2f63e0fcf17879973"
+                "sha256:a8b4052604bba21ae1e4ccf5249ad60a8967a8ccdeebec710dcbeea33322f0c5"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.1.1"
         },
         "invenio-jsonschemas": {
             "hashes": [
@@ -548,10 +540,10 @@
         },
         "invenio-logging": {
             "hashes": [
-                "sha256:8c2f6633905d100867814e5894564e79682bca7e45ea2870a6c03a69c4860dec",
-                "sha256:f3a87ab70993e6c7eb5990e70dda3ab0729b1bfa6c90ecf1f9890018accb926f"
+                "sha256:2aab96570ea6475f66054883a3430b166d67e3af68979110ddda6cd3e8dff477",
+                "sha256:34a23a488c99b0d54c9dc374ec6bfa6688348495a5ccf7e460e3793045ba77ee"
             ],
-            "version": "==1.1.1"
+            "version": "==1.2.1"
         },
         "invenio-mail": {
             "hashes": [
@@ -567,11 +559,11 @@
         },
         "invenio-oaiserver": {
             "hashes": [
-                "sha256:0ad03228ff0cb1be9bc403420c8ebc2b7b5fc8625fbde14e254b068a12020abe",
-                "sha256:c3aa3b0e63f79ab68ac88b950f8b67d455bc5458b93bf0b07ffef67d88412100"
+                "sha256:aa2e5c562e3ce4dcda6cc192c73decf3e5e2814b6a788fa80f18156bf5a8b56b",
+                "sha256:b685a5288fee11c3798bb3818c01e5e150d051ff11f406e092e2d5e7b379c1dd"
             ],
             "index": "pypi",
-            "version": "==1.0.3"
+            "version": "==1.1.2"
         },
         "invenio-oauth2server": {
             "hashes": [
@@ -589,11 +581,11 @@
         },
         "invenio-pidstore": {
             "hashes": [
-                "sha256:582b28e7e2bdf4df93e5398a0e147b2eb08690ede339249dd3a8c92b713e6f00",
-                "sha256:77f59075dfa34564b913e5d58f37d55b2c78d7b4fa1eeaa5f8c42576848bb06d"
+                "sha256:052f9972c4b91176609b339635d4b074fc2a9423a3fe78d9fff8576947099ca7",
+                "sha256:76a16f24b3a7ac2f898969ce3012bf4b0b9969d5e8c4cd179657cc73c94e1b86"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "invenio-records": {
             "hashes": [
@@ -605,11 +597,11 @@
         },
         "invenio-records-rest": {
             "hashes": [
-                "sha256:ea5bb3e05d331bd38dfcf154d8fc123558dbeaaad0eb990dab852f946ee8f5b9",
-                "sha256:f89124c7e1e8fcc16b8652597d3c529a66cfc9f1bbba7e4d40bf880038b29691"
+                "sha256:3b88511d14182ef385123f04e8f3680600a4035dd80586ff46aeab2edf8f57d7",
+                "sha256:f549b5c71e8f224c7f09b892484bef3d108ee8cbff740aced2fd4dafc16db32e"
             ],
             "index": "pypi",
-            "version": "==1.4.2"
+            "version": "==1.6.4"
         },
         "invenio-records-ui": {
             "hashes": [
@@ -621,17 +613,17 @@
         },
         "invenio-rest": {
             "hashes": [
-                "sha256:665cdc6d7f47b532e4823dc1a0a62de32e31caf387efc93aff7593a34124ee1d",
-                "sha256:e5a73fcfc15c052840608950c0524447f1e86d24cc58a8fbf12a48a82f7e582a"
+                "sha256:3a76fc42cd1265e2a589a6bd8b0fa06d62e651e67a33b547d991b72b251600c9",
+                "sha256:3f44ef712d8d0c2956ec841aaa3fb6434d3c8cf1dddad05d7a4cc98a50afc671"
             ],
-            "version": "==1.0.0"
+            "version": "==1.1.3"
         },
         "invenio-search": {
             "hashes": [
-                "sha256:3db927a9a447bcfb8f84f4798a3bf656ab8ff6f093d8de83224bdde4518bf830",
-                "sha256:b51d0af749fb08a6d8e46e8d7d2232e75462d87bb11a78aade33497ed1079773"
+                "sha256:5956be4f6f024f84d4732307356b618ff826336e437e9d1c7ec99edfc1b7d734",
+                "sha256:bf104f3ef751d38ea545689c08b25c94d6dc91130096ea890c92315fa519299c"
             ],
-            "version": "==1.1.1"
+            "version": "==1.2.3"
         },
         "invenio-theme": {
             "hashes": [
@@ -696,13 +688,6 @@
                 "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
             ],
             "version": "==2.11.1"
-        },
-        "jinja2-time": {
-            "hashes": [
-                "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40",
-                "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"
-            ],
-            "version": "==0.2.0"
         },
         "jsmin": {
             "hashes": [
@@ -842,10 +827,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:7cb1881a0fa84be4b5c1e301168236932c345f6910725f99905d636bfe93e9e9",
-                "sha256:e9390c0c80437d7a02d84e3d1635dc20f37a8bcb149ca443d93791bdc683f28d"
+                "sha256:90854221bbb1498d003a0c3cc9d8390259137551917961c8b5258c64026b2f85",
+                "sha256:ac2e13b30165501b7d41fc0371b8df35944f5849769d136f20e2c5f6cdc6e665"
             ],
-            "version": "==2.21.0"
+            "markers": "python_version >= '3.0.0'",
+            "version": "==3.5.1"
         },
         "maxminddb": {
             "hashes": [
@@ -859,11 +845,28 @@
             ],
             "version": "==2018.703"
         },
-        "msgpack-python": {
+        "msgpack": {
             "hashes": [
-                "sha256:378cc8a6d3545b532dfd149da715abae4fda2a3adb6d74e525d0d5e51f46909b"
+                "sha256:002a0d813e1f7b60da599bdf969e632074f9eec1b96cbed8fb0973a63160a408",
+                "sha256:25b3bc3190f3d9d965b818123b7752c5dfb953f0d774b454fd206c18fe384fb8",
+                "sha256:271b489499a43af001a2e42f42d876bb98ccaa7e20512ff37ca78c8e12e68f84",
+                "sha256:39c54fdebf5fa4dda733369012c59e7d085ebdfe35b6cf648f09d16708f1be5d",
+                "sha256:4233b7f86c1208190c78a525cd3828ca1623359ef48f78a6fea4b91bb995775a",
+                "sha256:5bea44181fc8e18eed1d0cd76e355073f00ce232ff9653a0ae88cb7d9e643322",
+                "sha256:5dba6d074fac9b24f29aaf1d2d032306c27f04187651511257e7831733293ec2",
+                "sha256:7a22c965588baeb07242cb561b63f309db27a07382825fc98aecaf0827c1538e",
+                "sha256:908944e3f038bca67fcfedb7845c4a257c7749bf9818632586b53bcf06ba4b97",
+                "sha256:9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0",
+                "sha256:aa5c057eab4f40ec47ea6f5a9825846be2ff6bf34102c560bad5cad5a677c5be",
+                "sha256:b3758dfd3423e358bbb18a7cccd1c74228dffa7a697e5be6cb9535de625c0dbf",
+                "sha256:c901e8058dd6653307906c5f157f26ed09eb94a850dddd989621098d347926ab",
+                "sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08",
+                "sha256:db685187a415f51d6b937257474ca72199f393dad89534ebbdd7d7a3b000080e",
+                "sha256:e35b051077fc2f3ce12e7c6a34cf309680c63a842db3a0616ea6ed25ad20d272",
+                "sha256:e7bbdd8e2b277b77782f3ce34734b0dfde6cbe94ddb74de8d733d603c7f9e2b1",
+                "sha256:ea41c9219c597f1d2bf6b374d951d310d58684b5de9dc4bd2976db9e1e22c140"
             ],
-            "version": "==0.5.6"
+            "version": "==1.0.0"
         },
         "node-semver": {
             "hashes": [
@@ -921,13 +924,6 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
-        },
-        "poyo": {
-            "hashes": [
-                "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a",
-                "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"
-            ],
-            "version": "==0.5.0"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -1066,14 +1062,6 @@
             ],
             "index": "pypi",
             "version": "==5.3"
-        },
-        "raven": {
-            "hashes": [
-                "sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54",
-                "sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4"
-            ],
-            "index": "pypi",
-            "version": "==6.10.0"
         },
         "redis": {
             "hashes": [
@@ -1223,10 +1211,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.8"
         },
         "uwsgi": {
             "hashes": [
@@ -1272,10 +1260,11 @@
         },
         "webargs": {
             "hashes": [
-                "sha256:d66a056b3a40c5a3774a650fd349db5970cd91fa8f04ac50d00582c949b45b26",
-                "sha256:dfe01cd3711cee9a3651bfd5ca67770ace4a6f35f3cae583aa8400bbf7706bb4"
+                "sha256:4f04918864c7602886335d8099f9b8960ee698b6b914f022736ed50be6b71235",
+                "sha256:871642a2e0c62f21d5b78f357750ac7a87e6bc734c972f633aa5fb6204fbf29a",
+                "sha256:fc81c9f9d391acfbce406a319217319fd8b2fd862f7fdb5319ad06944f36ed25"
             ],
-            "version": "==6.0.0"
+            "version": "==5.5.3"
         },
         "webassets": {
             "hashes": [
@@ -1297,13 +1286,6 @@
                 "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
             ],
             "version": "==0.16.1"
-        },
-        "whichcraft": {
-            "hashes": [
-                "sha256:acdbb91b63d6a15efbd6430d1d7b2d36e44a71697e93e19b7ded477afd9fce87",
-                "sha256:deda9266fbb22b8c64fd3ee45c050d61139cd87419765f588e37c8d23e236dd9"
-            ],
-            "version": "==0.6.1"
         },
         "wtforms": {
             "hashes": [
@@ -1481,10 +1463,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.7"
+            "version": "==2.9"
         },
         "imagesize": {
             "hashes": [
@@ -1563,10 +1545,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:7cb1881a0fa84be4b5c1e301168236932c345f6910725f99905d636bfe93e9e9",
-                "sha256:e9390c0c80437d7a02d84e3d1635dc20f37a8bcb149ca443d93791bdc683f28d"
+                "sha256:90854221bbb1498d003a0c3cc9d8390259137551917961c8b5258c64026b2f85",
+                "sha256:ac2e13b30165501b7d41fc0371b8df35944f5849769d136f20e2c5f6cdc6e665"
             ],
-            "version": "==2.21.0"
+            "markers": "python_version >= '3.0.0'",
+            "version": "==3.5.1"
         },
         "mock": {
             "hashes": [
@@ -1678,11 +1661,11 @@
         },
         "pytest-invenio": {
             "hashes": [
-                "sha256:096063be36e57586db47e735ea848d0577b7b9b54d868a852af56cb5448dd93b",
-                "sha256:2a980fe0cb1834e30e887b19576cd52d57b6bc02afca6c3343e59895f3413b82"
+                "sha256:8f2625312714a61a0ab18b96efa2002253acfa38d1577270d3d120b7b7acb078",
+                "sha256:9a7e12c21a7cca0bccadc88e03016283fd7aeac5d58c2ade30aeefc9eb686f3b"
             ],
             "index": "pypi",
-            "version": "==1.0.6"
+            "version": "==1.2.1"
         },
         "pytest-mock": {
             "hashes": [
@@ -1830,10 +1813,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.8"
         },
         "wcwidth": {
             "hashes": [

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -116,59 +116,35 @@ I18N_LANGUAGES = [
     ('de', _('German')),
     ('it', _('Italian')),
 ]
+# Define the default system currency in used. Each organisation can override
+# this parameter using the 'default_currency' field
+RERO_ILS_DEFAULT_CURRENCY = 'CHF'
 
 # Base templates
 # ==============
 #: Global base template.
 BASE_TEMPLATE = 'rero_ils/page.html'
-THEME_BASE_TEMPLATE = BASE_TEMPLATE
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'rero_ils/page_cover.html'
-THEME_COVER_TEMPLATE = COVER_TEMPLATE
 #: Footer base template.
-THEME_FOOTER_TEMPLATE = 'rero_ils/footer.html'
+FOOTER_TEMPLATE = 'rero_ils/footer.html'
 #: Header base template.
 HEADER_TEMPLATE = 'rero_ils/header.html'
-#: Header base template.
-THEME_HEADER_TEMPLATE = HEADER_TEMPLATE
-#: Settings page template used for e.g. display user settings views.
-THEME_SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
+#: Settings base template
+SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
+#: Admin base template
+ADMIN_BASE_TEMPLATE = BASE_TEMPLATE
+
+# Miscellaneous variable around templates
+# =======================
 #: Template for security pages.
 SECURITY_LOGIN_USER_TEMPLATE = 'rero_ils/login_user.html'
 SECURITY_REGISTER_USER_TEMPLATE = 'rero_ils/register_user.html'
 SECURITY_FORGOT_PASSWORD_TEMPLATE = 'rero_ils/forgot_password.html'
 SECURITY_RESET_PASSWORD_TEMPLATE = 'rero_ils/reset_password.html'
-#: Template for error pages.
-THEME_ERROR_TEMPLATE = 'rero_ils/page_error.html'
 #: Template for tombstone page.
 RECORDS_UI_TOMBSTONE_TEMPLATE = "rero_ils/tombstone.html"
-
-RERO_ILS_THEME_SEARCH_ENDPOINT = '/search/documents'
-
-# Logings
-# =======
-LOGGING_SENTRY_LEVEL = "ERROR"
-LOGGING_SENTRY_CELERY = True
-
-# Theme configuration
-# ===================
-#: Site name
-THEME_SITENAME = _('rero-ils')
-#: Use default frontpage.
-THEME_FRONTPAGE = False
-#: Frontpage title.
-THEME_FRONTPAGE_TITLE = _('rero-ils')
-#: Frontpage template.
-THEME_FRONTPAGE_TEMPLATE = 'rero_ils/frontpage.html'
-
-#: Template for including a tracking code for web analytics.
-THEME_TRACKINGCODE_TEMPLATE = 'rero_ils/trackingcode.html'
-THEME_JAVASCRIPT_TEMPLATE = 'rero_ils/javascript.html'
-#: Brand logo.
-THEME_LOGO = 'images/logo_rero_ils.png'
-# External CSS for each organisation customization
-RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT = 'https://resources.rero.ch/ils/test/css/'
-
+#: Miscellaneous templates
 SEARCH_UI_JSTEMPLATE_RESULTS = (
     'templates/rero_ils/brief_view_documents.html'
 )
@@ -184,6 +160,45 @@ REROILS_SEARCHBAR_TEMPLATE = 'templates/rero_ils/searchbar.html'
 RERO_ILS_EDITOR_TEMPLATE = 'rero_ils/editor.html'
 SECURITY_LOGIN_USER_TEMPLATE = 'rero_ils/login_user.html'
 
+# Theme configuration
+# ===================
+#: Brand logo.
+THEME_LOGO = 'images/logo_rero_ils.png'
+#: Site name
+THEME_SITENAME = _('rero-ils')
+#: Use default frontpage.
+THEME_FRONTPAGE = False
+#: Frontpage title.
+THEME_FRONTPAGE_TITLE = _('rero-ils')
+#: Frontpage template.
+THEME_FRONTPAGE_TEMPLATE = 'rero_ils/frontpage.html'
+#: Theme base template.
+THEME_BASE_TEMPLATE = BASE_TEMPLATE
+#: Cover page theme template (used for e.g. login/sign-up).
+THEME_COVER_TEMPLATE = COVER_TEMPLATE
+#: Footer theme template.
+THEME_FOOTER_TEMPLATE = FOOTER_TEMPLATE
+#: Header theme template.
+THEME_HEADER_TEMPLATE = HEADER_TEMPLATE
+#: Settings page template used for e.g. display user settings views.
+THEME_SETTINGS_TEMPLATE = SETTINGS_TEMPLATE
+#: Template for error pages.
+THEME_ERROR_TEMPLATE = 'rero_ils/page_error.html'
+#: RERO-ils search endpoint (i.e /search/documents)
+RERO_ILS_THEME_SEARCH_ENDPOINT = '/search/documents'
+# External CSS for each organisation customization
+RERO_ILS_THEME_ORGANISATION_CSS_ENDPOINT = 'https://resources.rero.ch/ils/test/css/'
+#: Template for including a tracking code for web analytics.
+THEME_TRACKINGCODE_TEMPLATE = 'rero_ils/trackingcode.html'
+THEME_JAVASCRIPT_TEMPLATE = 'rero_ils/javascript.html'
+
+# Logings
+# =======
+#: Sentry level
+LOGGING_SENTRY_LEVEL = "ERROR"
+#: Sentry: use celery or not
+LOGGING_SENTRY_CELERY = True
+
 # Email configuration
 # ===================
 #: Email address for support.
@@ -193,8 +208,8 @@ MAIL_SUPPRESS_SEND = True
 
 # Assets
 # ======
-#: Static files collection method (defaults to copying files).
-# COLLECT_STORAGE = 'flask_collect.storage.file'
+#: Static files collection method (defaults to symbolic link to files).
+COLLECT_STORAGE = 'flask_collect.storage.link'
 
 # Accounts
 # ========
@@ -204,6 +219,11 @@ SECURITY_EMAIL_SENDER = SUPPORT_EMAIL
 SECURITY_EMAIL_SUBJECT_REGISTER = _("Welcome to RERO-ILS!")
 #: Redis session storage URL.
 ACCOUNTS_SESSION_REDIS_URL = 'redis://localhost:6379/1'
+#: Enable session/user id request tracing. This feature will add X-Session-ID
+#: and X-User-ID headers to HTTP response. You MUST ensure that NGINX (or other
+#: proxies) removes these headers again before sending the response to the
+#: client. Set to False, in case of doubt.
+ACCOUNTS_USERINFO_HEADERS = False
 # Disable User Profiles
 USERPROFILES = False
 # make security blueprints available to the REST API
@@ -278,7 +298,6 @@ SECRET_KEY = 'CHANGE_ME'
 MAX_CONTENT_LENGTH = 100 * 1024 * 1024  # 100 MiB
 #: For dev. Set to false when testing on localhost in no debug mode
 APP_ENABLE_SECURE_HEADERS = True
-
 # TODO: review theses rules for security purposes
 APP_DEFAULT_SECURE_HEADERS = {
     # disabled as https is not used by the application:
@@ -319,7 +338,7 @@ APP_DEFAULT_SECURE_HEADERS = {
     'session_cookie_secure': True,
     'session_cookie_http_only': True,
 }
-#: Sets cookie with the secure flag by default
+#: Sets cookie with the secure flag (by default False)
 SESSION_COOKIE_SECURE = False
 #: Since HAProxy and Nginx route all requests no matter the host header
 #: provided, the allowed hosts variable is set to localhost. In production it
@@ -330,6 +349,12 @@ APP_ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 # OAI-PMH
 # =======
 OAISERVER_ID_PREFIX = 'oai:ils.rero.ch:'
+
+# TODO: Check if needed one day
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+# PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
 
 # Debug
 # =====
@@ -1394,8 +1419,6 @@ RERO_ILS_PERSONS_LABEL_ORDER = {
     'de': ['gnd', 'rero', 'bnf'],
 }
 
-ADMIN_BASE_TEMPLATE = BASE_TEMPLATE
-
 #: Invenio circulation configuration.
 CIRCULATION_ITEM_EXISTS = Item.get_record_by_pid
 CIRCULATION_PATRON_EXISTS = Patron.get_record_by_pid
@@ -1517,9 +1540,5 @@ CIRCULATION_POLICIES = dict(
         can_be_requested=can_be_requested
     )
 )
-
-# Define the default system currency in used. Each organisation can override
-# this parameter using the 'default_currency' field
-RERO_ILS_DEFAULT_CURRENCY = 'CHF'
 
 WEBPACKEXT_PROJECT = 'rero_ils.webpack:project'

--- a/rero_ils/es_templates/v6/__init__.py
+++ b/rero_ils/es_templates/v6/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2020 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""ES Templates module for RERO-ils."""

--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -206,13 +206,13 @@ def init(force):
     click.secho('Putting templates...', fg='green', bold=True, file=sys.stderr)
     with click.progressbar(
             current_search.put_templates(ignore=[400] if force else None),
-            length=len(current_search.templates.keys())) as bar:
+            length=len(current_search.templates)) as bar:
         for response in bar:
             bar.label = response
     click.secho('Creating indexes...', fg='green', bold=True, file=sys.stderr)
     with click.progressbar(
             current_search.create(ignore=[400] if force else None),
-            length=current_search.number_of_indexes) as bar:
+            length=len(current_search.mappings)) as bar:
         for name, response in bar:
             bar.label = name
 
@@ -448,6 +448,7 @@ def check_license(configfile, verbose, progress):
         lines_with_errors = []
         lines = [line.rstrip() for line in file]
         linenbr = 0
+        linemaxnbr = len(lines)
         prefix = extension.get('prefix')
         line, linenbr = get_line(lines, linenbr, prefix)
         while lines[linenbr-1].startswith('#!'):
@@ -472,6 +473,9 @@ def check_license(configfile, verbose, progress):
                 if verbose:
                     show_diff(linenbr, license_line, line)
                 lines_with_errors.append(linenbr)
+            # Fix crash while testing a file with only comments.
+            if linenbr >= linemaxnbr:
+                continue
             line, linenbr = get_line(lines, linenbr, prefix)
         return lines_with_errors
 

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -174,7 +174,7 @@ class Document(IlsRecord):
             auth_pid = author.get('pid')
             if auth_pid:
                 from ..persons.api import Person
-                person = Person.get_record_by_pid(auth_pid)
+                person = Person.get_record_by_mef_pid(auth_pid)
                 if bulk:
                     persons_ids.append(person.id)
                 else:

--- a/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/mappings/v6/documents/document-v0.0.1.json
@@ -24,7 +24,7 @@
     }
   },
   "mappings": {
-    "document": {
+    "document-v0.0.1": {
       "date_detection": false,
       "numeric_detection": false,
       "properties": {

--- a/rero_ils/modules/indexer_utils.py
+++ b/rero_ils/modules/indexer_utils.py
@@ -20,8 +20,8 @@
 import re
 
 from flask import current_app
+from invenio_indexer.utils import schema_to_index
 from invenio_search import current_search
-from invenio_search.utils import schema_to_index
 
 
 def record_to_index(record):
@@ -39,8 +39,11 @@ def record_to_index(record):
         schema = schema.get('$ref', '')
 
     # put all document in the same index
+    # 'document-minimal-v0.0.1.json' becomes 'document-v0.0.1.json'
     if re.search(r'/documents/', schema):
-        schema = re.sub(r'-.*\.json', '.json', schema)
+        schema = re.sub(
+            r'/document(?P<word>-\D+)?(?P<version>-v[\d,\.]+).json',
+            r'/document\g<version>.json', schema)
     # authorities specific transformation
     if re.search(r'/authorities/', schema):
         schema = re.sub(r'/authorities/', '/persons/', schema)

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -22,14 +22,14 @@ from functools import wraps
 from flask import abort, current_app
 from flask_login import current_user
 from flask_principal import RoleNeed
-from invenio_access.permissions import DynamicPermission
+from invenio_access.permissions import Permission
 from invenio_admin.permissions import \
     admin_permission_factory as default_admin_permission_factory
 
 from .modules.patrons.api import Patron
 
-request_item_permission = DynamicPermission(RoleNeed('patron'))
-librarian_permission = DynamicPermission(RoleNeed('librarian'))
+request_item_permission = Permission(RoleNeed('patron'))
+librarian_permission = Permission(RoleNeed('librarian'))
 
 
 def user_is_authenticated(user=None):

--- a/rero_ils/templates/__init__.py
+++ b/rero_ils/templates/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2020 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Template module for RERO-ils."""

--- a/scripts/setup
+++ b/scripts/setup
@@ -170,6 +170,7 @@ eval ${PREFIX} invenio index queue purge delete
 set -e
 eval ${PREFIX} invenio index destroy --force --yes-i-know
 # Override index init to load templates before mapping
+# TODO: check if invenio index init --force works (to delete utils init --force)
 info_msg "Override index init to load templates before mapping"
 eval ${PREFIX} invenio utils init --force
 # eval ${PREFIX} invenio index init --force

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,18 +40,18 @@ def es(appctx):
     should used the function-scoped :py:data:`es_clear` fixture to leave the
     indexes clean for the following tests.
     """
-    from elasticsearch.exceptions import RequestError
+    from invenio_search.errors import IndexAlreadyExistsError
     from invenio_search import current_search, current_search_client
 
     try:
         list(current_search.put_templates())
-    except RequestError:
+    except IndexAlreadyExistsError:
         current_search_client.indices.delete_template('*')
         list(current_search.put_templates())
 
     try:
         list(current_search.create())
-    except RequestError:
+    except IndexAlreadyExistsError:
         list(current_search.delete(ignore=[404]))
         list(current_search.create())
     current_search_client.indices.refresh()

--- a/tests/ui/test_indexer_utils.py
+++ b/tests/ui/test_indexer_utils.py
@@ -27,7 +27,11 @@ def test_record_to_index(app):
     assert record_to_index({
         '$schema': 'https://ils.rero.ch/schema/'
         'documents/document-minimal-v0.0.1.json'
-    }) == ('documents-document', 'document')
+    }) == ('documents-document-v0.0.1', 'document-v0.0.1')
+    assert record_to_index({
+        '$schema': 'https://ils.rero.ch/schema/'
+        'documents/document-v0.0.1.json'
+    }) == ('documents-document-v0.0.1', 'document-v0.0.1')
 
     # for mef-persons
     assert record_to_index({


### PR DESCRIPTION
* Updates Invenio framework from 3.1 to 3.2.1
* Adapts tests regarding new invenio-search module
* Lists all templates at same place in config.py file
* Fixes init() in CLI (for indexes)
* Fixes test_license() in CLI for files that only have comments (#) lines
* Migrates from DynamicPermission to Permission from invenio-access
* Fixes record_to_index() for documents
* Improves regular expression for schema detection for documents
* Changes document mappings name to document-v0.0.1
* Fixes persons indexation in doc. mappings by using `get_record_by_mef_pid()`

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>
Co-Authored-by: Peter Weber <peter.weber@rero.ch>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

Because of https://tree.taiga.io/project/rero21-reroils/task/1307?kanban-status=1224895 task in order to upgrade invenio-circulation.

## How to test?

* Deploy a complete instance of RERO-ils with this kind of setup: `pipenv run setup -w -P -b`
* Tests `run-tests.sh` script
* Attempt to list documents in public search
* Try API
* Try whatever you want as Invenio 3.2.1 as an impact on database, elasticsearch, etc.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
