### PR TITLE
project: improve test on dates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,7 @@ include docker/haproxy/Dockerfile
 include docker/nginx/Dockerfile
 include docker/postgres/Dockerfile
 include Dockerfile
+exclude scripts/all_year_days
 include scripts/bootstrap
 include scripts/console
 include scripts/dojson_virtua

--- a/scripts/all_year_days
+++ b/scripts/all_year_days
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Launch a command every day of current year
+#
+# Depends on: faketime (`apt install faketime` i.e.)
+#
+# EXAMPLE:
+# ./scripts/all_year_days pipenv run pytest -vvs --no-cov --disable-warnings tests/api/test_loans_rest.py
+#
+
+# variables
+launch_command="$@"
+
+# functions
+error+exit() {
+  echo -e "$1" && exit 1
+}
+
+# tests
+if [[ -z "${launch_command}" ]]; then
+  echo "No command given." && exit 1
+fi
+
+if [[ -z $(which faketime) ]]; then
+  echo "faketime command is missing! Please install libfaketime." && exit 1
+fi
+
+# initialization
+current_year=`date +"%Y"`
+# display all days of year (from current year)
+for i in {0..366}; do
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    date="$(date -j -v01m -v01d -v${current_year}y -v+${i}d '+%Y-%m-%d') 9:30:42"
+  else
+    date="$(date -u +"%Y-%m-%d" -d "${current_year}-01-01 +$i days") 9:30:42"
+  fi
+  # display choosen date
+  echo -e "#### CHOOSEN DATE: ${date} ####"
+  faketime "${date}" ${launch_command} \
+    || error+exit "'${launch_command}' FAILED this day: ${date}."
+done
+
+# end
+exit 0
+#vim: ts=2 sw=2 et nu

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -38,6 +38,9 @@ from rero_ils.modules.loans.utils import can_be_requested
 from rero_ils.modules.notifications.api import NotificationsSearch, \
     number_of_reminders_sent
 
+# Display current system time
+print("\n#### PYTHON KNOWN DATE: %s ####\n" % datetime.now())
+
 
 def test_loans_permissions(client, loan_pending_martigny, json_header):
     """Test record retrieval."""
@@ -177,9 +180,8 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
     checkout_loan = Loan.get_record_by_pid(loan_pid)
     loan_date = ciso8601.parse_datetime(checkout_loan.get('end_date'))
 
-    # should be 22:59 in UTC+0
-    tocheck_date = loan_date
-    assert tocheck_date.minute == 59 and tocheck_date.hour == 22
+    # as instance timezone is Europe/Zurich, it should be either 21 or 22
+    check_timezone_date(pytz.utc, loan_date, [21, 22])
 
     # should be 14:59/15:59 in US/Pacific (because of daylight saving time)
     check_timezone_date(pytz.timezone('US/Pacific'), loan_date, [14, 15])
@@ -511,4 +513,4 @@ It should be the same date, even if timezone changed."
     assert loan_datetime.month == lib_datetime.month, fail_msg
     assert loan_datetime.day == lib_datetime.day, fail_msg
     # Loan date differs regarding timezone, and day of the year (GMT+1/2).
-    check_timezone_date(pytz.utc, loan_datetime, [22, 23])
+    check_timezone_date(pytz.utc, loan_datetime, [21, 22])


### PR DESCRIPTION
The project uses circulation policy to process loan due date.
It uses timezone in UTC and then process date.
To check all is OK about dates, we create a script.
* Adds new `all_year_days` script
* tests test_loans_rest.py all day of current year

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

https://github.com/rero/rero-ils/commit/ca01c491519d225ffb1fd4471f2903e23b1bc782 resolve some timezone problem. But that's not the first time we encount problems with timezone.
As a result we need to check that all is OK for every year days.

This commit add a new `all_year_days` that permits to launch a command for every day of current year.

## How to test?

You need libfaketime (MacOS, ArchLinux) or faketime (Debian, Ubuntu) on your computer.

To check all is OK, you should do:

```bash
docker-compose up -d
./scripts/all_year_days pipenv run pytest -vvs --no-cov --disable-warnings tests/api/test_loans_rest.py
```

It takes approximatively 3 hours.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
