### PR TITLE
location: adapt JSON schema for pickup_name required if is_pickup

### DIFF
--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -113,5 +113,28 @@
         }
       }
     }
-  }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "is_pickup": {
+          "enum": [
+            true
+          ]
+        }
+      },
+      "required": [
+        "pickup_name"
+      ]
+    },
+    {
+      "properties": {
+        "is_pickup": {
+          "enum": [
+            false
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/tests/unit/test_locations_jsonschema.py
+++ b/tests/unit/test_locations_jsonschema.py
@@ -52,3 +52,15 @@ def test_locations_name(location_schema, loc_public_martigny_data):
         data = copy.deepcopy(loc_public_martigny_data)
         data['name'] = 25
         validate(data, location_schema)
+
+
+def test_locations_pickup(location_schema, loc_public_martigny_data):
+    """Test pickup location behavior through jsonschemas."""
+    validate(loc_public_martigny_data, location_schema)
+
+    # If location is a pickup_location, then the pickup_name must be present.
+    with pytest.raises(ValidationError):
+        data = copy.deepcopy(loc_public_martigny_data)
+        data['is_pickup'] = True
+        del(data['pickup_name'])
+        validate(data, location_schema)


### PR DESCRIPTION
Before this change, the location JSON schema accept that the location was a
pickup location (is_pickup=true) but without pickup_name. This fix change this
behavior ; when a location is defined as pickup location, then the 'pickup_name'
is now required.

Note : the schema already contains behavior for the formly editor

* Closes rero/rero-ils#794.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
