### PR TITLE
cli: fix typo

### DIFF
--- a/rero_ils/modules/cli.py
+++ b/rero_ils/modules/cli.py
@@ -1510,7 +1510,7 @@ def export(verbose, pid_type, outfile, pidfile, indent, schema):
                     'RERO_ILS_PERSONS_SOURCES', [])
                 for persons_source in persons_sources:
                     try:
-                        del rec[persons_sources]['$schema']
+                        del rec[persons_source]['$schema']
                     except:
                         pass
             output = ''


### PR DESCRIPTION
* Fixes 'person_source' typo in cli.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
