### PR TITLE
document: fix cover image in public detailed view

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -22,15 +22,29 @@
 {%- block body %}
 <header class="row">
 
+  {% if record | get_cover_art%}
+  <a id="thumbnail" class="col-sm-2 col-md-1 d-flex justify-content-start" href="{{ (record | get_cover_art) }}" target="_blank">
+    <icon-thumbnail class="thumb"
+      thumbnailurl='{{ (record | get_cover_art) }}'
+      type="{{ record.type }}"
+      config='{{ {"thumbnail_service_url": config.RERO_ILS_THUMBNAIL_SERVICE_URL} | tojson }}'>
+    </icon-thumbnail>
+  </a>
+  {% else %}
   <div id="thumbnail" class="col-sm-2 col-md-1 d-flex justify-content-start">
-    <icon-thumbnail class="thumb" {% if record.cover_art %} thumbnailurl='{{ (record.cover_art) }}' {% else %}
-      thumbnailurl="/static/images/icon_{{ record.type }}.png" {% if record.identifiedBy %}
-      identifiers='{{ (record.identifiedBy|document_isbn)|tojson }}' {% else %} thumbnailurl=""
-      {% if record.identifiedBy %} identifiers='{{ (record.identifiedBy|document_isbn)|tojson }}' {% else %}
-      identifiers="" {% endif %} {% endif %} {% endif %} type="{{ record.type }}"
+    <icon-thumbnail class="thumb"
+      thumbnailurl="/static/images/icon_{{ record.type }}.png"
+        {% if record.identifiedBy %} identifiers='{{ (record.identifiedBy|document_isbn)|tojson }}'
+        {% else %} thumbnailurl=""
+          {% if record.identifiedBy %} identifiers='{{ (record.identifiedBy|document_isbn)|tojson }}'
+          {% else %} identifiers=""
+          {% endif %}
+        {% endif %}
+      type="{{ record.type }}"
       config='{{ {"thumbnail_service_url": config.RERO_ILS_THUMBNAIL_SERVICE_URL} | tojson }}'>
     </icon-thumbnail>
   </div>
+  {% endif %}
 
   <h1 class="col-sm-10 col-md-11">{{ record.title }}</h1>
 </header>

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -443,10 +443,10 @@ def get_cover_art(record):
     :param record: record
     :return: url for cover art or None
     """
-    for electronic_locator in record.get('electronicLocator'):
+    for electronic_locator in record.get('electronicLocator', []):
         type = electronic_locator.get('type')
         content = electronic_locator.get('content')
-        if type == 'resource' and content == 'coverImage':
+        if type == 'relatedResource' and content == 'coverImage':
             return electronic_locator.get('url')
     return None
 
@@ -463,8 +463,7 @@ def get_accesses(record):
     def filter_type(electronic_locator):
         """Filter electronic locator for resources and not cover image."""
         types = ['resource', 'versionOfResource']
-        if electronic_locator.get('type') in types \
-                and electronic_locator.get('content') != 'coverImage':
+        if electronic_locator.get('type') in types:
             return True
         else:
             return False
@@ -498,7 +497,8 @@ def get_other_accesses(record):
 
     def filter_type(electronic_locator):
         """Filter electronic locator for related resources and no info."""
-        if electronic_locator.get('type') in ['relatedResource', 'noInfo']:
+        if electronic_locator.get('type') in ['relatedResource', 'noInfo'] \
+                and electronic_locator.get('content') != 'coverImage':
             return True
         else:
             return False

--- a/rero_ils/modules/ebooks/dojson/contrib/marc21/model.py
+++ b/rero_ils/modules/ebooks/dojson/contrib/marc21/model.py
@@ -430,7 +430,7 @@ def marc21_electronicLocator(self, key, value):
         if subfield_3 and subfield_3 == 'Image de couverture':
             electronic_locator = {
                 'url': url,
-                'type': 'resource',
+                'type': 'relatedResource',
                 'content': 'coverImage'
             }
     elif indicator2 == '0':

--- a/tests/unit/test_documents_dojson.py
+++ b/tests/unit/test_documents_dojson.py
@@ -2099,7 +2099,7 @@ def test_marc21_to_electronicLocator_from_856():
         <subfield code="q">application/pdf</subfield>
         <subfield code="z">Bd. 1</subfield>
       </datafield>
-      <datafield tag="856" ind1="4" ind2="0">
+      <datafield tag="856" ind1="4" ind2="2">
         <subfield code="3">coverImage</subfield>
         <subfield code="u">http://d-nb.info/image.png</subfield>
       </datafield>
@@ -2119,7 +2119,7 @@ def test_marc21_to_electronicLocator_from_856():
         },
         {
             'content': 'coverImage',
-            'type': 'resource',
+            'type': 'relatedResource',
             'url': 'http://d-nb.info/image.png'
         },
         {
@@ -2129,7 +2129,14 @@ def test_marc21_to_electronicLocator_from_856():
         }
     ]
     assert get_cover_art(data) == 'http://d-nb.info/image.png'
-    assert get_accesses(data) == []
+    assert get_accesses(data) == [
+        {
+            'content': 'coverImage',
+            'public_note': '',
+            'type': 'versionOfResource',
+            'url': 'http://d-nb.info/image2.png'
+            }
+    ]
     assert get_other_accesses(data) == [
         {
             'content': 'http://d-nb.info/1071856731/04',

--- a/tests/unit/test_documents_dojson_ebooks.py
+++ b/tests/unit/test_documents_dojson_ebooks.py
@@ -566,7 +566,7 @@ def test_marc21_electronicLocator_ebooks():
         },
         {
             'url': 'http://site2.org/resources/2',
-            'type': 'resource',
+            'type': 'relatedResource',
             'content': 'coverImage'
         }
     ]
@@ -591,7 +591,7 @@ def test_marc21_cover_art_ebooks():
     assert data.get('electronicLocator') == [
         {
             'url': 'http://site2.org/resources/2',
-            'type': 'resource',
+            'type': 'relatedResource',
             'content': 'coverImage'
         }
     ]


### PR DESCRIPTION
* Corrects url type filter.
* Displays cover as a link for coverImage type.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>
Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To complete US 1262 https://tree.taiga.io/project/rero21-reroils/us/1262?milestone=257446

## How to test?

1. Edit a record to add an electronic location with a type `Covert art` (suggested url: https://d2v9ipibika81v.cloudfront.net/uploads/sites/21/Africa-990x684.jpg)
1. Go to the detailed view in public interface
1. Check that the cover image is a working link

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
