### PR TITLE
indexer: fix delayed bulk indexing

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -227,7 +227,7 @@ CELERY_RESULT_BACKEND = 'redis://localhost:6379/2'
 #: Scheduled tasks configuration (aka cronjobs).
 CELERY_BEAT_SCHEDULE = {
     'indexer': {
-        'task': 'invenio_indexer.tasks.process_bulk_queue',
+        'task': 'rero_ils.modules.tasks.process_bulk_queue',
         'schedule': timedelta(minutes=5),
     },
     'accounts': {

--- a/rero_ils/modules/tasks.py
+++ b/rero_ils/modules/tasks.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Celery tasks to index records."""
+
+from celery import shared_task
+
+from .api import IlsRecordIndexer
+
+
+@shared_task(ignore_result=True)
+def process_bulk_queue(version_type=None, es_bulk_kwargs=None):
+    """Process bulk indexing queue.
+
+    :param str version_type: Elasticsearch version type.
+    :param dict es_bulk_kwargs: Passed to
+        :func:`elasticsearch:elasticsearch.helpers.bulk`.
+    Note: You can start multiple versions of this task.
+    """
+    IlsRecordIndexer(version_type=version_type).process_bulk_queue(
+        es_bulk_kwargs=es_bulk_kwargs)
+
+
+@shared_task(ignore_result=True)
+def index_record(record_uuid):
+    """Index a single record.
+
+    :param record_uuid: The record UUID.
+    """
+    IlsRecordIndexer().index_by_id(record_uuid)
+
+
+@shared_task(ignore_result=True)
+def delete_record(record_uuid):
+    """Delete a single record.
+
+    :param record_uuid: The record UUID.
+    """
+    IlsRecordIndexer().delete_by_id(record_uuid)

--- a/setup.py
+++ b/setup.py
@@ -264,9 +264,10 @@ setup(
             'base-record = rero_ils.es_templates:list_es_templates'
         ],
         'invenio_celery.tasks': [
-            'rero_ils_oaiharvest = rero_ils.modules.ebooks.tasks',
-            'rero_ils_mefharvest = rero_ils.modules.apiharvester.tasks',
-            'rero_ils_notifications = rero_ils.modules.notifications.tasks',
+            'ebooks = rero_ils.modules.ebooks.tasks',
+            'apiharvester = rero_ils.modules.apiharvester.tasks',
+            'notifications = rero_ils.modules.notifications.tasks',
+            'modules = rero_ils.modules.tasks'
         ],
         'invenio_records.jsonresolver': [
             'organisations = rero_ils.modules.organisations.jsonresolver',


### PR DESCRIPTION
## Why are you opening this PR?

- scheduled indexing task was not using the right indexer class

## How to test?

- `pipenv run invenio utils reindex -t doc` and start task `rero_ils.modules.task.process_bulk_queue` from console. Verify the documents were indext correctly.
- repeat with `process_bulk_queue.delay()`. A beat worker must be running for this.
- See if the scheduled task `indexer` runs correctly 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
