### PR TITLE
subscriptions: display message when patron has pending subscription

### DIFF
--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -38,7 +38,8 @@ from ..minters import id_minter
 from ..organisations.api import Organisation
 from ..patron_transactions.api import PatronTransaction
 from ..providers import Provider
-from ..utils import get_ref_for_pid, trim_barcode_for_record
+from ..utils import extracted_data_from_ref, get_ref_for_pid, \
+    trim_barcode_for_record
 
 _datastore = LocalProxy(lambda: current_app.extensions['security'].datastore)
 
@@ -398,3 +399,17 @@ class Patron(IlsRecord):
             })
             self['subscriptions'] = subscriptions
             self.update(self, dbcommit=dbcommit, reindex=reindex)
+
+    def get_pending_subscriptions(self):
+        """Get the pending subscriptions for a patron."""
+        # Not need to use a generator to get pending subscriptions.
+        # In a normal process, the maximum number of subscriptions for a patron
+        # is two : current subscription and possibly next one.
+        pending_subs = []
+        for sub in self.get('subscriptions', []):
+            trans_pid = extracted_data_from_ref(
+                sub['patron_transaction'], data='pid')
+            transaction = PatronTransaction.get_record_by_pid(trans_pid)
+            if transaction.status == 'open':
+                pending_subs.append(sub)
+        return pending_subs

--- a/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
+++ b/rero_ils/modules/patrons/templates/rero_ils/patron_profile.html
@@ -21,6 +21,14 @@
 {%- block body %}
 {% include('rero_ils/_patron_profile_head.html') %}
 
+<section>
+  {% for key, data in alerts.items() %}
+    {% for message in data['messages'] %}
+      <div class="alert alert-{{ data['level'] }}" role="alert">{{ message }}</div>
+    {% endfor %}
+  {% endfor %}
+</section>
+
 <article class="mt-4">
   <header>
     <nav>
@@ -52,6 +60,7 @@
       </ul>
     </nav>
   </header>
+
   <article class="tab-content">
     <section {% if tab == 'checkouts' %}class="tab-pane show active py-2"{%else%}class="tab-pane show py-2"{% endif %} id="checkouts" role="tabpanel" aria-labelledby="checkouts-tab">
       {% if checkouts|length > 0 %}

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -133,10 +133,27 @@ def profile(viewcode):
 
     checkouts, requests, history = patron_profile_loans(patron.pid)
 
+    # patron alert list
+    #   each alert dictionary key represent an alert category (subscription,
+    #   fees, blocked, ...). For each category, we define a bootstrap level
+    #   (https://getbootstrap.com/docs/4.0/components/alerts/) and a list of
+    #   message. Each message will be displayed into a separate alert box.
+    alerts = {}
+    pending_subscriptions = patron.get_pending_subscriptions()
+    if pending_subscriptions:
+        alerts['subscriptions'] = {
+            'messages': map(
+                lambda sub: _('You have a pending subscription fee.'),
+                pending_subscriptions
+            ),
+            'level': 'warning'  # bootstrap alert level
+        }
+
     return render_template(
         'rero_ils/patron_profile.html',
         record=patron,
         checkouts=checkouts,
+        alerts=alerts,
         pendings=requests,
         history=history,
         viewcode=viewcode,

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -122,6 +122,23 @@ def get_record_class_update_permission_from_route(route_name):
             return record_class, update_permission
 
 
+def get_endpoint_configuration(module):
+    """Search into configuration file to find configuration for a module.
+
+    :param module: name of module (class name or endpoint name or module name)
+    :return: The configuration dictionary of the resource. 'None' if resource
+             is not found.
+    """
+    if not isinstance(module, str):
+        # Get the pid_type for the class
+        module = module.provider.pid_type
+    endpoints = current_app.config.get('RECORDS_REST_ENDPOINTS', {})
+    for idx, endpoint in endpoints.items():
+        search_index = endpoint.get('search_index')
+        if search_index == module or idx == module:
+            return endpoint
+
+
 def get_ref_for_pid(module, pid):
     """Get the $ref for a pid.
 
@@ -129,22 +146,62 @@ def get_ref_for_pid(module, pid):
     :param pid: pid for record
     :return: url for record
     """
-    if not isinstance(module, str):
-        # Get the pid_type for the class
-        module = module.provider.pid_type
-    endpoints = current_app.config.get('RECORDS_REST_ENDPOINTS')
-    for endpoint in endpoints:
-        search_index = endpoints[endpoint].get('search_index')
-        # Try to find module in entpoints or entpoints.serch_index
-        if search_index == module or endpoint == module:
-            list_route = endpoints[endpoint].get('list_route')
-            if list_route:
-                return '{url}/api{route}{pid}'.format(
-                    url=current_app.config.get('RERO_ILS_APP_BASE_URL'),
-                    route=list_route,
-                    pid=pid
-                )
-    return None
+    configuration = get_endpoint_configuration(module)
+    if configuration and configuration.get('list_route'):
+        return '{url}/api{route}{pid}'.format(
+            url=current_app.config.get('RERO_ILS_APP_BASE_URL'),
+            route=configuration.get('list_route'),
+            pid=pid
+        )
+
+
+def extracted_data_from_ref(input, data='pid'):
+    """Extract a data from a `$ref` string.
+
+    :param input: string where to search data, or a dict containing '$ref' key
+    :param data: the data to found. Allowed values are :
+        * 'pid': the pid from the input
+        * 'resource': the resource search_index from input
+        * 'record_class': the record class to used to manage the input
+        * 'record': the record represented by the input
+
+    USAGE :
+      * extract_pid_from_ref('http://localhost/[resource]/[pid]', data='pid')
+      * extract_pid_from_ref({'$ref': 'http://localhost/[resource]/[pid]'})
+    """
+
+    def extract_part(input_string, idx=0):
+        """Extract part of a $ref string."""
+        parts = input_string.split('/')
+        if len(parts) > abs(idx):
+            return input_string.split('/')[idx]
+
+    def get_record_class():
+        """Search about a record_class name for a $ref URI."""
+        resource_list = extracted_data_from_ref(input, data='resource')
+        if resource_list is None:
+            return None
+        configuration = get_endpoint_configuration(resource_list)
+        if configuration and configuration.get('record_class'):
+            return obj_or_import_string(configuration.get('record_class'))
+
+    def get_record():
+        """Try to load a resource corresponding to a $ref URI."""
+        pid = extracted_data_from_ref(input, data='pid')
+        record_class = extracted_data_from_ref(input, data='record_class')
+        if record_class and pid:
+            return record_class.get_record_by_pid(pid)
+
+    if isinstance(input, str):
+        input = {'$ref': input}
+    switcher = {
+        'pid': lambda: extract_part(input.get('$ref'), -1),
+        'resource': lambda: extract_part(input.get('$ref'), -2),
+        'record_class': get_record_class,
+        'record': get_record
+    }
+    if data in switcher:
+        return switcher.get(data)()
 
 
 def add_years(initial_date, years):

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -48,58 +48,58 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "مرحباً بك في RERO-ILS"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "تصنبف المستند"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "الشبكة"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "المكتبة"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "اللغة"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "الموضوع"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "الحالة"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "مهام"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "الميزانية"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "المصادر"
 
@@ -385,7 +385,7 @@ msgstr "المبلغ المخصص لحساب التزويد"
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "مكتبة"
 
@@ -650,8 +650,8 @@ msgstr "مطلوب"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "قيد الانتظار"
 
@@ -1032,7 +1032,7 @@ msgstr "فيديو"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "العنوان"
 
@@ -7149,6 +7149,10 @@ msgstr "تم تجديد النسخة %(item_id)s ."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "خطأ في تجديد النسخة %(item_id)s."
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "مستخدم"
@@ -7327,63 +7331,63 @@ msgstr ""
 msgid "Phone"
 msgstr "الهاتف"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "الإعارات"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "تاريخ الاعارات"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "معلومات شخصية"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "ليست إعارة"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "لا انتظار"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "لا يوجد تسجيلات"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "رقم الاستدعاء"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "مكتبة إستلام"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "تاريخ الإستحقاق"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "تاريخ الحجز"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "يوم الاسترجاع"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "التجديدات"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr "الغاء"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "تجديد"
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: de\n"
@@ -54,58 +54,58 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Willkommen zu RERO ILS!"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "Dokumenttyp"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "Bibliothek"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "Autor"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "Autor"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "Autor"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "Autor"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "Sprache"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "Schlagwort"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "Status"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "Rollen"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "Budget"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "Quellen"
 
@@ -391,7 +391,7 @@ msgstr "Zugewiesener Betrag"
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "Bibliothek"
 
@@ -656,8 +656,8 @@ msgstr "Bestellt"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "Bestellungen"
 
@@ -1040,7 +1040,7 @@ msgstr "Film"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "Titel"
 
@@ -7177,6 +7177,10 @@ msgstr "Das Exemplar %(item_id)s wurde verlängert."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "Fehler bei der Verlängerung des Exemplares %(item_id)s."
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "Benutzer"
@@ -7355,63 +7359,63 @@ msgstr ""
 msgid "Phone"
 msgstr "Telefonnummer"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "Ausleihe"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "Historie"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "Personendaten"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "Keine Ausleihe"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "Keine Bestellung"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "Keine Historie"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "Signatur"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "Abholort"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "Fälligkeitsdatum"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "Bestellungsdatum"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "Rückgabedatum"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "Verlängerungen"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "Verlängern "
 

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: en\n"
@@ -54,58 +54,58 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Welcome to RERO-ILS!"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "document type"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "library"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "author"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "author"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "author"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "author"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "language"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "subject"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "roles"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "sources"
 
@@ -391,7 +391,7 @@ msgstr "Allocated amount."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "Library"
 
@@ -656,8 +656,8 @@ msgstr "Requested"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "Pending"
 
@@ -1038,7 +1038,7 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "Title"
 
@@ -7165,6 +7165,10 @@ msgstr "The item %(item_id)s has been renewed."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "Error during the renewal of the item %(item_id)s."
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "user"
@@ -7343,63 +7347,63 @@ msgstr "Patron transaction creation date"
 msgid "Phone"
 msgstr "Phone"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "Loans"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "History"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "Personal data"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "No loan"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "No pending"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "No history"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "Call Number"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "Pickup location"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "Due date"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "Request date"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "Checkin date"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "Renewals"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr "Cancel"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "Renew"
 

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -49,58 +49,58 @@ msgstr "RERO-ILS"
 msgid "Welcome to RERO-ILS!"
 msgstr "¡Bienvenido en RERO-ILS!"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "Tipo de documento"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "organización"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "Autores"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "Autores"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "Autores"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "Autores"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "idioma"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "sujeto"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "estado"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "funcciones"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "presupuesto"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "fuentes"
 
@@ -386,7 +386,7 @@ msgstr "Monto asignado para la cuenta."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "Biblioteca"
 
@@ -651,8 +651,8 @@ msgstr "Reservado"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "Pendiente"
 
@@ -1037,7 +1037,7 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "Título"
 
@@ -7168,6 +7168,10 @@ msgstr "El ejemplar %(item_id)s ha sido renovado."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "Error durante la renovación del ejemplar %(item_id)s."
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "usuario"
@@ -7346,63 +7350,63 @@ msgstr ""
 msgid "Phone"
 msgstr "Teléfono"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "Préstamos"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "Historial"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "Datos personales"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "Ningún préstamo"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "Ninguna reservación"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "Ningún historial"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "Número de clasificación"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "Lugar de recogida"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "Fecha de vencimiento"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "Fecha de reservación"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "Fecha de devolución"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "Renovaciones"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "Renovación"
 

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -56,58 +56,58 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Bienvenue sur RERO-ILS!"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "Type de document"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "organisation"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "bibliothèque"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "auteur"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "auteur"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "auteur"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "auteur"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "langue"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "sujet"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "statut"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "rôles"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "sources"
 
@@ -393,7 +393,7 @@ msgstr "Montant alloué"
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "Bibliothèque"
 
@@ -658,8 +658,8 @@ msgstr "Demandé"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "En attente"
 
@@ -1042,7 +1042,7 @@ msgstr "vidéo"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "Titre"
 
@@ -7175,6 +7175,10 @@ msgstr "L'exemplaire %(item_id)s a été prolongé."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "Erreur lors de la prolongation de l'exemplaire %(item_id)s. "
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "utilisateur"
@@ -7353,63 +7357,63 @@ msgstr ""
 msgid "Phone"
 msgstr "Téléphone"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "Emprunts"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "Historique"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "Données personnelles"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "Aucun livre emprunté"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "Aucune réservation"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "Pas d'historique"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "Cote"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "Lieu de retrait"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "Date de retour"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "Date de la réservation"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "Date de retour"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "Prolongations"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "Prolongation"
 

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Gianni Pante <gianni.pante@rero.ch>, 2020\n"
 "Language: it\n"
@@ -57,58 +57,58 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Benvenuti su RERO ILS!"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "tipo di documento"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "Ente"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "autore"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "autore"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "autore"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "autore"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "lingua"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "oggetto"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "stato"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "ruoli"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "bilancio"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "fonti"
 
@@ -394,7 +394,7 @@ msgstr "L'importo stanziato al conto."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "Biblioteca"
 
@@ -659,8 +659,8 @@ msgstr "Richiesto"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "Richieste"
 
@@ -1043,7 +1043,7 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "Titolo"
 
@@ -7175,6 +7175,10 @@ msgstr "L'esemplare %(item_id)s è stato prorogato."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "Errore durante la proroga dell'esemplare %(item_id)s."
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "utente"
@@ -7353,63 +7357,63 @@ msgstr ""
 msgid "Phone"
 msgstr "Telefono"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "Prestiti"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "Storico"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "Dati personali"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "Nessun prestito"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "Nessuna richiesta"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "Nessuno storico"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "Segnatura"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "Punto di ritiro"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "Data di scadenza"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "Data di prenotazione"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "Data di ritorno"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "Proroghe"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr "Annullare"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "Prorogare"
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,58 +42,58 @@ msgstr ""
 msgid "Welcome to RERO-ILS!"
 msgstr ""
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr ""
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr ""
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr ""
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr ""
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr ""
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr ""
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr ""
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr ""
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr ""
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr ""
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr ""
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr ""
 
@@ -379,7 +379,7 @@ msgstr ""
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr ""
 
@@ -644,8 +644,8 @@ msgstr ""
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr ""
 
@@ -7133,6 +7133,10 @@ msgstr ""
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr ""
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr ""
@@ -7311,63 +7315,63 @@ msgstr ""
 msgid "Phone"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr ""
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr ""
 

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-14 08:58+0200\n"
+"POT-Creation-Date: 2020-04-14 09:04+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -48,58 +48,58 @@ msgstr "rero-ils"
 msgid "Welcome to RERO-ILS!"
 msgstr "Welkom bij RERO-ILS!"
 
-#: rero_ils/config.py:1094
+#: rero_ils/config.py:1099
 msgid "document_type"
 msgstr "type van document"
 
-#: rero_ils/config.py:1095
+#: rero_ils/config.py:1100
 msgid "organisation"
 msgstr "organisatie"
 
-#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
-#: rero_ils/config.py:1186
+#: rero_ils/config.py:1103 rero_ils/config.py:1147 rero_ils/config.py:1169
+#: rero_ils/config.py:1191
 msgid "library"
 msgstr "bibliotheek"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1104
 msgid "author__en"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1100
+#: rero_ils/config.py:1105
 msgid "author__fr"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1106
 msgid "author__de"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1102
+#: rero_ils/config.py:1107
 msgid "author__it"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1103
+#: rero_ils/config.py:1108
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "taal"
 
-#: rero_ils/config.py:1104
+#: rero_ils/config.py:1109
 msgid "subject"
 msgstr "onderwerp"
 
-#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
+#: rero_ils/config.py:1110 rero_ils/config.py:1170 rero_ils/config.py:1192
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1121
+#: rero_ils/config.py:1126
 msgid "roles"
 msgstr "rollen"
 
-#: rero_ils/config.py:1143
+#: rero_ils/config.py:1148
 msgid "budget"
 msgstr "begroting"
 
-#: rero_ils/config.py:1203
+#: rero_ils/config.py:1208
 msgid "sources"
 msgstr "bron"
 
@@ -385,7 +385,7 @@ msgstr "Het toegekende bedrag voor de account."
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
 msgid "Library"
 msgstr "Bibliotheek"
 
@@ -650,8 +650,8 @@ msgstr "Opgevraagd"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:70
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:134
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:32
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:42
 msgid "Pending"
 msgstr "In afwachting"
 
@@ -1036,7 +1036,7 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:93
 msgid "Title"
 msgstr "Titel"
 
@@ -7171,6 +7171,10 @@ msgstr "De exemplaar %(item_id)s is verlengd."
 msgid "Error during the renewal of the item %(item_id)s."
 msgstr "Fout bij de verlenging van de exemplaar %(item_id)s."
 
+#: rero_ils/modules/patrons/views.py:146
+msgid "You have a pending subscription fee."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:4
 msgid "user"
 msgstr "Lezer"
@@ -7349,63 +7353,63 @@ msgstr ""
 msgid "Phone"
 msgstr "Telefoon"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:26
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:28
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:34
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:36
 msgid "Loans"
 msgstr "Loans"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:38
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:40
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:48
 msgid "History"
 msgstr "Historiek"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:45
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:46
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:53
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:54
 msgid "Personal data"
 msgstr "Persoonlijke gegevens"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:57
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:66
 msgid "No loan"
 msgstr "Geen lening"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:64
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:73
 msgid "No pending"
 msgstr "Geen in afwachting"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:71
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:80
 msgid "No history"
 msgstr "Geen historiek"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:85
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:94
 msgid "Call Number"
 msgstr "Plaatskenmerk"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:88
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:97
 msgid "Pickup library"
 msgstr "Afhaal bibliotheek"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:98
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
 msgid "Due date"
 msgstr "Vervaldatum"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:100
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:109
 msgid "Request date"
 msgstr "Aanvraagdatum"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:102
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:111
 msgid "Checkin date"
 msgstr "Checkin datum"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:107
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:116
 msgid "Renewals"
 msgstr "Verlengingen"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:112
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:165
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:121
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:174
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:154
+#: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:163
 msgid "Renew"
 msgstr "Verlengingen"
 


### PR DESCRIPTION
## How to test?

!!! use `rero/zan-US1297-subscriptions` for RERO-ILS-UI

- Assign a patron_type requiring a subscription to patron (Monnet, Philippe). A new subscription fee will be created
- In the public interface, login as this patron (reroilstest+philippe@gmail.com) and display the profile of this patron. An alert box should be displayed to alert there is a pending subscription.

![image](https://user-images.githubusercontent.com/10031585/78679982-33cde280-78eb-11ea-88e1-883c243d1364.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
