### PR TITLE
bootstrap: fix useless tgz file installation

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -58,7 +58,7 @@ success_msg() {
 msg "PROGRAM: ${PROGRAM}"
 
 # options may be followed by one colon to indicate they have a required argument
-if ! options=$(getopt -o dsb -l -t deploy,ci,tgz_path: -- "$@")
+if ! options=$(getopt -o dct: -l deploy,ci,tgz_package: -- "$@")
 then
     # something went wrong, getopt will put out an error message for us
     exit 1
@@ -81,7 +81,7 @@ do
       ci=true ;;
     -t|--tgz_package)
       tgz_file=$2
-      if [ ! -f ${tgz_file} ]
+      if [[ ! -f "${tgz_file}" ]]
       then
         error_msg+exit "package tgz file dos not exist: ${tgz_file}"
       fi ;;
@@ -93,7 +93,7 @@ do
 done
 
 # PIPENV is a mandatory condition to launch this program!
-if [[ -z  "${VIRTUAL_ENV}" ]]; then
+if [[ -z "${VIRTUAL_ENV}" ]]; then
   error_msg+exit "Error - Launch this script via pipenv command:\n\tpipenv run ${PROGRAM}"
 fi
 
@@ -116,7 +116,7 @@ info_msg "Install with command: ${cmd} ${flags[@]}"
 ${cmd} ${flags[@]}
 
 # to avoid IPython dependency problem on Mac OS X
-if [ "$(uname -s)" == "Darwin" ]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
   info_msg "Install 'appnope' for Mac OS X"
   pip install appnope
 fi
@@ -135,7 +135,7 @@ info_msg "Search static folder location"
 static_folder=$(pipenv run invenio shell --no-term-title -c "print('static_folder:%s' % app.static_folder)"|grep static_folder| cut -d: -f2-)
 info_msg "Install static folder npm dependencies in: ${static_folder}"
 npm install --prefix "${static_folder}"
-if [ -f ${tgz_file} ]
+if [[ -f "${tgz_file}" ]]
 then
   info_msg "Install RERO-ILS-UI from tgz: ${tgz_file}"
   npm install "${tgz_file}" --prefix "${static_folder}"

--- a/scripts/console
+++ b/scripts/console
@@ -60,7 +60,7 @@ msg "PROGRAM: ${PROGRAM}"
 set -e
 
 # PIPENV is a mandatory condition to launch this program!
-if [[ -z  "${VIRTUAL_ENV}" ]]; then
+if [[ -z "${VIRTUAL_ENV}" ]]; then
   error_msg+exit "Error - Launch this script via pipenv command:\n\tpipenv run ${PROGRAM}"
 fi
 

--- a/scripts/server
+++ b/scripts/server
@@ -61,7 +61,7 @@ set -e
 
 script_path=$(dirname "$0")
 # PIPENV is a mandatory condition to launch this program!
-if [[ -z  "${VIRTUAL_ENV}" ]]; then
+if [[ -z "${VIRTUAL_ENV}" ]]; then
   error_msg+exit "Error - Launch this script via pipenv command:\n\tpipenv run ${PROGRAM}"
 fi
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -93,7 +93,7 @@ ENABLE_WARNINGS=${ENABLE_WARNINGS:=true}
 msg "PROGRAM: ${PROGRAM}"
 
 # PIPENV is a mandatory condition to launch this program!
-if [[ -z  "${VIRTUAL_ENV}" ]]; then
+if [[ -z "${VIRTUAL_ENV}" ]]; then
   error_msg+exit "Error - Launch this script via pipenv command:\n\tpipenv run ${PROGRAM}"
 fi
 
@@ -125,7 +125,7 @@ do
     shift
 done
 
-if [ ! -d ${DATA_PATH} ]; then
+if [[ ! -d "${DATA_PATH}" ]]; then
     error_msg+exit "Error - data path does not exist: ${DATA_PATH}"
 fi
 

--- a/scripts/update
+++ b/scripts/update
@@ -60,7 +60,7 @@ msg "PROGRAM: ${PROGRAM}"
 set -e
 
 # PIPENV is a mandatory condition to launch this program!
-if [[ -z  "${VIRTUAL_ENV}" ]]; then
+if [[ -z "${VIRTUAL_ENV}" ]]; then
   error_msg+exit "Error - Launch this script via pipenv command:\n\tpipenv run ${PROGRAM}"
 fi
 


### PR DESCRIPTION
While using bootstrap script, it attempts to install TGZ_FILE.
Something like `[INFO]: Install RERO-ILS-UI from tgz: ` appears. But no
file were given.

* Fixes #856 - by changing `[` tests to `[[` (bash)

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because of #856 issue.

## How to test?

Launch `pipenv run bootstrap` and check that no `[INFO]: Install RERO-ILS-UI from tgz: ` appears.

Then do the same with a TGZ file, for example those from https://github.com/rero/rero-ils-ui/releases/tag/v0.0.12, like : 

`pipenv run bootstrap -t v0.0.12.tar.gz`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
