### PR TITLE
permissions: update permission API and configuration

### DIFF
--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -51,9 +51,9 @@ from .modules.acq_invoices.api import AcquisitionInvoice
 from .modules.acq_order_lines.api import AcqOrderLine, AcqOrderLinesIndexer
 from .modules.acq_orders.api import AcqOrder
 from .modules.budgets.api import Budget
-from .modules.budgets.permissions import can_create_budgets_factory, \
-    can_list_budgets_factory, can_update_delete_budgets_factory
+from .modules.budgets.permissions import can_list_budgets_factory
 from .modules.circ_policies.api import CircPolicy
+from .modules.circ_policies.permissions import can_update_circ_policy_factory
 from .modules.documents.api import Document, DocumentsIndexer
 from .modules.holdings.api import Holding, HoldingsIndexer
 from .modules.item_types.api import ItemType
@@ -61,8 +61,7 @@ from .modules.items.api import Item, ItemsIndexer
 from .modules.items.permissions import can_create_item_factory, \
     can_update_delete_item_factory
 from .modules.libraries.api import Library
-from .modules.libraries.permissions import can_create_library_factory, \
-    can_delete_library_factory, can_update_library_factory
+from .modules.libraries.permissions import can_update_library_factory
 from .modules.loans.api import Loan
 from .modules.loans.permissions import can_list_loan_factory, \
     can_read_loan_factory
@@ -76,7 +75,6 @@ from .modules.locations.permissions import can_create_location_factory, \
     can_update_delete_location_factory
 from .modules.notifications.api import Notification
 from .modules.organisations.api import Organisation
-from .modules.organisations.permissions import can_update_organisations_factory
 from .modules.patron_transaction_events.api import PatronTransactionEvent
 from .modules.patron_transaction_events.permissions import can_list_patron_transaction_event_factory, \
     can_read_patron_transaction_event_factory
@@ -95,6 +93,7 @@ from .permissions import can_access_organisation_patrons_factory, \
     can_delete_organisation_records_factory, can_list_acquisition_factory, \
     can_read_update_delete_acquisition_factory, \
     can_update_organisation_records_factory, \
+    is_system_librarian_organisation_record_factory, \
     librarian_delete_permission_factory, librarian_permission_factory, \
     librarian_update_permission_factory, wiki_edit_ui_permission, \
     wiki_edit_view_permission
@@ -408,7 +407,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='rero_ils.query:document_search_factory',
         read_permission_factory_imp=allow_all,
         list_permission_factory_imp=allow_all,
-        update_permission_factory_imp=librarian_update_permission_factory
+        update_permission_factory_imp=librarian_update_permission_factory,
+        delete_permission_factory_imp=librarian_update_permission_factory
     ),
     item=dict(
         pid_type='item',
@@ -471,9 +471,9 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         read_permission_factory_imp=can_access_organisation_records_factory,
-        create_permission_factory_imp=can_create_organisation_records_factory,
-        update_permission_factory_imp=can_update_organisation_records_factory,
-        delete_permission_factory_imp=can_delete_organisation_records_factory,
+        create_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        update_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        delete_permission_factory_imp=is_system_librarian_organisation_record_factory,
     ),
     hold=dict(
         pid_type='hold',
@@ -635,9 +635,9 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         read_permission_factory_imp=can_access_organisation_records_factory,
-        create_permission_factory_imp=can_create_organisation_records_factory,
-        update_permission_factory_imp=can_update_organisation_records_factory,
-        delete_permission_factory_imp=can_create_organisation_records_factory,
+        create_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        update_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        delete_permission_factory_imp=is_system_librarian_organisation_record_factory,
     ),
     org=dict(
         pid_type='org',
@@ -668,7 +668,7 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='rero_ils.query:organisation_organisation_search_factory',
         list_permission_factory_imp=can_access_organisation_patrons_factory,
         create_permission_factory_imp=deny_all,
-        update_permission_factory_imp=can_update_organisations_factory,
+        update_permission_factory_imp=deny_all,
         delete_permission_factory_imp=deny_all,
         read_permission_factory_imp=can_access_organisation_records_factory,
     ),
@@ -701,9 +701,9 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='rero_ils.query:organisation_search_factory',
         list_permission_factory_imp=can_access_organisation_patrons_factory,
         read_permission_factory_imp=can_access_organisation_records_factory,
-        create_permission_factory_imp=can_create_library_factory,
+        create_permission_factory_imp=is_system_librarian_organisation_record_factory,
         update_permission_factory_imp=can_update_library_factory,
-        delete_permission_factory_imp=can_delete_library_factory,
+        delete_permission_factory_imp=is_system_librarian_organisation_record_factory,
     ),
     loc=dict(
         pid_type='loc',
@@ -798,9 +798,9 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='rero_ils.query:organisation_search_factory',
         read_permission_factory_imp=can_access_organisation_records_factory,
-        create_permission_factory_imp=can_create_organisation_records_factory,
-        update_permission_factory_imp=can_update_organisation_records_factory,
-        delete_permission_factory_imp=can_delete_organisation_records_factory,
+        create_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        update_permission_factory_imp=can_update_circ_policy_factory,
+        delete_permission_factory_imp=is_system_librarian_organisation_record_factory,
     ),
     notif=dict(
         pid_type='notif',
@@ -932,9 +932,9 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='rero_ils.query:organisation_search_factory',
         read_permission_factory_imp=can_access_organisation_records_factory,
         list_permission_factory_imp=can_list_budgets_factory,
-        create_permission_factory_imp=can_create_budgets_factory,
-        update_permission_factory_imp=can_update_delete_budgets_factory,
-        delete_permission_factory_imp=can_update_delete_budgets_factory,
+        create_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        update_permission_factory_imp=is_system_librarian_organisation_record_factory,
+        delete_permission_factory_imp=is_system_librarian_organisation_record_factory,
     ),
     acor=dict(
         pid_type='acor',

--- a/rero_ils/modules/budgets/permissions.py
+++ b/rero_ils/modules/budgets/permissions.py
@@ -20,41 +20,6 @@
 from ...permissions import staffer_is_authenticated
 
 
-def can_update_delete_budgets_factory(record, *args, **kwargs):
-    """Checks if logged user can update or delete its organisation budgets.
-
-    user must have librarian or system_librarian role
-    librarian can not update nor delete its affiliated library budgets.
-    sys_librarian can update or delete any budgets of its organisation.
-    """
-    def can(self):
-        patron = staffer_is_authenticated()
-        if patron and patron.organisation_pid == record.organisation_pid:
-            if not patron.is_system_librarian:
-                return False
-            return True
-        return False
-    return type('Check', (), {'can': can})()
-
-
-def can_create_budgets_factory(record, *args, **kwargs):
-    """Checks if the logged user can create budgets of its organisation.
-
-    librarian may not create budgets for its organisation.
-    system_librarian can create budgets of its org.
-    system_librarian or librarian can not create budgets at another org.
-    """
-    def can(self):
-        if record is None:
-            return True
-        patron = staffer_is_authenticated()
-        if patron and patron.organisation_pid == record.organisation_pid:
-            if patron.is_system_librarian:
-                return True
-        return False
-    return type('Check', (), {'can': can})()
-
-
 def can_list_budgets_factory(record, *args, **kwargs):
     """Checks if the logged user have access to budget list.
 

--- a/rero_ils/modules/libraries/permissions.py
+++ b/rero_ils/modules/libraries/permissions.py
@@ -38,37 +38,3 @@ def can_update_library_factory(record, *args, **kwargs):
             return True
         return False
     return type('Check', (), {'can': can})()
-
-
-def can_delete_library_factory(record, *args, **kwargs):
-    """Checks if logged user can delete its organisation libraries.
-
-    librarian must have system_librarian role.
-    librarian can not delete any library.
-    sys_librarian can delete any library of its organisation only.
-    """
-    def can(self):
-        patron = staffer_is_authenticated()
-        if patron and patron.organisation_pid == record.organisation_pid:
-            if patron.is_system_librarian:
-                return True
-        return False
-    return type('Check', (), {'can': can})()
-
-
-def can_create_library_factory(record, *args, **kwargs):
-    """Checks if the logged user can create libraries of its organisation.
-
-    user must have a system_librarian role.
-    returns False if a librarian tries to create a library.
-    returns False if a system_librarian tries to create a library in other org.
-    """
-    def can(self):
-        patron = staffer_is_authenticated()
-        if patron and not record:
-            return True
-        if patron and patron.organisation_pid == record.organisation_pid:
-            if patron.is_system_librarian:
-                return True
-        return False
-    return type('Check', (), {'can': can})()

--- a/rero_ils/modules/permissions.py
+++ b/rero_ils/modules/permissions.py
@@ -35,17 +35,29 @@ def jsonify_permission_api_response(
 def record_update_delete_permissions(record_pid=None, route_name=None):
     """Return record permissions."""
     try:
-        rec_class, update_permission = \
+        rec_class, update_permission, delete_permission = \
             get_record_class_update_permission_from_route(route_name)
         record = rec_class.get_record_by_pid(record_pid)
 
         if not record:
             return jsonify({'status': 'error: Record not found.'}), 404
 
+        # We have two behavior for 'can_delete'. Either the record has linked
+        # resource and so children resources should be deleted before ; either
+        # the `delete_permissions_factory` for this record should be called. If
+        # this call send 'False' then the reason_not_to_delete should be
+        # "permission denied"
+        can_delete = record.can_delete and delete_permission(record).can()
+        reasons = record.reasons_not_to_delete()
+        if not can_delete and not reasons:
+            # in this case, it's because config delete factory return `False`
+            # So the reason is 'Permission denied'
+            reasons = {'others': {'permission': 'permission denied'}}
+
         return jsonify_permission_api_response(
             can_update=update_permission(record).can(),
-            can_delete=record.can_delete,
-            reasons=record.reasons_not_to_delete(),
+            can_delete=can_delete,
+            reasons=reasons
         )
     except Exception as error:
         return jsonify({'status': 'error: Bad request'}), 400

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -119,7 +119,9 @@ def get_record_class_update_permission_from_route(route_name):
             record_class = obj_or_import_string(record.get('record_class'))
             update_permission = obj_or_import_string(
                 record.get('update_permission_factory_imp'))
-            return record_class, update_permission
+            delete_permission = obj_or_import_string(
+                record.get('delete_permission_factory_imp'))
+            return record_class, update_permission, delete_permission
 
 
 def get_ref_for_pid(module, pid):

--- a/tests/api/test_circ_policies_rest.py
+++ b/tests/api/test_circ_policies_rest.py
@@ -237,12 +237,12 @@ def test_circ_policy_secure_api(client, json_header,
 
 def test_circ_policy_secure_api_create(client, json_header,
                                        circ_policy_default_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       system_librarian_martigny_no_email,
+                                       system_librarian_sion_no_email,
                                        circ_policy_default_martigny_data):
     """Test circulation policies secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     post_entrypoint = 'invenio_records_rest.cipo_list'
 
     del circ_policy_default_martigny_data['pid']
@@ -254,7 +254,7 @@ def test_circ_policy_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res, _ = postdata(
         client,
@@ -266,13 +266,17 @@ def test_circ_policy_secure_api_create(client, json_header,
 
 def test_circ_policy_secure_api_update(client,
                                        circ_policy_short_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
                                        circ_policy_short_martigny_data,
+                                       circ_policy_temp_martigny,
+                                       circ_policy_temp_martigny_data,
+                                       system_librarian_martigny_no_email,
+                                       system_librarian_sion_no_email,
+                                       librarian_martigny_no_email,
+                                       librarian_saxon_no_email,
                                        json_header):
     """Test circulation policies secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_short_martigny.pid)
 
@@ -286,7 +290,7 @@ def test_circ_policy_secure_api_update(client,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res = client.put(
         record_url,
@@ -295,24 +299,41 @@ def test_circ_policy_secure_api_update(client,
     )
     assert res.status_code == 403
 
+    # special case : cipo at library_level
+    record_url = url_for('invenio_records_rest.cipo_item',
+                         pid_value=circ_policy_temp_martigny.pid)
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(circ_policy_temp_martigny_data),
+        headers=json_header
+    )
+    assert res.status_code == 200
+    login_user_via_session(client, librarian_saxon_no_email.user)
+    res = client.put(
+        record_url,
+        data=json.dumps(circ_policy_temp_martigny_data),
+        headers=json_header
+    )
+    assert res.status_code == 403
+
 
 def test_circ_policy_secure_api_delete(client,
                                        circ_policy_short_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       system_librarian_martigny_no_email,
+                                       system_librarian_sion_no_email,
                                        circ_policy_short_martigny_data,
                                        json_header):
     """Test circulation policies secure api delete."""
-    # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
     record_url = url_for('invenio_records_rest.cipo_item',
                          pid_value=circ_policy_short_martigny.pid)
 
+    # Martigny
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     res = client.delete(record_url)
     assert res.status_code == 204
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
-
+    login_user_via_session(client, system_librarian_sion_no_email.user)
     res = client.delete(record_url)
     assert res.status_code == 410

--- a/tests/api/test_item_types_rest.py
+++ b/tests/api/test_item_types_rest.py
@@ -243,12 +243,12 @@ def test_item_type_secure_api(client, json_header,
 
 def test_item_type_secure_api_create(client, json_header,
                                      item_type_standard_martigny,
-                                     librarian_martigny_no_email,
-                                     librarian_sion_no_email,
+                                     system_librarian_martigny_no_email,
+                                     system_librarian_sion_no_email,
                                      item_type_standard_martigny_data):
     """Test item type secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     post_entrypoint = 'invenio_records_rest.itty_list'
 
     del item_type_standard_martigny_data['pid']
@@ -260,7 +260,7 @@ def test_item_type_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res, _ = postdata(
         client,
@@ -272,13 +272,13 @@ def test_item_type_secure_api_create(client, json_header,
 
 def test_item_type_secure_api_update(client,
                                      item_type_on_site_martigny,
-                                     librarian_martigny_no_email,
-                                     librarian_sion_no_email,
+                                     system_librarian_martigny_no_email,
+                                     system_librarian_sion_no_email,
                                      item_type_on_site_martigny_data,
                                      json_header):
     """Test item type secure api update."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     record_url = url_for('invenio_records_rest.itty_item',
                          pid_value=item_type_on_site_martigny.pid)
 
@@ -292,7 +292,7 @@ def test_item_type_secure_api_update(client,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res = client.put(
         record_url,
@@ -304,13 +304,13 @@ def test_item_type_secure_api_update(client,
 
 def test_item_type_secure_api_delete(client,
                                      item_type_on_site_martigny,
-                                     librarian_martigny_no_email,
-                                     librarian_sion_no_email,
+                                     system_librarian_martigny_no_email,
+                                     system_librarian_sion_no_email,
                                      item_type_on_site_martigny_data,
                                      json_header):
     """Test item type secure api delete."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     record_url = url_for('invenio_records_rest.itty_item',
                          pid_value=item_type_on_site_martigny.pid)
 
@@ -319,7 +319,7 @@ def test_item_type_secure_api_delete(client,
         assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403

--- a/tests/api/test_organisations_rest_api.py
+++ b/tests/api/test_organisations_rest_api.py
@@ -19,9 +19,28 @@
 
 import json
 
+import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import postdata
+
+from rero_ils.modules.organisations.api import Organisation
+
+
+def test_get_record_by_viewcode(org_martigny):
+    """Test Organisation.get_record_by_viewcode."""
+    data = Organisation.get_record_by_viewcode('org1')
+    assert data['pid'] == org_martigny.pid
+    with pytest.raises(Exception):
+        assert Organisation.get_record_by_viewcode('dummy')
+
+
+def test_get_record_by_online_harvested_source(org_martigny):
+    """Test get_record_by_online_harvested_source."""
+    source = org_martigny.get('online_harvested_source')
+    org = Organisation.get_record_by_online_harvested_source(source)
+    assert org.pid == org_martigny.pid
+    assert Organisation.get_record_by_online_harvested_source('dummy') is None
 
 
 def test_organisation_secure_api_update(client, json_header, org_martigny,
@@ -41,7 +60,7 @@ def test_organisation_secure_api_update(client, json_header, org_martigny,
         data=json.dumps(data),
         headers=json_header
     )
-    assert res.status_code == 200
+    assert res.status_code == 403
 
     login_user_via_session(client, librarian_martigny_no_email.user)
     data['name'] = 'New Name 2'

--- a/tests/api/test_patron_types_rest.py
+++ b/tests/api/test_patron_types_rest.py
@@ -244,12 +244,12 @@ def test_patron_type_secure_api(client, json_header,
 
 def test_patron_type_secure_api_create(client, json_header,
                                        patron_type_children_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       system_librarian_martigny_no_email,
+                                       system_librarian_sion_no_email,
                                        patron_type_children_martigny_data):
     """Test patron type secure api create."""
     # Martigny
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     post_entrypoint = 'invenio_records_rest.ptty_list'
 
     del patron_type_children_martigny_data['pid']
@@ -261,7 +261,7 @@ def test_patron_type_secure_api_create(client, json_header,
     assert res.status_code == 201
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res, _ = postdata(
         client,
@@ -273,11 +273,11 @@ def test_patron_type_secure_api_create(client, json_header,
 
 def test_patron_type_secure_api_update(client, json_header,
                                        patron_type_adults_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       system_librarian_martigny_no_email,
+                                       system_librarian_sion_no_email,
                                        patron_type_adults_martigny_data):
     """Test patron type secure api create."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     record_url = url_for('invenio_records_rest.ptty_item',
                          pid_value=patron_type_adults_martigny.pid)
 
@@ -291,7 +291,7 @@ def test_patron_type_secure_api_update(client, json_header,
     assert res.status_code == 200
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res = client.put(
         record_url,
@@ -303,11 +303,11 @@ def test_patron_type_secure_api_update(client, json_header,
 
 def test_patron_type_secure_api_delete(client, json_header,
                                        patron_type_adults_martigny,
-                                       librarian_martigny_no_email,
-                                       librarian_sion_no_email,
+                                       system_librarian_martigny_no_email,
+                                       system_librarian_sion_no_email,
                                        patron_type_adults_martigny_data):
     """Test patron type secure api delete."""
-    login_user_via_session(client, librarian_martigny_no_email.user)
+    login_user_via_session(client, system_librarian_martigny_no_email.user)
     record_url = url_for('invenio_records_rest.ptty_item',
                          pid_value=patron_type_adults_martigny.pid)
 
@@ -316,7 +316,7 @@ def test_patron_type_secure_api_delete(client, json_header,
         assert res.status_code == 204
 
     # Sion
-    login_user_via_session(client, librarian_sion_no_email.user)
+    login_user_via_session(client, system_librarian_sion_no_email.user)
 
     res = client.delete(record_url)
     assert res.status_code == 403

--- a/tests/api/test_permissions_librarian.py
+++ b/tests/api/test_permissions_librarian.py
@@ -22,8 +22,22 @@ from copy import deepcopy
 
 import mock
 from flask import url_for
+from invenio_access import Permission
 from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
+
+from rero_ils.permissions import librarian_delete_permission_factory, \
+    user_has_roles
+
+
+def test_librarian_delete_permission_factory(
+        client, librarian_fully_no_email, org_martigny, lib_martigny):
+    """Test librarian_delete_permission_factory """
+    login_user_via_session(client, librarian_fully_no_email.user)
+    assert type(
+        librarian_delete_permission_factory(None, credentials_only=True)
+    ) == Permission
+    assert librarian_delete_permission_factory(org_martigny) is not None
 
 
 def test_librarian_permissions(
@@ -168,3 +182,17 @@ def test_librarian_permissions(
 
     res = client.delete(record_url)
     assert res.status_code == 403
+
+
+def test_user_has_roles(system_librarian_martigny_no_email,
+                        librarian_martigny_no_email):
+    """Test if user has roles permissions."""
+    assert user_has_roles(system_librarian_martigny_no_email.user,
+                          roles=['system_librarian', 'librarian'],
+                          condition='and')
+    assert user_has_roles(librarian_martigny_no_email.user,
+                          roles=['system_librarian', 'librarian'],
+                          condition='or')
+    assert user_has_roles(librarian_martigny_no_email.user,
+                          roles=['system_librarian', 'librarian'],
+                          condition='and') is False

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -25,7 +25,7 @@ from utils import get_json
 
 def test_document_permissions(
         client, document, librarian_martigny_no_email,
-        patron_martigny_no_email, ebook_1):
+        patron_martigny_no_email, ebook_1, circ_policy_short_martigny):
     """Test document permissions."""
     # failed: invlaid document pid is given
     res = client.get(
@@ -94,3 +94,17 @@ def test_document_permissions(
         )
     )
     assert res.status_code == 400
+
+    # failed: permission denied
+    res = client.get(
+        url_for(
+            'api_blueprint.permissions',
+            route_name='circ_policies',
+            record_pid=circ_policy_short_martigny.pid
+        )
+    )
+    data = get_json(res)
+    assert res.status_code == 200
+    assert data.get('delete', {}).get('can') is False
+    reasons = data.get('delete', {}).get('reasons', {})
+    assert 'others' in reasons and 'permission' in reasons['others']


### PR DESCRIPTION
Some ressource permissions defined into the main ReroILS configuration file wasn't correct.
Some resources (circulation policy, patron type, item type, budget, ...) should only be created by
'system_librarian` user. This PR fix this problem

The permission API are updated to take care of main configuration for 'can_delete' permission.
The permission API only checked if the record is linked to other resources (children). If not, despite
the main configuration, it return True. Now, if a ressource has no linked resources, then the API
check also if user has the permission to delete the record.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Login as Astrid (system_librarian)
- check `~/api/permissions/circ_policies/1`
- You should "can_update" but cannot "can_delete" (due to children)
- Create an new CIPO
- check `~/api/permissions/circ_policies/[NEW_ID]`
- You should "can_update" and "can_delete"

- Login as Jean (librarian)
- check `~/api/permissions/circ_policies/[NEW_ID]`
- You shouldn't "can_update" and "can_delete" (permission)

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [x] Extracted translations?
