### PR TITLE
subscription: adds listener methods to create a subscription if needed

### DIFF
--- a/data/patron_types.json
+++ b/data/patron_types.json
@@ -6,7 +6,8 @@
     "description": "Standard patron.",
     "organisation": {
       "$ref": "https://ils.rero.ch/api/organisations/1"
-    }
+    },
+    "subscription_amount": 10
   },
   {
     "$schema": "https://ils.rero.ch/schema/patron_types/patron_type-v0.0.1.json",

--- a/rero_ils/modules/ext.py
+++ b/rero_ils/modules/ext.py
@@ -25,8 +25,7 @@ from flask_wiki import Wiki
 from invenio_circulation.signals import loan_state_changed
 from invenio_indexer.signals import before_record_index
 from invenio_oaiharvester.signals import oaiharvest_finished
-from invenio_records.signals import after_record_delete, after_record_insert, \
-    after_record_revert, after_record_update
+from invenio_records.signals import after_record_insert, after_record_update
 
 from .apiharvester.signals import apiharvest_part
 from .documents.listener import enrich_document_data
@@ -39,7 +38,8 @@ from .notifications.listener import enrich_notification_data
 from .patron_transaction_events.listener import \
     enrich_patron_transaction_event_data
 from .patron_transactions.listener import enrich_patron_transaction_data
-from .patrons.listener import enrich_patron_data
+from .patrons.listener import create_subscription_patron_transaction, \
+    enrich_patron_data
 from .persons.listener import enrich_persons_data
 from .persons.receivers import publish_api_harvested_records
 from ..filter import format_date_filter, jsondumps, text_to_id, to_pretty_json
@@ -101,6 +101,9 @@ class REROILSAPP(object):
         before_record_index.connect(enrich_notification_data)
         before_record_index.connect(enrich_patron_transaction_event_data)
         before_record_index.connect(enrich_patron_transaction_data)
+
+        after_record_insert.connect(create_subscription_patron_transaction)
+        after_record_update.connect(create_subscription_patron_transaction)
 
         loan_state_changed.connect(listener_loan_state_changed, weak=False)
 

--- a/rero_ils/modules/patron_transactions/api.py
+++ b/rero_ils/modules/patron_transactions/api.py
@@ -73,6 +73,37 @@ class PatronTransaction(IlsRecord):
             delete_pid=delete_pid, update_parent=False)
         return record
 
+    @classmethod
+    def _build_transaction_query(cls, patron_pid, status=None):
+        """Private function to build a transaction query linked to a patron."""
+        query = PatronTransactionsSearch() \
+            .filter('term', patron__pid=patron_pid)
+        if status:
+            query = query.filter('term', status=status)
+        return query
+
+    @classmethod
+    def get_transactions_pids_for_patron(cls, patron_pid, status=None):
+        """Get patron transactions linked to a patron.
+
+        :param patron_pid: the patron pid being searched
+        :param status: (optional) transaction status filter,
+        """
+        query = cls._build_transaction_query(patron_pid, status)
+        results = query.source('pid').scan()
+        for result in results:
+            yield result.pid
+
+    @classmethod
+    def get_transactions_count_for_patron(cls, patron_pid, status=None):
+        """Get patron transactions count linked to a patron.
+
+        :param patron_pid: the patron pid being searched
+        :param status: (optional) transaction status filter,
+        """
+        query = cls._build_transaction_query(patron_pid, status)
+        return query.source().count()
+
     @property
     def loan_pid(self):
         """Return the loan pid of the the overdue patron transaction."""

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -37,8 +37,7 @@ from ..minters import id_minter
 from ..organisations.api import Organisation
 from ..patron_transactions.api import PatronTransaction
 from ..providers import Provider
-from ..utils import get_ref_for_pid
-from ..utils import trim_barcode_for_record
+from ..utils import get_ref_for_pid, trim_barcode_for_record
 
 _datastore = LocalProxy(lambda: current_app.extensions['security'].datastore)
 
@@ -230,6 +229,10 @@ class Patron(IlsRecord):
         loans = self.get_number_of_loans()
         if loans:
             links['loans'] = loans
+        transactions = PatronTransaction.get_transactions_count_for_patron(
+            self.pid, status='open')
+        if transactions > 0:
+            links['transactions'] = transactions
         return links
 
     def reasons_to_keep(self):
@@ -347,7 +350,8 @@ class Patron(IlsRecord):
         subs = filter(is_subscription_valid, self.get('subscriptions', []))
         return list(subs)
 
-    def add_subscription(self, patron_type, start_date, end_date):
+    def add_subscription(self, patron_type, start_date, end_date,
+                         dbcommit=True, reindex=True, delete_pids=False):
         """Add a subscription to a patron type.
 
         :param patron_type: the patron_type linked to the subscription
@@ -356,7 +360,7 @@ class Patron(IlsRecord):
         """
         transaction = PatronTransaction.create_subscription_for_patron(
             self, patron_type, start_date, end_date,
-            dbcommit=True, reindex=True, delete_pid=True)
+            dbcommit=dbcommit, reindex=reindex, delete_pid=delete_pids)
         if transaction:
             subscriptions = self.get('subscriptions', [])
             subscriptions.append({
@@ -370,4 +374,4 @@ class Patron(IlsRecord):
                 'end_date': end_date.strftime('%Y-%m-%d'),
             })
             self['subscriptions'] = subscriptions
-            self.update(self, dbcommit=True, reindex=True)
+            self.update(self, dbcommit=dbcommit, reindex=reindex)

--- a/rero_ils/modules/patrons/listener.py
+++ b/rero_ils/modules/patrons/listener.py
@@ -17,7 +17,11 @@
 
 """Signals connector for patron."""
 
+from datetime import datetime
+
 from .api import Patron, PatronsSearch
+from ..patron_types.api import PatronType
+from ..utils import add_years, get_schema_for_resource
 
 
 def enrich_patron_data(sender, json=None, record=None, index=None,
@@ -38,3 +42,30 @@ def enrich_patron_data(sender, json=None, record=None, index=None,
             json['organisation'] = {
                 'pid': org_pid
             }
+
+
+def create_subscription_patron_transaction(sender, record=None, **kwargs):
+    """This method check the patron to know if a subscription is requested.
+
+    This method checks the patron_type linked to a patron and determine if
+    a new subscription patron transaction should be created or not. If a
+    subscriotion is needed, then the 'subscription' patron attribute will be
+    updated.
+    This method should be connect with 'before_record_insert' and
+    'before_record_update'.
+
+    :param record: the record being performed
+    """
+    if record.get('$schema') != get_schema_for_resource(Patron):
+        return
+    if record.patron_type_pid is None:
+        return
+    ptty = PatronType.get_record_by_pid(record.patron_type_pid)
+    if ptty.is_subscription_required and not record.has_valid_subscription:
+        # TODO : (2020-03-27)
+        #   At this time, subscription are only possible for one year. In
+        #   the future, the subscription period should be defined as a
+        #   patron_type attribute.
+        start_date = datetime.now()
+        end_date = add_years(start_date, 1)
+        record.add_subscription(ptty, start_date, end_date)

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -172,3 +172,24 @@ def trim_barcode_for_record(data=None):
     if data and data.get('barcode'):
         data['barcode'] = data.get('barcode').strip()
     return data
+
+
+def get_schema_for_resource(resource):
+    """Return the schema corresponding to a resources.
+
+    :param resource: Either the resource_type shortcut as a string,
+                     Either a resource class (subclass of IlsRecord
+
+    USAGE:
+      schema = get_schemas_for_resource('ptrn')
+      shcema = get_schemas_for_resource(Patron)
+    """
+    if not isinstance(resource, str):
+        resource = resource.provider.pid_type
+    schemas = current_app.config.get('RECORDS_JSON_SCHEMA')
+    if resource in schemas:
+        return '{url}{endpoint}{schema}'.format(
+            url=current_app.config.get('RERO_ILS_APP_BASE_URL'),
+            endpoint=current_app.config.get('JSONSCHEMAS_ENDPOINT'),
+            schema=schemas[resource]
+        )

--- a/tests/api/test_patron_transactions_rest.py
+++ b/tests/api/test_patron_transactions_rest.py
@@ -468,3 +468,16 @@ def test_patron_subscription_transaction(
     assert event.get('type') == 'fee'
     assert event.get('subtype') == 'other'
     assert event.get('amount') == subscription.get('total_amount')
+
+
+def test_get_transactions_pids_for_patron(patron_sion_no_email):
+    """Test function get_transactions_pids_for_patron."""
+    assert PatronTransaction.get_transactions_count_for_patron(
+        patron_sion_no_email.pid
+    ) == 2
+    assert len(list(PatronTransaction.get_transactions_pids_for_patron(
+        patron_sion_no_email.pid, status='open'
+    ))) == 2
+    assert len(list(PatronTransaction.get_transactions_pids_for_patron(
+        patron_sion_no_email.pid, status='closed'
+    ))) == 0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,13 @@ import pytest
 from pkg_resources import resource_string
 
 
+@pytest.fixture(scope='module')
+def create_app():
+    """Create test app."""
+    from invenio_app.factory import create_ui
+    return create_ui
+
+
 @pytest.fixture()
 def circ_policy_schema():
     """Patron Jsonschema for records."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,7 +20,9 @@
 import os
 from datetime import datetime
 
-from rero_ils.modules.utils import add_years, read_json_record
+from rero_ils.modules.patrons.api import Patron
+from rero_ils.modules.utils import add_years, get_schema_for_resource, \
+    read_json_record
 from rero_ils.utils import unique_list
 
 
@@ -54,3 +56,10 @@ def test_add_years():
     assert tow_years_later.month == 3 and tow_years_later.day == 1
     assert four_years_later.month == initial_date.month and \
         four_years_later.day == initial_date.day
+
+
+def test_get_schema_for_resources(app):
+    """Test get_schemas_for_resource function."""
+    json_schema = 'https://ils.rero.ch/schema/patrons/patron-v0.0.1.json'
+    assert get_schema_for_resource(Patron) == json_schema
+    assert get_schema_for_resource('ptrn') == json_schema


### PR DESCRIPTION
When a patron is create/updated, if the patron is linked to a patron type requiring a subscription,
we need to create a subscription transaction if the patron doesn't have any current one.
This is the purpose of this PR.

* Adds a listerner method for patron signals : after_record_create, after_record_update
* Adds unit tests

## How to test?

- Edit a patron_type to have one with a yearly subscription
- Create a new patron and assign it with this patron_type
- Check the patron fee tabs, you should see a new subscription fee

- Update this patron to assign it to a patron_type without subscription
- Update again this patron to re-assign it the patron_type with a subscription
- No new fee should be assign to the patron

- Search for a patron previously linked to the patron_type with subscription
- Edit this patron 
- Check this patron has now a subscription fee.


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
