### PR TITLE
serials: new items will not be attached to holdings of type serial

### DIFF
--- a/rero_ils/modules/ebooks/utils.py
+++ b/rero_ils/modules/ebooks/utils.py
@@ -23,8 +23,8 @@ from invenio_oaiharvester.models import OAIHarvestConfig
 
 from ..documents.api import Document
 from ..holdings.api import create_holding, \
-    get_holding_pid_by_document_location_item_type, \
-    get_holdings_by_document_item_type
+    get_holdings_by_document_item_type, \
+    get_monograph_holding_pid_by_doc_location_item_type
 from ..organisations.api import Organisation
 
 
@@ -127,8 +127,8 @@ def update_document_holding(record, pid):
             item_type_pid = org.online_circulation_category()
             locations = org.get_online_locations()
             for location_pid in locations:
-                if not get_holding_pid_by_document_location_item_type(
-                        new_record.pid, location_pid, item_type_pid
+                if not get_monograph_holding_pid_by_doc_location_item_type(
+                    new_record.pid, location_pid, item_type_pid
                 ):
                     create_holding(
                         document_pid=new_record.pid,

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -335,12 +335,15 @@ class Holding(IlsRecord):
         return text
 
 
-def get_holding_pid_by_document_location_item_type(
+def get_monograph_holding_pid_by_doc_location_item_type(
         document_pid, location_pid, item_type_pid):
-    """Returns holding pid for document/location/item type."""
+    """Returns monograph holding pid for document/location/item type."""
     result = HoldingsSearch().filter(
         'term',
         document__pid=document_pid
+    ).filter(
+        'term',
+        holdings_type='monograph'
     ).filter(
         'term',
         circulation_category__pid=item_type_pid

--- a/rero_ils/modules/items/api.py
+++ b/rero_ils/modules/items/api.py
@@ -267,15 +267,15 @@ class Item(IlsRecord):
         data['organisation'] = org_ref
 
     def item_link_to_holding(self):
-        """Link an item to a holding record."""
+        """Link an item to a monograph holding record."""
         from ..holdings.api import \
-            get_holding_pid_by_document_location_item_type, \
+            get_monograph_holding_pid_by_doc_location_item_type, \
             create_holding
 
         item = self.replace_refs()
         document_pid = item.get('document').get('pid')
 
-        holding_pid = get_holding_pid_by_document_location_item_type(
+        holding_pid = get_monograph_holding_pid_by_doc_location_item_type(
             document_pid, self.location_pid, self.item_type_pid)
 
         if not holding_pid:


### PR DESCRIPTION
When a librarian tries to create a new item on a document, the system
will not try to attach the item to a holding of type serial. if no
holding exists, will attempt to create a new monograph holding for
the new item.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1383?kanban-status=1224894

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
