### PR TITLE
patron: add blocking functionnality

### DIFF
--- a/data/loans.json
+++ b/data/loans.json
@@ -62,7 +62,8 @@
     },
     "requests": {
       "requests": 1
-    }
+    },
+    "blocked": "Lost card"
   },
   {
     "barcode": "2030124287",
@@ -104,7 +105,8 @@
       "rank_1": 1,
       "rank_2": 1,
       "requests": 2
-    }
+    },
+    "blocked": "Another reason to block someone."
   },
   {
     "barcode": "3050124312",

--- a/data/users.json
+++ b/data/users.json
@@ -73,7 +73,9 @@
     "postal_code": "11100",
     "street": "Via Croix Noire 3",
     "communication_channel": "email",
-    "communication_language": "ita"
+    "communication_language": "ita",
+    "blocked": false,
+    "blocked_note": "Test functionnality when active is false"
   },
   {
     "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",

--- a/rero_ils/modules/items/api_views.py
+++ b/rero_ils/modules/items/api_views.py
@@ -104,6 +104,13 @@ def jsonify_action(func):
                 'action_applied': action_applied
             })
         except CirculationException as error:
+            patron = False
+            # Detect patron details
+            if data.get('patron_pid'):
+                patron = Patron.get_record_by_pid(data.get('patron_pid'))
+            # Add more info in case of blocked patron (for UI)
+            if patron and patron.get('blocked', {}) is True:
+                abort(403, "BLOCKED USER")
             abort(403)
         except NotFound as error:
             raise(error)

--- a/rero_ils/modules/loans/utils.py
+++ b/rero_ils/modules/loans/utils.py
@@ -35,11 +35,20 @@ def get_circ_policy(loan):
     patron = Patron.get_record_by_pid(loan.get('patron_pid'))
     patron_type_pid = patron.patron_type_pid
 
-    return CircPolicy.provide_circ_policy(
+    result = CircPolicy.provide_circ_policy(
         library_pid,
         patron_type_pid,
         holding_circulation_category
     )
+
+    # checkouts and request are not allowed anymore for blocked patrons
+    if patron.get('blocked', False):
+        result.update({
+            "allow_checkout": False,
+            "allow_requests": False,
+        })
+
+    return result
 
 
 def get_default_loan_duration(loan):

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -18,7 +18,9 @@
     "patron_type",
     "communication_channel",
     "communication_language",
-    "library"
+    "library",
+    "blocked",
+    "blocked_note"
   ],
   "required": [
     "$schema",
@@ -332,6 +334,22 @@
               }
             }
           }
+        }
+      }
+    },
+    "blocked": {
+      "title": "Blocking",
+      "description": "A patron with a blocked account cannot request and borrow items, but can still renew and check in items.",
+      "type": "boolean"
+    },
+    "blocked_note": {
+      "title": "Reason",
+      "type": "string",
+      "description": "The reason is displayed in the circulation module and is visible by the patron in his account.",
+      "form": {
+        "hideExpression": "field.model.blocked !== true",
+        "expressionProperties": {
+          "templateOptions.required": "model.blocked === true"
         }
       }
     }

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -89,8 +89,8 @@
   </article>
 </article>
 
-
 {%- endblock body %}
+
 {% macro build_table(type, loans) %}
 <div class="table-responsive">
   <table class="table table-striped table-sm">

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -148,6 +148,14 @@ def profile(viewcode):
             ),
             'level': 'warning'  # bootstrap alert level
         }
+    if patron.get('blocked'):
+        alerts['blocking'] = {
+            'messages': [
+                _('Your account is currently blocked. Reason: %(reason)s',
+                    reason=patron.get('blocked_note', ''))
+            ],
+            'level': 'danger'
+        }
 
     return render_template(
         'rero_ils/patron_profile.html',

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -6764,7 +6764,7 @@ msgid "Address of the library."
 msgstr "عنوان المكتبة"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7145,7 +7145,7 @@ msgid "Patron transaction type"
 msgstr "تصنيف معاملة المستخدم "
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "المستخدم"
 
@@ -7240,77 +7240,77 @@ msgstr "مستخدم"
 msgid "JSON schema for a user."
 msgstr "مخطط JSON للمستخدم"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "مخطط لتدقيق تسجيلات المستخدمين"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "ID المستخدم"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "الإسم الأول"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "إسم العائلة"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "تاريخ الميلاد"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "مثال: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "الشارع"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "الشارع ورقم العنوان. ينفصلان بفصلة."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "رقم البريد"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "المدينة"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "رقم الهاتف"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "رقم الهاتف مع البادئة الدولية ، دون مسافات"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "مثال: 41791231212+ "
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "تصنيف المستخدم"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "تصنيف المستخدم لسياسة الإعارة "
 
@@ -7319,52 +7319,52 @@ msgstr "تصنيف المستخدم لسياسة الإعارة "
 msgid "Patron Type URI"
 msgstr "URI ل تصنيف مستخدم"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "الرقم الممغنط او رقم البطاقة للمستخدم"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "الرقم الممغنط محجوز"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "توابع المكتبة"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "مهمة"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "تحديد مهام المستخدم"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "امين المكتبة"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "اخصائي المكتبة"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "وسيلة اتصال"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "البريد الالكتروني"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "البريد"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "لغة الاتصال"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "الانجليزية"
@@ -7395,6 +7395,26 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -6801,7 +6801,7 @@ msgid "Address of the library."
 msgstr "Bibliotheksaddresse."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7186,7 +7186,7 @@ msgid "Patron transaction type"
 msgstr "Leser Transaktion Typ"
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "Leser"
 
@@ -7285,77 +7285,77 @@ msgstr "Benutzer"
 msgid "JSON schema for a user."
 msgstr "JSON Schema für einen Benutzer"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "Schema zur Validierung von Benutzern."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "ID des Benutzers"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "Vorname"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "Nachname"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Beispiel: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "Strasse"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "Strasse und Hausnummer, getrennt durch ein Koma."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "Stadt"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Telefonnummer mit internationaler Anzeige, ohne Leerzeichen."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "Beispiel: +41791231212"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "Lesertyp"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "Lesertyp in Bezug auf Ausleihpolitik."
 
@@ -7364,52 +7364,52 @@ msgstr "Lesertyp in Bezug auf Ausleihpolitik."
 msgid "Patron Type URI"
 msgstr "URI des Lesertypen"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "Lesers Barcode oder Kartennummer"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "Der Barcode ist bereits vergeben."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "Bibliothekzugehörigkeit"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "Rolle"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "Die Rollen des Benutzers definieren."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "Bibliothekar"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "Systembibliothekar"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "Kommunikationskanal"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "E-Mail"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "Post"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "Kommunikationssprache"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "Englisch"
@@ -7441,6 +7441,26 @@ msgstr "Das Enddatum des Abonnements (ausgewähltes Datum ausgeschlossen)."
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
 msgstr "Leser-Transaktion"
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
+msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29
 msgid "Phone"

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -6775,7 +6775,7 @@ msgid "Address of the library."
 msgstr "Address of the library."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7158,7 +7158,7 @@ msgid "Patron transaction type"
 msgstr "Type of fee"
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "Patron"
 
@@ -7253,77 +7253,77 @@ msgstr "user"
 msgid "JSON schema for a user."
 msgstr "JSON schema for a user."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "Schema to validate user records against."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "User ID"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "First name"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "Last name"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "Date of birth"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Example: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "Street"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "Street and number of the address, separated by a coma."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "Postal code"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "City"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "Phone number"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Phone number with the international prefix, without spaces."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "Example: +41791231212"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "Patron Type"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "Patron type in terms of circulation policy."
 
@@ -7332,52 +7332,52 @@ msgstr "Patron type in terms of circulation policy."
 msgid "Patron Type URI"
 msgstr "Patron Type URI"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "Patron's barcode or card number"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "The barcode is already taken."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "Library affiliation."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "Role"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "Define the roles of the user."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "Librarian"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "System librarian"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "Communication channel"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "email"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "mail"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "Communication language"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "English"
@@ -7408,6 +7408,26 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -6780,7 +6780,7 @@ msgid "Address of the library."
 msgstr "Dirección de la biblioteca."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7163,7 +7163,7 @@ msgid "Patron transaction type"
 msgstr ""
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "Usuario"
 
@@ -7258,77 +7258,77 @@ msgstr "usuario"
 msgid "JSON schema for a user."
 msgstr "Esquema JSON para un usuario"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "Esquema para validar los usuarios."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "ID del usuario"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "Nombre"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "Apellido"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "Fecha de nacimiento"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Ejemplo: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "Calle"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "Calle y número de la dirección, separados por un coma."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "Código postal"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "Ciudad"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "Número de teléfono."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Número de teléfono con el prefijo internacional, sin espacios."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "Ejemplo: +41791231212"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "Tipo de usuario"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "Tipo de usuario en términos de política de circulación."
 
@@ -7337,52 +7337,52 @@ msgstr "Tipo de usuario en términos de política de circulación."
 msgid "Patron Type URI"
 msgstr "URI del tipo de usuario"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "Código de barras o número de tarjeta del usuario"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "El código de barras está utilisado."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "Biblioteca afiliada"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "Función"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "Define las funciones del usuario."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "Bibliotecario"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "Bibliotecario del sistema"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "Canal de comunicación"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "correo electrónico"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "correo"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "Idioma para comunicar"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "Inglés"
@@ -7413,6 +7413,26 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -6788,7 +6788,7 @@ msgid "Address of the library."
 msgstr "Adresse de la bibliothèque."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7171,7 +7171,7 @@ msgid "Patron transaction type"
 msgstr ""
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "Lecteur"
 
@@ -7266,77 +7266,77 @@ msgstr "utilisateur"
 msgid "JSON schema for a user."
 msgstr "Schéma JSON d'un utilisateur."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "Schéma de validation des utilisateurs."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "ID de l'utilisateur"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "Prénom"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "Nom de famille"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "Date de naissance"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Exemple: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "Rue"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "Rue et n° de l'adresse, séparés par une virgule."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "Code postal"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "Ville"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Numéro de téléphone avec l'indicatif international, sans espaces."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "Exemple: +41791231212"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "Type de lecteur"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "Type de lecteur en termes de politique de circulation."
 
@@ -7345,52 +7345,52 @@ msgstr "Type de lecteur en termes de politique de circulation."
 msgid "Patron Type URI"
 msgstr "URI du type de lecteur"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "Code-barres ou numéro de carte du lecteur"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "Le code-barres est déjà utilisé."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "Bibliothèque d'affiliation."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "Rôle"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "Définir les rôles de l'utilisateur."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "bibliothécaire"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "bibliothécaire système"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "Canal de communication"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "e-mail"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "poste"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "Langue de communication"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "Anglais"
@@ -7421,6 +7421,26 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -6786,7 +6786,7 @@ msgid "Address of the library."
 msgstr "Indirizzo della biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7169,7 +7169,7 @@ msgid "Patron transaction type"
 msgstr ""
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "Lettore"
 
@@ -7264,77 +7264,77 @@ msgstr "utente"
 msgid "JSON schema for a user."
 msgstr "JSON schema per un utente"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "Schema di convalida per utenti"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "ID dell'utente"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "Nome"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "Cognome"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Esempio: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "Via"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "Via e numero dell'indirizzo, separati da una virgola."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "Codice postale"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "Città"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "Numero di telefono"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Numero di telefono con l'indicazione internazionale, senza spazi."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "Esempio: +41791231212"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "Tipo di lettore"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "Tipo di lettore in termini di politica di prestito."
 
@@ -7343,52 +7343,52 @@ msgstr "Tipo di lettore in termini di politica di prestito."
 msgid "Patron Type URI"
 msgstr "URI del tipo di lettore"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "Numero di codice a barre o di tessera del lettore"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "Il codice a barre è già utilizzato."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "Biblioteca di affiliazione"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "Ruolo"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "Definire i ruoli dell'utente."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "Bibliotecario/a"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "Bibliotecario/a del sistema"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "Canali di comunicazione"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "e-mail"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "posta"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "Lingua di comunicazione"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "Inglese"
@@ -7419,6 +7419,26 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -6748,7 +6748,7 @@ msgid "Address of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7129,7 +7129,7 @@ msgid "Patron transaction type"
 msgstr ""
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr ""
 
@@ -7224,77 +7224,77 @@ msgstr ""
 msgid "JSON schema for a user."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr ""
 
@@ -7303,52 +7303,52 @@ msgstr ""
 msgid "Patron Type URI"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr ""
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr ""
@@ -7379,6 +7379,24 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -6781,7 +6781,7 @@ msgid "Address of the library."
 msgstr "Adres van de bibliotheek."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:55
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:72
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
@@ -7166,7 +7166,7 @@ msgid "Patron transaction type"
 msgstr ""
 
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:62
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:206
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:208
 msgid "Patron"
 msgstr "Lezer"
 
@@ -7261,77 +7261,77 @@ msgstr "Lezer"
 msgid "JSON schema for a user."
 msgstr "JSON schema voor een gebruiker."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:35
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:37
 msgid "Schema to validate user records against."
 msgstr "Schema om records van de gebruiker tegen te valideren."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:41
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:43
 msgid "User ID"
 msgstr "Gebruiker ID"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:45
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:47
 msgid "First name"
 msgstr "Voornaam"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:53
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:55
 msgid "Last name"
 msgstr "Achternaam"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:58
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:60
 msgid "Date of birth"
 msgstr "Geboortedatum"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:68
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Voorbeeld: 1985-12-29"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:86
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:124
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:185
 msgid "Street"
 msgstr "Straat"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:87
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:125
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:186
 msgid "Street and number of the address, separated by a coma."
 msgstr "Straat en nummer van het adres, gescheiden door een coma."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:92
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:94
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:130
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:191
 msgid "Postal code"
 msgstr "Postcode"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:97
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:99
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
 msgid "City"
 msgstr "Stad"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:102
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:104
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number"
 msgstr "Telefoonnummer"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:103
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:105
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Telefoonnummer met internationaal kengetal, zonder spaties."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:114
 msgid "Example: +41791231212"
 msgstr "Voorbeeld: +41791231212"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:116
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
 msgid "Patron Type"
 msgstr "Lezerstype"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:117
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:119
 msgid "Patron type in terms of circulation policy."
 msgstr "Lezerstype in termen van circulatiebeleid."
 
@@ -7340,52 +7340,52 @@ msgstr "Lezerstype in termen van circulatiebeleid."
 msgid "Patron Type URI"
 msgstr "Lezerstype URI"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:142
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:144
 msgid "Patron's barcode or card number"
 msgstr "Barcode of kaartnummer van de lezer"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:155
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:157
 msgid "The barcode is already taken."
 msgstr "De barcode is al bezet."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:162
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
 msgid "Library affiliation."
 msgstr "Bibliotheek aansluiting."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:187
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:189
 msgid "Role"
 msgstr "Rol"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:188
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:190
 msgid "Define the roles of the user."
 msgstr "Definieer de rol van de gebruiker."
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:210
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:212
 msgid "Librarian"
 msgstr "Bibliothecaris"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:214
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:216
 msgid "System Librarian"
 msgstr "System librarian"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:222
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:224
 msgid "Communication channel"
 msgstr "Communicatiekanaal"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:231
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:233
 msgid "email"
 msgstr "email"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:235
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:237
 msgid "mail"
 msgstr "mail"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:246
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:248
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:67
 msgid "Communication language"
 msgstr "Communicatietaal"
 
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:261
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:263
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:84
 msgid "English"
 msgstr "Engels"
@@ -7416,6 +7416,26 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:322
 msgid "Patron transaction"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:282
+msgid "Blocking"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:283
+msgid ""
+"A patron with a blocked account cannot request and borrow items, but can "
+"still renew and check in items."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:287
+msgid "Reason"
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:289
+msgid ""
+"The reason is displayed in the circulation module and is visible by the "
+"patron in his account."
 msgstr ""
 
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:29

--- a/tests/api/test_patrons_blocked.py
+++ b/tests/api/test_patrons_blocked.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST API patrons."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from utils import get_json
+
+
+def test_blocked_field_exists(
+        client,
+        librarian_martigny_no_email,
+        patron_martigny_no_email,
+        patron3_martigny_no_email):
+    """Test ptrn6 have blocked field present and set to False."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+
+    # non blocked patron
+    non_blocked_patron_url = url_for(
+        'invenio_records_rest.ptrn_item',
+        pid_value=patron_martigny_no_email.pid)
+    res = client.get(non_blocked_patron_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'blocked' in data['metadata']
+    assert data['metadata']['blocked'] is False
+
+    # blocked patron
+    blocked_patron_url = url_for(
+        'invenio_records_rest.ptrn_item',
+        pid_value=patron3_martigny_no_email.pid)
+    res = client.get(blocked_patron_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'blocked' in data['metadata']
+    assert data['metadata']['blocked'] is True
+
+
+def test_blocked_field_not_present(
+        client,
+        librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test ptrn7 do not have any blocked field."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item_url = url_for(
+        'invenio_records_rest.ptrn_item',
+        pid_value=patron2_martigny_no_email.pid)
+    res = client.get(item_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'blocked' not in data['metadata']
+
+
+def test_blocked_patron_cannot_request(client,
+                                       librarian_martigny_no_email,
+                                       item_lib_martigny,
+                                       lib_martigny,
+                                       patron_martigny_no_email,
+                                       patron3_martigny_no_email,
+                                       circulation_policies):
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res = client.get(
+        url_for(
+            'api_item.can_request',
+            item_pid=item_lib_martigny.pid,
+            library_pid=lib_martigny.pid,
+            patron_barcode=patron3_martigny_no_email.get('barcode')
+        )
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('can_request', {}) is False
+
+    # Check with valid patron
+    res = client.get(
+        url_for(
+            'api_item.can_request',
+            item_pid=item_lib_martigny.pid,
+            library_pid=lib_martigny.pid,
+            patron_barcode=patron_martigny_no_email.get('barcode')
+        )
+    )
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('can_request', {}) is True

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2185,7 +2185,9 @@
     "communication_channel": "email",
     "roles": [
       "patron"
-    ]
+    ],
+    "blocked": false,
+    "blocked_note": "Check that even if blocking block exists, user is safe."
   },
   "ptrn7": {
     "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",
@@ -2263,6 +2265,32 @@
     "roles": [
       "patron"
     ]
+  },
+  "ptrn11": {
+    "$schema": "https://ils.rero.ch/schema/patrons/patron-v0.0.1.json",
+    "pid": "ptrn11",
+    "first_name": "Marvin",
+    "barcode": "42421313000",
+    "last_name": "Lorgne",
+    "street": "Avenue de la Gare, 42",
+    "postal_code": "1920",
+    "city": "Martigny",
+    "birth_date": "1958-01-12",
+    "patron_type": {
+      "$ref": "https://ils.rero.ch/api/patron_types/ptty2"
+    },
+    "email": "mlorgne@gmail.com",
+    "phone": "+41324993142",
+    "communication_language": "eng",
+    "communication_channel": "email",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib1"
+    },
+    "roles": [
+      "patron"
+    ],
+    "blocked": true,
+    "blocked_note": "Lost card"
   },
   "dummy_notif": {
     "$schema": "https://ils.rero.ch/schema/notifications/notification-v0.0.1.json",

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -362,6 +362,47 @@ def patron2_martigny_no_email(
     return ptrn
 
 
+# ------------ Org: Martigny Patron 3 (blocked) ----------
+@pytest.fixture(scope="module")
+def patron3_martigny_data(data):
+    """Load Martigny blocked patron data."""
+    return deepcopy(data.get('ptrn11'))
+
+
+@pytest.fixture(scope="module")
+def patron3_martigny(
+        app,
+        roles,
+        lib_martigny,
+        patron_type_adults_martigny,
+        patron3_martigny_data):
+    """Create Martigny patron record."""
+    ptrn = Patron.create(
+        data=patron3_martigny_data,
+        delete_pid=True,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn
+
+
+@pytest.fixture(scope="module")
+@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
+def patron3_martigny_no_email(
+        app,
+        roles,
+        patron_type_adults_martigny,
+        patron3_martigny_data):
+    """Create Martigny patron without sending reset password instruction."""
+    ptrn = Patron.create(
+        data=patron3_martigny_data,
+        delete_pid=True,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn
+
+
 # ------------ Org: Sion, Lib: Sion, System Librarian ----------
 @pytest.fixture(scope="module")
 def system_librarian_sion_data(data):

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -119,3 +119,16 @@ def test_user_librarian_can_delete(librarian_martigny):
     """Test can delete a librarian."""
     assert librarian_martigny.get_links_to_me() == {}
     assert librarian_martigny.can_delete
+
+
+def test_get_patron_blocked_field(patron_martigny_no_email):
+    """Test patron blocked field retrieval."""
+    patron = Patron.get_patron_by_email(patron_martigny_no_email.get('email'))
+    assert 'blocked' in patron
+    assert patron.get('blocked', {}) is False
+
+
+def test_get_patron_blocked_field_absent(patron2_martigny_no_email):
+    """Test patron blocked field retrieval."""
+    patron = Patron.get_patron_by_email(patron2_martigny_no_email.get('email'))
+    assert 'blocked' not in patron

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -123,3 +123,28 @@ def test_patrons_logged_user(client, librarian_martigny_no_email):
         data = get_json(res)
         assert data.get('metadata') == librarian_martigny_no_email
         assert data.get('settings').get('language') == 'fr'
+
+
+def test_patrons_logged_user_resolve(
+        client,
+        lib_martigny,
+        patron3_martigny_no_email):
+    """Test that patron library is resolved in JSON data."""
+    login_user_via_session(client, patron3_martigny_no_email.user)
+    res = client.get(url_for('patrons.logged_user', resolve=1))
+    assert res.status_code == 200
+    data = get_json(res)
+    assert data.get('metadata', {}).get('library')
+
+
+def test_patrons_blocked_user_profile(
+        client,
+        lib_martigny,
+        patron3_martigny_no_email):
+    """Test blocked patron profile."""
+    # The patron logged in
+    login_user_via_session(client, patron3_martigny_no_email.user)
+    res = client.get(url_for('patrons.profile'))
+    assert res.status_code == 200
+    # The profile displays the patron a blocked account message.
+    assert "Your account is currently blocked." in res.get_data(as_text=True)

--- a/tests/unit/test_patrons_jsonschema.py
+++ b/tests/unit/test_patrons_jsonschema.py
@@ -139,3 +139,38 @@ def test_roles(patron_schema, librarian_martigny_data_tmp):
     with pytest.raises(ValidationError):
         librarian_martigny_data_tmp['roles'] = 'text'
         validate(librarian_martigny_data_tmp, patron_schema)
+
+
+def test_blocked(patron_schema, librarian_martigny_data_tmp):
+    """Test blocked field for patron jsonschemas."""
+    validate(librarian_martigny_data_tmp, patron_schema)
+
+    # blocked is a boolean field, should fail with everything except boolean
+    with pytest.raises(ValidationError):
+        librarian_martigny_data_tmp['blocked'] = 25
+        validate(librarian_martigny_data_tmp, patron_schema)
+
+    with pytest.raises(ValidationError):
+        librarian_martigny_data_tmp['blocked'] = 'text'
+        validate(librarian_martigny_data_tmp, patron_schema)
+
+    # Should pass with boolean
+    librarian_martigny_data_tmp['blocked'] = False
+    validate(librarian_martigny_data_tmp, patron_schema)
+
+
+def test_blocked_note(patron_schema, librarian_martigny_data_tmp):
+    """Test blocked_note field for patron jsonschemas."""
+    validate(librarian_martigny_data_tmp, patron_schema)
+
+    # blocked_note is text field. Should fail except with text.
+    with pytest.raises(ValidationError):
+        librarian_martigny_data_tmp['blocked_note'] = 25
+        validate(librarian_martigny_data_tmp, patron_schema)
+
+    with pytest.raises(ValidationError):
+        librarian_martigny_data_tmp['blocked_note'] = True
+        validate(librarian_martigny_data_tmp, patron_schema)
+
+    librarian_martigny_data_tmp['blocked_note'] = 'Lost card'
+    validate(librarian_martigny_data_tmp, patron_schema)


### PR DESCRIPTION
In some cases a patron could be blocked by a librarian to restrict its
account. For an example if patron lost its card.

* Adds new jsonschema definition to block patron.
* Displays if patron is blocked on its profile.
* Adds tests to check if patron is blocked or not.
* Reduce patron circulation policy to deny all checkout and requests
from a blocked patron account.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

[US299](https://tree.taiga.io/project/rero21-reroils/us/299?milestone=260625): block patrons

## How to test?

Needs https://github.com/rero/rero-ils-ui/pull/234

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
