### PR TITLE
tests: fix Zürich timezone problems

### DIFF
--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -308,7 +308,8 @@ class Library(IlsRecord):
         return cannot_delete
 
     def get_timezone(self):
-        """Get library timezone. By default use BABEL_DEFAULT_TIMEZONE."""
-        # TODO: get timezone regarding Library address
+        """Get library timezone."""
+        # TODO: get timezone regarding Library address.
+        # TODO: Use BABEL_DEFAULT_TIMEZONE by default
         default = pytz.timezone('Europe/Zurich')
         return default

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,10 +171,16 @@ def get_timezone_difference(timezone, date):
 def check_timezone_date(timezone, date, expected=[]):
     """Check hour and minute of given date regarding given timezone."""
     difference = get_timezone_difference(timezone, date)
-    hour = date.hour + difference
+    # In case the difference is positive, the result hour could be greater
+    # or equal to 24.
+    # A day doesn't contain more than 24 hours.
+    # We so use modulo to always have less than 24.
+    hour = (date.hour + difference) % 24
     # Expected list defines accepted hours for tests
     if expected:
         assert hour in expected
     tocheck_date = date.astimezone(timezone)
-    assert tocheck_date.minute == date.minute
-    assert tocheck_date.hour == hour
+    error_msg = "Date: %s. Expected: %s. Minutes should be: %s. Hour: %s" % (
+        tocheck_date, date, date.minute, hour)
+    assert tocheck_date.minute == date.minute, error_msg
+    assert tocheck_date.hour == hour, error_msg


### PR DESCRIPTION
When timezone difference is positive it happens that the we compare an
hour superior or equal to 24. In these cases tests on loan/items fails.
This commit fixes that and it:

* fixes check_timezone_date() using a modulo 24.
* displays more info if an error happens in check_timezone_date test
* changes get_timezone() description to correspond to reality
* fixes a test that compare an UTC date to an non-UTC date

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because tests failed on timezoned date. March, the 20th we will change the timezone from GMT+1 to GMT+2 which displays errors.

## How to test?

`pipenv run pytest -vvs --no-cov --disable-warnings tests/api/test_items_rest.py`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
