### PR TITLE
circulation: return all applied actions after a checkin or checkout

### DIFF
--- a/tests/api/test_circ_bug.py
+++ b/tests/api/test_circ_bug.py
@@ -67,7 +67,8 @@ def test_document_with_one_item_attached_bug(
         'api_item.checkin',
         dict(
             item_pid=item_lib_martigny.pid,
-            pid=loan_pid
+            pid=loan_pid,
+            transaction_location_pid=loc_public_martigny.pid
         )
     )
     assert res.status_code == 200


### PR DESCRIPTION
Applies additional circulation actions after/before a successful checkin/checkout transactions of an item. The additional actions are to address the reroils circulation use cases.

    * Returns the receive, cancelled and checkout loans after a successful checkout.
    * Returns the checked-in, cancelled, validated loans after a successful automatic validation of a checked-in transaction.
    * Creates additonal unit testings.
    * Closes #826

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1338?kanban-status=1224894

## How to test?

`run_tests.py`
the new returned loans, will be used by the frontend

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
