### PR TITLE
test: fix library opening timezone due date

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,11 +176,12 @@ def check_timezone_date(timezone, date, expected=[]):
     # A day doesn't contain more than 24 hours.
     # We so use modulo to always have less than 24.
     hour = (date.hour + difference) % 24
-    # Expected list defines accepted hours for tests
-    if expected:
-        assert hour in expected
+    # Prepare date
     tocheck_date = date.astimezone(timezone)
     error_msg = "Date: %s. Expected: %s. Minutes should be: %s. Hour: %s" % (
         tocheck_date, date, date.minute, hour)
+    # Expected list defines accepted hours for tests
+    if expected:
+        assert hour in expected, error_msg
     assert tocheck_date.minute == date.minute, error_msg
     assert tocheck_date.hour == hour, error_msg


### PR DESCRIPTION
As we will enter in GMT+2 in few days, a test failed as it compare wrong
date (first in Zurich timezone and second in UTC one).
We should compare dates in UTC only.
* Compares date in UTC for opening hours of a given library

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because of https://tree.taiga.io/project/rero21-reroils/task/1381

## How to test?

`./run-tests.sh`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
