### PR TITLE
public interface: improve patron request deletion

### DIFF
--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -26,13 +26,13 @@
     <nav>
       <ul class="nav nav-tabs" id="nav-tab" role="tablist">
         <li class="nav-item">
-          <a class="nav-link active" href="#checkouts" data-toggle="tab" id="checkouts-tab" title="{{ _('Checkouts') }}"
+          <a {% if tab == 'checkouts' %}class="nav-link active"{%else%}class="nav-link"{% endif %} href="#checkouts" data-toggle="tab" id="checkouts-tab" title="{{ _('Checkouts') }}"
             role="tab" aria-controls="checkouts" aria-selected="true">
             {{ _('Checkouts') }} ({{ checkouts|length }})
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#pending" data-toggle="tab" id="pending-tab" title="{{ _('Pending') }}" role="tab"
+          <a {% if tab == 'pendings' %}class="nav-link active"{%else%}class="nav-link"{% endif %} href="#pending" data-toggle="tab" id="pending-tab" title="{{ _('Pending') }}" role="tab"
             aria-controls="pending" aria-selected="false">
             {{ _('Pending') }} ({{ pendings|length }})
           </a>
@@ -53,14 +53,14 @@
     </nav>
   </header>
   <article class="tab-content">
-    <section class="tab-pane show active py-2" id="checkouts" role="tabpanel" aria-labelledby="checkouts-tab">
+    <section {% if tab == 'checkouts' %}class="tab-pane show active py-2"{%else%}class="tab-pane show py-2"{% endif %} id="checkouts" role="tabpanel" aria-labelledby="checkouts-tab">
       {% if checkouts|length > 0 %}
       {{ build_table('checkouts', checkouts) }}
       {% else %}
       <p>{{ _('No loan') }}</p>
       {% endif %}
     </section>
-    <section class="tab-pane py-2" id="pending" role="tabpanel" aria-labelledby="pending-tab">
+    <section {% if tab == 'pendings' %}class="tab-pane show active py-2"{%else%}class="tab-pane show py-2"{% endif %} id="pending" role="tabpanel" aria-labelledby="pending-tab">
       {% if pendings|length > 0 %}
       {{ build_table('requests', pendings) }}
       {% else %}

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -100,6 +100,7 @@ def logged_user():
 )
 def profile(viewcode):
     """Patron Profile Page."""
+    tab = 'checkouts'
     patron = Patron.get_patron_by_user(current_user)
     if patron is None:
         raise NotFound()
@@ -107,6 +108,7 @@ def profile(viewcode):
         loan = Loan.get_record_by_pid(request.values.get('loan_pid'))
         item = Item.get_record_by_pid(loan.get('item_pid'))
         if request.form.get('type') == 'cancel':
+            tab = 'pendings'
             data = loan
             try:
                 item.cancel_loan(**data)
@@ -137,7 +139,8 @@ def profile(viewcode):
         checkouts=checkouts,
         pendings=requests,
         history=history,
-        viewcode=viewcode
+        viewcode=viewcode,
+        tab=tab
     )
 
 


### PR DESCRIPTION
* Keeps 'pendings' tab active after cancel.

Co-Authored-by: Alicia Zangger  <alicia.zangger@rero.ch>

## Why are you opening this PR?

To implement task 1330 of US 1262
https://tree.taiga.io/project/rero21-reroils/task/1330?kanban-status=1224895

## How to test?

1. Login as a patron.
2. Go to your profile, 'pending' tab
3. Cancel a request.
4. You should stay in this tab after action.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
