### PR TITLE
circulation: fix some loan scenarios

### DIFF
--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -769,6 +769,9 @@ class Item(IlsRecord):
         #       to deal with multiple pickup locations for a library
         item = cls.get_record_by_pid(item_pid)
         if item:
+            last_location = item.get_last_location()
+            if last_location:
+                return last_location.pid
             return item.get_owning_pickup_location_pid()
 
     @add_loans_parameters_and_flush_indexes
@@ -825,6 +828,9 @@ class Item(IlsRecord):
             request = next(self.get_requests())
             if loan.is_active:
                 item, cancel_action = self.cancel_loan(pid=loan.pid)
+            # pass the correct transaction location
+            transaction_loc_pid = loan.get('transaction_location_pid')
+            request['transaction_location_pid'] = transaction_loc_pid
             item, validate_item = self.validate_request(**request)
             # return the validated loan instead of the checked-in loan
             loan = validate_item[LoanAction.VALIDATE]


### PR DESCRIPTION
* Closes #770
* Improves finding a location of an item when in circulation.
* Fixes units testing.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## How to test?

Login as reroilstest+elena@gmail.com [AVISE library]:
- checkout `item1` of the `AVISE` library to Broglio,Giulia barcode=`2050124312`
- checkout `item2` of the `AVISE` library to Broglio,Giulia barcode=`2050124312`

Login as reroilstest+simonetta@gmail.com:
- request the item `item1` to pickup location `AOSTE-LYCEE`
- request the item `item2` to pickup location `AOSTE-AVISE`

Login as reroilstest@gmail.com: [LYCEE library]
- checkin `item1`, item status will be `AT_DESK`
- checkin `item2`, item status will be `IN_TRANSIT to AOSTE-AVISE`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
