### PR TITLE
serials: create api to preview predicted issues

### DIFF
--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -305,18 +305,33 @@ class Holding(IlsRecord):
         return patterns
 
     def prediction_issues_preview(self, predictions=1):
-        """Display prview of next predictions.
+        """Display preview of next predictions.
 
-        :param predictions: Number of the next issued to predict.
+        :param predictions: Number of the next issues to predict.
         :returns: An array of issues display text.
         """
-        if not self.patterns or not self.patterns.get('values'):
-            return []
-        patterns = deepcopy(self.patterns)
         text = []
-        for r in range(predictions):
-            text.append(self._get_next_issue_display_text(patterns))
-            patterns = self._increment_next_prediction(patterns)
+        if self.patterns and self.patterns.get('values'):
+            patterns = deepcopy(self.patterns)
+            for r in range(predictions):
+                text.append(self._get_next_issue_display_text(patterns))
+                patterns = self._increment_next_prediction(patterns)
+        return text
+
+    @classmethod
+    def prediction_issues_preview_for_pattern(
+            cls, patterns, number_of_predictions=1, ):
+        """Display preview of next predictions for a given pattern.
+
+        :param predictions: Number of the next issues to predict.
+        :param patterns: The patterns to predict.
+        :returns: An array of issues display text.
+        """
+        text = []
+        if patterns and patterns.get('values'):
+            for r in range(number_of_predictions):
+                text.append(Holding._get_next_issue_display_text(patterns))
+                patterns = Holding._increment_next_prediction(patterns)
         return text
 
 

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -175,19 +175,27 @@
       }
     }
   },
-  "if": {
-    "properties": {
-      "holdings_type": {
-        "const": "serial"
-      }
+  "oneOf": [
+    {
+      "properties": {
+        "holdings_type": {
+          "enum": [
+            "serial"
+          ]
+        }
+      },
+      "required": [
+        "patterns"
+      ]
     },
-    "required": [
-      "holdings_type"
-    ]
-  },
-  "then": {
-    "required": [
-      "patterns"
-    ]
-  }
+    {
+      "properties": {
+        "holdings_type": {
+          "enum": [
+            "monograph"
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
             'api_documents = rero_ils.modules.documents.views:api_blueprint',
             'items = rero_ils.modules.items.api_views:api_blueprint',
             'persons = rero_ils.modules.persons.views:api_blueprint',
-            'holdings = rero_ils.modules.holdings.api_views:api_blueprint',
+            'holdings = rero_ils.modules.holdings.api_views:api_blueprint'
         ],
         'invenio_config.module': [
             'rero_ils = rero_ils.config',

--- a/tests/unit/test_holdings_jsonschema.py
+++ b/tests/unit/test_holdings_jsonschema.py
@@ -28,8 +28,19 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
 
-def test_required(holding_schema, holding_lib_martigny_w_patterns_data):
-    """Test required for library jsonschemas."""
+def test_required(holding_schema, holding_lib_martigny_data):
+    """Test required for holdings of type monograph jsonschemas."""
+    validate(holding_lib_martigny_data, holding_schema)
+
+    with pytest.raises(ValidationError):
+        validate({}, holding_schema)
+        validate(
+            holding_lib_martigny_data, holding_schema)
+
+
+def test_required_patterns(
+        holding_schema, holding_lib_martigny_w_patterns_data):
+    """Test required for holdings jsonschemas."""
     validate(holding_lib_martigny_w_patterns_data, holding_schema)
 
     with pytest.raises(ValidationError):


### PR DESCRIPTION
These APIs allow to return predicted issues for a given holdings_pid or a given pattern.

* Adds condition to require field patterns for holdings of type serial.
* Creates units tests.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1369?kanban-status=1224894

## How to test?

- `scripts/bootstrap` 
- `scripts/setup`
- find holdings records with patterns:

     ` ~/api/holdings/?&q=holdings_type:serial`

- display predicted issues of a holdings record from the list above:

     by default, the api lists the first 10 issues:

     `~/api/holding/<holdings_pid>/patterns/preview/`

     to display the first 25 issues, use the `size` variable:

     `~/api/holding/<holdings_pi>/patterns/preview/?size=25`

- api to return the predicted issues for a given pattern (holding record is not yet created), size parameter is also available here
     POST method with data = the `patterns` json
    `~/api/holding/pattern/preview/?size=15` 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
