### PR TITLE
patron_transaction: fix total amount calculation problem

### DIFF
--- a/rero_ils/modules/patron_transaction_events/api.py
+++ b/rero_ils/modules/patron_transaction_events/api.py
@@ -93,7 +93,7 @@ class PatronTransactionEvent(IlsRecord):
         total_amount = patron_transaction.get('total_amount')
         if self.event_type == 'fee':
             total_amount = total_amount + self.amount
-        elif self.event_type == 'payment':
+        elif self.event_type in ('payment', 'resolved'):
             total_amount = total_amount - self.amount
         patron_transaction['total_amount'] = total_amount
         if total_amount == 0:


### PR DESCRIPTION
When a 'resolved' patron transaction events was received, the amount of this
event was ignored for the total_amount calculation of the parent transaction

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
