### PR TITLE
location: correct schema to work well with formly

### DIFF
--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -60,12 +60,16 @@ class Location(IlsRecord):
         """Validate record against schema.
 
         and extended validation to allow only one location with field
-        is_online = True per library.
+        is_online = True per library. Also check that "pickup_name" field
+        is present and not empty if location is pickup
         """
         online_location_pid = self.get_library().online_location
         if self.get('is_online') and online_location_pid and \
                 self.pid != online_location_pid:
             return _('Another online location exists in this library')
+        if self.get('is_pickup', False) and \
+                not self.get('pickup_name', '').strip():
+            return _('Pickup name field is required.')
         return True
 
     @classmethod

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -113,28 +113,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "is_pickup": {
-          "enum": [
-            true
-          ]
-        }
-      },
-      "required": [
-        "pickup_name"
-      ]
-    },
-    {
-      "properties": {
-        "is_pickup": {
-          "enum": [
-            false
-          ]
-        }
-      }
-    }
-  ]
+  }
 }

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -1,105 +1,105 @@
-# Translations template for rero-ils.
+# Arabic translations for rero-ils.
 # Copyright (C) 2020 RERO
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
-# 
+#
 # Translators:
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Aly Badr <aly.badr@rero.ch>, 2020
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-23 14:46+0100\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
+"Language: ar\n"
 "Language-Team: Arabic (https://www.transifex.com/rero/teams/77935/ar/)\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : "
+"n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "الفرنسية"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "الألمانية"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "الايطالية"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "مرحباً بك في RERO-ILS"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "تصنبف المستند"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "الشبكة"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "المكتبة"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "المؤلف"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "اللغة"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "الموضوع"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "الحالة"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "مهام"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "الميزانية"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "المصادر"
 
@@ -185,8 +185,8 @@ msgid "sound"
 msgstr "صوت"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1069
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1069
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "فيديو"
 
@@ -222,42 +222,42 @@ msgid "ui_language_it"
 msgstr "الايطالية"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "نشر"
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:392
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "تصنيع"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:396
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "توزيع"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:400
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "إنتاج"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:432
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:432
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "مكان"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:249
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:249
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "التاريخ"
 
@@ -313,8 +313,8 @@ msgstr "مخطط JSON لحساب التزويد"
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:22
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:22
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:16
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:35
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:35
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:36
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:13
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
@@ -341,10 +341,10 @@ msgid "Account ID"
 msgstr "رقم الحساب"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:227
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -395,8 +395,8 @@ msgstr "المبلغ المخصص لحساب التزويد"
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:44
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:48
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:47
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:51
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:67
@@ -421,10 +421,10 @@ msgstr "URI للمكتبة"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:288
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -568,9 +568,9 @@ msgid "Choose a date"
 msgstr "اختار تاريخ"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:614
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "ملاحظات"
 
@@ -699,12 +699,12 @@ msgid "Rate"
 msgstr "نسبة"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:506
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:793
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:793
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -893,8 +893,7 @@ msgid "Number of days after due date"
 msgstr "عدد الآيام بعد تاريخ الإستحقاق"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:77
-msgid ""
-"Number of days after due date for sending the first overdue notification."
+msgid "Number of days after due date for sending the first overdue notification."
 msgstr "عدد الآيام بعد تاريخ الإستحقاق لإرسال إشعار الإستحقاق"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:83
@@ -953,22 +952,22 @@ msgstr "تصنيف النسخة"
 msgid "Item type URI"
 msgstr "URI لتصنيف النسخة"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:263
-#: rero_ils/modules/documents/views.py:358
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:271
+#: rero_ils/modules/documents/views.py:362
 msgid "available"
 msgstr "متاح"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:263
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:265
-#: rero_ils/modules/documents/views.py:360
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:271
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:273
+#: rero_ils/modules/documents/views.py:364
 msgid "not available"
 msgstr "غيرمتاح"
 
-#: rero_ils/modules/documents/views.py:367 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "مستحق الى"
 
-#: rero_ils/modules/documents/views.py:369
+#: rero_ils/modules/documents/views.py:373
 msgid "requested"
 msgstr "مطلوب"
 
@@ -977,102 +976,167 @@ msgstr "مطلوب"
 msgid "Bibliographic Document"
 msgstr "مستند ببليوجرافي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:36
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:37
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:37
 msgid "Schema to validate document against."
 msgstr "مخطط لتدقيق المستند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:41
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:41
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:42
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:42
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:47
 msgid "Document PID"
 msgstr "PID المستند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:46
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:153
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:211
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:279
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:469
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:672
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:46
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:153
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:377
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:469
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
 msgid "Type"
 msgstr "تصنيف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:48
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:48
 msgid "Type of the document."
 msgstr "تصنيف المستند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:64
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:64
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:65
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:65
 msgid "Article"
 msgstr "مقالة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:68
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:68
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:69
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:69
 msgid "Book"
 msgstr "كتاب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:72
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:72
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:73
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:73
 msgid "E-Book"
 msgstr "كتاب الكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:76
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:76
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:77
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:77
 msgid "Journal"
 msgstr "دورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:80
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:80
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:81
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:81
 msgid "Other"
 msgstr "غير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:84
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:84
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:85
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:85
 msgid "Score"
 msgstr "نتيجة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:88
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:88
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:89
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:89
 msgid "Sound"
 msgstr "صوت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:92
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:92
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:93
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:93
 msgid "Video"
 msgstr "فيديو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:99
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
 msgstr "العنوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
-msgid "Entire title without statement of responsibility."
-msgstr "عنوان بأكمله دون بيان المسؤولية"
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:134
+msgid "ParallelTitle"
+msgstr "مقالة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:108
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:138
+msgid "VariantTitle"
+msgstr "مقالة"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:145
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:149
+msgid "Main Title"
+msgstr "عنوان منتظم"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:154
+msgid "Subtitle"
+msgstr "العنوان"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
+msgid "Parts"
+msgstr "المستخدمين"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
+msgid "Part"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
+msgid "Part Number"
+msgstr "رقم استدعاء"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
+msgid "Part Name"
+msgstr "إسم العائلة"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
+msgid "Responsibilities"
+msgstr "المسؤوليات"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
+msgid "Responsibility"
+msgstr "المسؤولية"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "العناوين المناسبة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:109
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
@@ -1080,5323 +1144,5321 @@ msgstr ""
 "عنوان موحد ، عنوان ذو صلة أو عنوان تحليلي يتم التحكم فيه بواسطة ملف أو "
 "إسنادات ، يستخدم كنقطة دخول معتمدة."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:113
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:113
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "العنوان المناسب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:125
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:125
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "جزء من"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "عنوان المستند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "اللغات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "قائمة لغات المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:141
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:141
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "اللغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "لغات المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "تصنيف اللغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "لغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "الترجمة من"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "اللغة التي يتم ترجمة المصدر إليها"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:188
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "المؤلفين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:189
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:189
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "مؤلف(ي) المصدر. يمكن أن يكون إما أشخاص أو منظمات."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:193
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:55
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:197
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:220
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:197
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "إسناد المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:228
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "إسم إسنادات المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "MEF إسناد المؤلف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr "معلومات عن ولادة وموت اسناد مؤلف. مفيدة للناس إزالة الغموض."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:257
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:257
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:802
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "مؤهل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:258
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr "معلومات عن اسناد مؤلف، المهنة. مفيدة للناس إزالة الغموض."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:296
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "اسم الشبكة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "تواريخ حقوق النشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "تاريخ حقوق النشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:324
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "بيانات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "بيانات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:333
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:333
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "تسميات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "تسميات الطبعة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
-msgid "Responsibilities"
-msgstr "المسؤوليات"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:346
-msgid "Responsibility"
-msgstr "المسؤولية"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:357
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:357
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "أنشطة توفير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:361
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:361
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "نشاط توفير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "اماكن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "مكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "نوع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "البلد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "إقليم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "صياغات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "صياغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:458
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr "بيان مكان وكيل النشاط المخصص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "وكيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:494
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:498
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "ملصقات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "ملاحظة."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:514
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "تاريخ بدء النشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
-"Start date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Start date of the publication. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 msgstr ""
-"تاريخ بداية المنشور. يجب أن يكون عددًا صحيحًا ، أي 1989 ، 453 ، -50. يستخدم "
-"لفرز نتائج البحث. بمجرد تعيين هذا الحقل ، يمكن إضافة تاريخ نشر اخر في الحقل "
-"التالي."
+"تاريخ بداية المنشور. يجب أن يكون عددًا صحيحًا ، أي 1989 ، 453 ، -50. "
+"يستخدم لفرز نتائج البحث. بمجرد تعيين هذا الحقل ، يمكن إضافة تاريخ نشر اخر"
+" في الحقل التالي."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:524
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "تاريخ الانتهاء من النشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:525
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:525
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Used to sort search results. Once this field is set, a free formed date "
+"of publication can be added in the next field."
 msgstr ""
-"تاريخ الانتهاء من المنشور. يجب أن يكون عددًا صحيحًا ، أي 1989 ، 453 ، -50. "
-"يستخدم لفرز نتائج البحث. بمجرد تعيين هذا الحقل ، يمكن إضافة تاريخ نشر اخر في"
-" الحقل التالي"
+"تاريخ الانتهاء من المنشور. يجب أن يكون عددًا صحيحًا ، أي 1989 ، 453 ، "
+"-50. يستخدم لفرز نتائج البحث. بمجرد تعيين هذا الحقل ، يمكن إضافة تاريخ "
+"نشر اخر في الحقل التالي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "مدى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:544
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "مدى المصدر ، أي عدد الصفحات أو المجلدات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "خصائص المواد الأخرى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr "خصائص المواد الأخرى ، مثل الرسوم التوضيحية ، سوداء ومع أو ملونة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:558
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "تنسيقات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "تنسيق المورد ، أي الأبعاد في سم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:568
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "مواد إضافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:569
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:569
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr "المواد المصاحبة للمصدر ، أي الخرائط."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:577
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:577
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:583
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:92
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "السلسلة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "السلسلة التي ينتمي إليها المورد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "عنوان السلسلة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:600
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "ترقيم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:601
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:601
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "ترقيم المصدر داخل السلسلة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "ملاحظة عن المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "ملخصات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:632
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "ملخص للمصدر."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:636
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:636
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:75
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "الملخص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:651
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:655
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:117
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "معرف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:700
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "رقم الإصدار الصوتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "bf:Doi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:708
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "bf:Ean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:712
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "bf:Gtin14Number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "معرف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:720
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "bf:Isan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "bf:Isbn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "bf:Ismn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:732
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "bf:Isrc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:736
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "bf:Issn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "bf:IssnL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:744
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "bf:Local"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:748
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "bf:MatrixNumber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:752
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "bf:MusicDistributorNumber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:756
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "bf:MusicPlate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "bf:MusicPublisherNumber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "bf:PublisherNumber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "bf:Upc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:772
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "bf:Urn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:776
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "bf:VideoRecordingNumber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:780
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
 msgstr "رقم التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:788
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
 msgid "Identifier value."
 msgstr "رقم التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:794
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "ملاحطة التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "تأهيل المعرف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "شروط المقنيات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:812
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "شروط المقنيات للمصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "مصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:818
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "مصدر رقم التعريف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:70
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "الحالة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:824
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "حالة معرف ISBN/ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:826
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "حالة المعرف ISBN/ISSN يجب اختيارها من القائمة "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:846
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "المواضيع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "موضوع المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "الموضوع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr "الاماكن الالكترونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:864
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
 msgstr "معلومات مطلوبة لتحديد والإتصال بالمصدر الإلكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr "مكان الكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:882
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr "url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
 msgstr "سجل URL وحيد هنا."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:884
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
 msgid "Example: https://www.rero.ch/"
 msgstr "مثال: https://www.rero.ch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:890
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr "تصنيف الرابط"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr "المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr "إصدار المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:910
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr "مصدر ذو صلة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:914
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr "URL مخفي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr "لا يوجد معلومات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:925
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:925
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr "تصنيف المحتوى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr "يتم عرضه كنص الرابط"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr "ملصق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:965
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:965
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr "صوت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:969
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr "كرت بريدي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr "إضافة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:977
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:977
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr "تلخيص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:981
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:981
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr "وثائق العروض"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:985
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:985
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr "خطأ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:989
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:989
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr "لوحة كتب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr "استخلاص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr "ورقة تعليمية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1001
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1001
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr "الرسوم التوضيحية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr "صورة الغلاف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1009
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1009
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr "معلومات التسليم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1013
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1013
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr "معلومات ببليوجرافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr "مقدمة/تمهيد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr "صف القراءة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr "أدوات المعلم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr "ملاحظة الناشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr "ملاحظة عن  المحتوى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1037
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1037
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr "صفحة العنوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr "التصوير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1045
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1045
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr "تلخيص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1049
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1049
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr "الموارد عبر الإنترنت من خلال RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1053
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1053
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr "استعراض الصحافة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1057
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1057
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "موقع الكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1061
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1061
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr "جدول المحتويات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1065
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1065
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr "النص الكامل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
 msgstr "ملاحظة عامة لمعرف الموارد الموحد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1077
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1077
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
 msgid "Is displayed next to the link, as additional information"
 msgstr "يتم عرض بجوار الرابط ، كمعلومات إضافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr "مثال: الوصول هنا فقط عن طريق المكتبة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "محصود"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "يتم حصاد المستند أم لا ، سيتم تعطيل إصدار السجل أو ما شابه"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "قيمة اللغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1594
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "الأفارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1598
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "الأبخازية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1602
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "الأتشينيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1606
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "الأكولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1610
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "الأدانجمية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1614
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "الأديغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1618
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "lang_afa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1622
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "الأفريهيلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1626
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "الأفريقانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1630
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "الآينوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "الأكانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1638
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "الأكادية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1642
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "lang_alb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "الأليوتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1650
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "lang_alg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1654
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "الألطائية الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1658
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "الأمهرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "الإنجليزية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1666
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "الأنجيكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1670
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "lang_apa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1674
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "العربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "الآرامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1682
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "الأراغونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "lang_arm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1690
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "المابودونغونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1694
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "الأراباهو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1698
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "lang_art"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "الأراواكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1706
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "الأسامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "الأسترية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1714
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "lang_ath"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1718
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "lang_aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1722
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "الأوارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "الأفستية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1730
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "الأوادية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "الأيمارا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1738
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "الأذربيجانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1742
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "lang_bad"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1746
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "lang_bai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1750
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "الباشكيرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1754
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "البلوشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1758
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "البامبارا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1762
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "البالينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "lang_baq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1770
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "الباسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1774
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "lang_bat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1778
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "البيجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1782
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "البيلاروسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1786
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "البيمبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1790
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "البنغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1794
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "lang_ber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1798
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "البهوجبورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1802
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "lang_bih"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1806
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "البيكولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1810
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "البينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1814
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "البيسلامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1818
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "السيكسيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1822
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "lang_bnt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1826
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "البوسنية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1830
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "البراجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1834
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "البريتونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1838
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "lang_btk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1842
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "البرياتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1846
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "البجينيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1850
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "البلغارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1854
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "lang_bur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1858
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "البلينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1862
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "الكادو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1866
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "lang_cai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1870
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "الكاريبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1874
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "الكتالانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1878
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "القوقازيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1882
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "السيبيوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1886
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "lang_cel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1890
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "التشامورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1894
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "التشيبشا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1898
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "الشيشانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "التشاجاتاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "الصينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1910
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "التشكيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1914
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "الماري"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1918
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "الشينوك جارجون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1922
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "الشوكتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "الشيباوايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1930
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "الشيروكي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1934
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "سلافية كنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1938
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "التشوفاشي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1942
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "الشايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1946
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "lang_cmc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1950
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "lang_cnr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1954
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "القبطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1958
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "الكورنية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "الكورسيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1966
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "lang_cpe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1970
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "lang_cpf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1974
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "lang_cpp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "الكرى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1982
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "لغة تتار القرم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1986
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "lang_crp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1990
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "الكاشبايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1994
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "lang_cus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1998
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "lang_cze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2002
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "الداكوتا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2006
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "الدانمركية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2010
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "الدارجوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2014
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "lang_day"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2018
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "الديلوير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2022
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "السلافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2026
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "الدوجريب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2030
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "الدنكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "المالديفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2038
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "الدوجرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2042
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "lang_dra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2046
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "صوربيا السفلى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2050
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "الديولا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2054
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "الهولندية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2058
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "lang_dut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2062
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "الدايلا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2066
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "الزونخاية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "الإفيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "المصرية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "الإكاجك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "الإمايت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "الإنجليزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "الإنجليزية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "الإسبرانتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "الإستونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "الإيوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "الإيوندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "الفانج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "الفاروية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "الفانتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "الفيجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "الفلبينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "الفنلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "lang_fiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "الفون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "الفرنسية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "الفرنسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "الفريزينية الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "الفريزينية الشرقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "الفريزيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "الفولانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "الفريلايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "الجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "الجايو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2182
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "الجبيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "lang_gem"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2190
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "lang_geo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2194
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "الالمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2198
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "الجعزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2202
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "لغة أهل جبل طارق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "الغيلية الأسكتلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2210
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "الأيرلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "الجاليكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "المنكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "الألمانية العليا الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2226
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "الألمانية العليا القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2230
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "الجندي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "الجورونتالو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2238
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "القوطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2242
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "الجريبو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2246
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "اليونانية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "lang_gre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2254
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "الغوارانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2258
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "الألمانية السويسرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2262
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "الغوجاراتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2266
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "غوتشن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "الهيدا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2274
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "الكريولية الهايتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2278
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "الهوسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2282
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "لغة هاواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "العبرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2290
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "الهيريرو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2294
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "الهيليجينون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "lang_him"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "الهندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "الحثية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "الهمونجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "الهيري موتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "الكرواتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "الصوربية العليا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "الهنغارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "الهبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "الإيبان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "الإيجبو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "lang_ice"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "الإيدو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "السيتشيون يي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "lang_ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "الإينكتيتت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "الإنترلينج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "الإيلوكو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "اللّغة الوسيطة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "lang_inc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "الإندونيسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "lang_ine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "الإنجوشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "الإينبياك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "lang_ira"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "lang_iro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "الإيطالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "الجاوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "اللوجبان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2414
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "اليابانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2418
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "الفارسية اليهودية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "العربية اليهودية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2426
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "الكارا-كالباك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2430
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "القبيلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2434
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "الكاتشين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "الكالاليست"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "الكامبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "الكانادا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2450
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "lang_kar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2454
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "الكشميرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2458
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "الكانوري"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2462
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "الكوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "الكازاخستانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "الكاباردايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2474
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "الكازية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2478
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "lang_khi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2482
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "الخميرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2486
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "الخوتانيز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2490
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "الكيكيو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2494
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "الكينيارواندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2498
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "القيرغيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2502
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "الكيمبندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2506
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "الكونكانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2510
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "الكومي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2514
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "الكونغو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2518
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "الكورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2522
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "الكوسراين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2526
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "الكبيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2530
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "الكاراتشاي-بالكار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2534
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "الكاريلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2538
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "lang_kro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2542
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "الكوروخ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2546
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "الكيونياما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2550
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "القموقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "الكردية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2558
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "الكتيناي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2562
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "اللادينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "اللاهندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2570
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "اللامبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2574
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "اللاوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2578
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "اللاتينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2582
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "اللاتفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2586
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "الليزجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2590
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "الليمبورغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2594
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "اللينجالا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2598
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "الليتوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2602
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "منغولى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2606
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "اللوزي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2610
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "اللكسمبورغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2614
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "اللبا-لؤلؤ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2618
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "اللوبا كاتانغا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2622
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "الغاندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2626
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "اللوسينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2630
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "اللوندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "اللو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2638
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "الميزو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2642
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "lang_mac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "المادريز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2650
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "الماجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2654
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "المارشالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2658
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "المايثيلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "الماكاسار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2666
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "المالايالامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2670
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "الماندينغ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2674
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "lang_mao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "lang_map"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2682
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "الماراثية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "الماساي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2690
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "lang_may"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2694
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "الموكشا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2698
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "الماندار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "الميند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2706
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "الأيرلندية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "الميكماكيونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2714
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "المينانجكاباو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2718
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "lang_mis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2722
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "lang_mkh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "الملغاشي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2730
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "المالطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "المانشو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2738
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "المانيبورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2742
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "lang_mno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2746
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "الموهوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2750
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "المنغولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2754
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "الموسي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2758
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "لغات متعددة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2762
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "lang_mun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "الكريك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2770
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "الميرانديز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2774
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "الماروارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2778
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "lang_myn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2782
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "الأرزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2786
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "lang_nah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2790
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "lang_nai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2794
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "النابولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2798
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "النورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2802
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "النافاجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2806
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "النديبيل الجنوبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2810
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "النديبيل الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2814
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "الندونجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2818
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "الألمانية السفلى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2822
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "النيبالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2826
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "النوارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2830
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "النياس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2834
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "lang_nic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2838
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "النيوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2842
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "النرويجية نينورسك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2846
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "النرويجية بوكمال"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2850
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "النوجاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2854
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "النورس القديم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2858
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "النرويجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2862
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "أنكو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2866
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "السوتو الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2870
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "lang_nub"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2874
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "النوارية التقليدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2878
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "النيانجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2882
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "النيامويزي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2886
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "النيانكول"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2890
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "النيورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2894
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "النزيما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2898
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "الأوكسيتانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "الأوجيبوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "الأورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2910
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "الأورومية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2914
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "الأوساج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2918
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "الأوسيتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2922
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "التركية العثمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "lang_oto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2930
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "lang_paa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2934
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "البانجاسينان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2938
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "البهلوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2942
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "البامبانجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2946
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "البنجابية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2950
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "البابيامينتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2954
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "البالوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2958
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "الفارسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "lang_per"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2966
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "lang_phi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2970
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "الفينيقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2974
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "البالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "البولندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2982
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "البوهنبيايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2986
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "البرتغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2990
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "lang_pra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2994
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "البروفانسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2998
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "البشتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3002
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "الكويتشوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3006
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "الراجاسثانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3010
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "الراباني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3014
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "الراروتونجاني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3018
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "lang_roa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3022
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "الرومانشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3026
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "الغجرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3030
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "lang_rum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "الرندي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3038
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "الأرومانيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3042
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "الروسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3046
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "السانداوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3050
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "السانجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3054
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "الساخيّة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3058
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "lang_sai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3062
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "lang_sal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3066
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "الآرامية السامرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "السنسكريتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "الساساك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "السانتالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "الصقلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "الأسكتلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "السيلكب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "lang_sem"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "الأيرلندية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "lang_sgn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "الشان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "السيدامو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "السنهالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "lang_sio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "lang_sit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "lang_sla"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "lang_slo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "السلوفانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "السامي الجنوبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "سامي الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "lang_smi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "اللول سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "الإيناري سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "الساموائية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "السكولت سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "الشونا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "السندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "السونينك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "السوجدين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3182
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "الصومالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "lang_son"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3190
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "السوتو الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3194
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "الإسبانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3198
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "السردينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3202
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "السرانان تونجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "الصربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3210
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "السرر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "lang_ssa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "السواتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "السوكوما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3226
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "السوندانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3230
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "السوسو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "السومارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3238
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "السواحلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3242
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "السويدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3246
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "سريانية تقليدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "السريانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3254
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "التاهيتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3258
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "lang_tai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3262
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "التاميلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3266
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "التترية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "التيلوغوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3274
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "التيمن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3278
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "التيرينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3282
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "التيتم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "الطاجيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3290
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "التاغالوغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3294
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "التايلاندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "lang_tib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "التيغرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "التغرينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "التيف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "التوكيلاو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "الكلينجون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "التلينغيتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "التاماشيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "تونجا - نياسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "التونغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "التوك بيسين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "التسيمشيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "التسوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "السونجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "التركمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "التامبوكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "lang_tup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "التركية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "lang_tut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "التوفالو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "التوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "التوفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "الأدمرت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "اليجاريتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "الأويغورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "الأوكرانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "الأمبندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "لغة غير معروفة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "الأوردية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3414
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "الأوزبكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3418
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "الفاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "الفيندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3426
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "الفيتنامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3430
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "لغة الفولابوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3434
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "الفوتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "lang_wak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "الولاياتا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "الواراي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3450
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "الواشو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3454
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "lang_wel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3458
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "lang_wen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3462
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "الولونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "الولوفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "الكالميك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3474
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "الخوسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3478
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "الياو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3482
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "اليابيز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3486
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "اليديشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3490
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "اليوروبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3494
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "lang_ypk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3498
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "الزابوتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3502
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "رموز المعايير الأساسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3506
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "الزيناجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3510
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "الزهيونج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3514
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "lang_znd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3518
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "الزولو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3522
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "الزونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3526
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "بدون محتوى لغوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3530
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "زازا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "قيمات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "قيمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3976
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "country_aa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3980
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "country_abc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3984
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "country_ac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3988
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "country_aca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "country_ae"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3996
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "country_af"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4000
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "country_ag"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4004
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "country_ai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4008
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "country_air"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4012
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "country_aj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4016
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "country_ajr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4020
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "country_aku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4024
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "country_alu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4028
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "country_am"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4032
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "country_an"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4036
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "country_ao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4040
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "(aq) أنتيغوا وبربودا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4044
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "country_aru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4048
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "country_as"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4052
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "country_at"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4056
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "country_au"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4060
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "country_aw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4064
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "country_ay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4068
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "country_azu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4072
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "country_ba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4076
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "(bb) بربادوس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4080
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "(bbc) كولومبيا البريطانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4084
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "country_bd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4088
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "country_be"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4092
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "country_bf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4096
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "country_bg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4100
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "country_bh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4104
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "country_bi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4108
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "country_bl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4112
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "country_bm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4116
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "country_bn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4120
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "country_bo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4124
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "(bp) جزر سليمان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "country_br"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4132
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "country_bs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4136
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "(bt) بوتان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4140
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "country_bu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "(bv) جزيرة بوفيه"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "(bw) بيلاروس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "country_bwr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "(bx) بروناي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "country_ca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "(cau) كاليفورنيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "country_cb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "(cc) الصين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "country_cd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "country_ce"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "(cf) كونجو برازفيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "country_cg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "country_ch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "country_ci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "(cj) جزر كايمان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "country_ck"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "(cl) تشيلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "country_cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "country_cn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "country_co"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "country_cou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "country_cp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "(cq) جزر القمر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "country_cr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "country_cs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "country_ctu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "country_cu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "country_cv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "(cw) جزر كوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "(cx) جمهورية أفريقيا الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "country_cy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "(cz) قناة الزون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "country_dcu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "country_deu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "country_dk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "country_dm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "(dq) دومينيكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "country_dr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "country_ea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "(ec) الإكوادور"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "country_eg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "country_em"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "country_enk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "country_er"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "country_err"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "country_es"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "country_et"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "country_fa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "(fg) غويانا الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "country_fi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "country_fj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "(fk) جزر الفوكلاند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "country_flu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "country_fm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "(fp) بولينيزيا الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "country_fr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "country_fs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "country_ft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "country_gau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "country_gb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "country_gd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "country_ge"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "country_gg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "country_gh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "country_gi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "country_gl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "country_gm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "country_gn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "country_go"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "(gp) غوادلوب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "country_gr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "country_gs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "country_gsr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "country_gt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "country_gu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "country_gv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "country_gw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "country_gy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "country_gz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "country_hiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "country_hk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "country_hm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "country_ho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "country_ht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "country_hu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "country_iau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "country_ic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "country_idu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "country_ie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "country_ii"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "country_ilu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "country_im"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "country_inu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "country_io"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "(iq) العراق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "country_ir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "country_is"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "country_it"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "country_iu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "country_iv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "(iw) المناطق المنزوعة السلاح بين إسرائيل والأردن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "country_iy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "country_ja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "(je) جيرسي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "country_ji"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "(jm) جامايكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "country_jn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "country_jo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "country_ke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "(kg) قيرغيزستان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "country_kgr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "country_kn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "country_ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "country_ksu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "country_ku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "(kv) كوسوفو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "country_kyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "country_kz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "country_kzr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "country_lau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "country_lb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "country_le"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "country_lh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "country_li"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "country_lir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "country_ln"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "country_lo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "country_ls"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "country_lu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "country_lv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "country_lvr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "(ly) ليبيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "country_mau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "country_mbc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "country_mc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "country_mdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "country_meu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "country_mf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "country_mg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "country_mh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "country_miu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "country_mj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "country_mk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "country_ml"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "(mm) مالطا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "country_mnu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "country_mo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "country_mou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "(mp) منغوليا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "(mq) جزر المارتينيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "country_mr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "country_msu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "country_mtu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "country_mu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "country_mv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "country_mvr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "country_mw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "(mx) المكسيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "country_my"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "(mz) موزمبيق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "country_na"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "country_nbu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "country_ncu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "country_ndu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "country_ne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "country_nfc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "country_ng"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "country_nhu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "country_nik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "country_nju"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "country_nkc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "country_nl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "country_nm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "country_nmu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "country_nn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "country_no"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "country_np"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "country_nq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "country_nr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "country_nsc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "country_ntc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "country_nu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "country_nuc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "country_nvu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "country_nw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "(nx) جزيرة نورفولك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "country_nyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "country_nz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "country_ohu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "country_oku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "country_onc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "country_oru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "country_ot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "(pau) بنسلفانيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "(pc) جزيرة بيتكيرن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "country_pe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "(pf) جزر باراسيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "country_pg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "country_ph"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "country_pic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "country_pk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "country_pl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "country_pn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "country_po"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "country_pp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "country_pr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "(pt) تيمور البرتغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "(pw) بالاو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "(py) باراغواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "(qa) قطر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "country_qea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "country_quc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "country_rb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "country_re"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "country_rh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "country_riu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "country_rm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "country_ru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "country_rur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "country_rw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr "country_ry"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "country_sa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "country_sb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "country_sc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "country_scu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "country_sd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "country_sdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "country_se"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "(sf) ساو تومي وبرينسيبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "country_sg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "country_sh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "country_si"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "country_sj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "country_sk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "country_sl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "country_sm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "country_sn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "country_snc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "country_so"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "country_sp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "(sq) إسواتيني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "country_sr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "country_ss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "country_st"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "country_stk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "country_su"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "country_sv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "country_sw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "country_sx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "country_sy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "(sz) سويسرا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "country_ta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "country_tar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "(tc) جزر توركس وكايكوس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "country_tg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "country_th"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "country_ti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "country_tk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "country_tkr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "country_tl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "country_tma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "country_tnu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "country_to"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "country_tr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "country_ts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "country_tt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "country_tu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "country_tv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "country_txu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "country_tz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "country_ua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "(uc) الولايات المتحدة متفرقات. جزر الكاريبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "country_ug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "country_ui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "country_uik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "country_uk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "country_un"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "country_unr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "country_up"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "country_ur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "country_us"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "country_utu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "(uv) بوركينا فاسو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "(uy) أورغواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "country_uz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "country_uzr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "country_vau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "(vb) جزر فيرجن البريطانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "(vc) مدينة الفاتيكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "country_ve"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "country_vi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "(vm) فيتنام"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "country_vn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "(vp) أماكن متعددة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "country_vra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "(vs) فيتنام الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "country_vtu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "country_wau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "(wb) برلين الغربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "country_wea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "(wf) جزر والس وفوتونا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "country_wiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "(wj) الضفة الغربية لنهر الأردن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "(wk) جزيرة ويك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "country_wlk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "country_ws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "(wvu) فرجينيا الغربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "country_wyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "country_xa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "(xb) جزر كوكوس (كيلينغ)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "(xc) جزر المالديف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "(xd) سانت كيتس-نيفيس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "(xe) جزر مارشال"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "(xf) جزر ميدواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "country_xga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "country_xh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "(xi) سانت كيتس-نيفيس أنغيلا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "(xj) سانت هيلانة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "(xk) سانت لوسيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "country_xl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "(xm) سانت فنسنت وجزر غرينادين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "(xn) مقدونيا الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "country_xna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "country_xo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "country_xoa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "(xp) جزيرة سبراتلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "(xr) التشيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "country_xra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "(xs) جورجيا الجنوبية وجزر ساندويتش الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "(xv) سلوفينيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "country_xx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "country_xxc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "country_xxk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "country_xxr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "country_xxu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "country_ye"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "country_ykc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "(ys) الجمهورية اليمنية الديمقراطية الشعبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "country_yu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "country_za"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "canton_ag"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "canton_ai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "canton_ar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "canton_be"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "canton_bl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "canton_bs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "canton_fr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "canton_ge"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "canton_gl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "canton_gr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "canton_ju"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "canton_lu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "canton_ne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "canton_nw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "canton_ow"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "canton_sg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "canton_sh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "canton_so"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "canton_sz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "canton_tg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "canton_ti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "canton_ur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "canton_vd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "canton_vs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "canton_zg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "canton_zh"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:60
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:56
+msgid "Variant title"
+msgstr "اسم متغير"
+
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:68
 msgid "Edition"
 msgstr "الإصدار"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:70
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:78
 msgid "Copyright date"
 msgstr "تاريخ الحقوق المحفوظة"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:82
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:90
 msgid "Physical description"
 msgstr "الوصف المادي"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:87
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:95
 msgid "Additional Materials"
 msgstr "مواد إضافية"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:97
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:105
 msgid "Uniform title"
 msgstr "عنوان منتظم"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:139
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:147
 msgid "Related resource"
 msgstr "مصدر ذو صلة"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:161
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:169
 msgid "Permalink"
 msgstr "رابط دائم"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:173
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:181
 #: rero_ils/templates/rero_ils/_editor_button_actions.html:22
 msgid "JSON"
 msgstr "JSON"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:181
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:189
 msgid "Access"
 msgstr "الدخول"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:196
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:204
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:74
 msgid "Online"
 msgstr "مباشر"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:253
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:261
 msgid "items"
 msgstr "النسخ"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:253
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:261
 msgid "item"
 msgstr "النسخة"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:323
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "طلب"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:328
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "اختيار مكان الإستلام"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:355
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:363
 msgid "Export Formats"
 msgstr "تنسيقات التصدير"
 
@@ -6434,9 +6496,9 @@ msgid "circulation category URI"
 msgstr "URI نوع الاعارة"
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:42
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:45
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:48
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:44
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:47
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "مكان"
@@ -6467,35 +6529,35 @@ msgid "PID"
 msgstr "PID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:38
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:67
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:70
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:37
 msgid "Call number"
 msgstr "رقم استدعاء"
 
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:46
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 msgid "Circulation category"
 msgstr "نوع الاعارة"
 
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:48
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:75
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:51
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:53
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:76
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:55
 msgid "Availability"
 msgstr "الإتاحة"
 
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:60
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:63
 msgid "Items"
 msgstr "النسخ"
 
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:66
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:69
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:27
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:30
 msgid "ID"
 msgstr "ID"
 
-#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:68
+#: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:71
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:30
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
@@ -6791,9 +6853,13 @@ msgid ""
 "state"
 msgstr "اسم الإجراء الصريح الذي أدى إلى الانتقال إلى الحالة الحالية"
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "يوجد مكان مباشر آخر في هذه المكتبة"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7541,8 +7607,8 @@ msgid ""
 "Enter your email address below and we will send you a link to reset your "
 "password."
 msgstr ""
-"أدخل عنوان بريدك الإلكتروني أدناه وسنرسل لك رابطًا لإعادة تعيين كلمة المرور "
-"الخاصة بك"
+"أدخل عنوان بريدك الإلكتروني أدناه وسنرسل لك رابطًا لإعادة تعيين كلمة "
+"المرور الخاصة بك"
 
 #: rero_ils/templates/rero_ils/forgot_password.html:37
 #: rero_ils/templates/rero_ils/login_user.html:30
@@ -7631,10 +7697,6 @@ msgstr "الفهرس الموحد"
 msgid "RERO ILS global"
 msgstr "RERO ILS global"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "البحث"
@@ -7651,6 +7713,10 @@ msgstr "جديد الى %(sitename)s؟"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "هل نسيت كلمة المرور؟"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format
@@ -7676,3 +7742,7 @@ msgstr "يتم حذف"
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "انقر هنا لإعادة تعيين كلمة المرور الخاصة بك"
+
+#~ msgid "Entire title without statement of responsibility."
+#~ msgstr "عنوان بأكمله دون بيان المسؤولية"
+

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: de\n"
@@ -28,84 +28,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Französisch"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Deutsch"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italienisch"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "Willkommen zu RERO ILS!"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "Dokumenttyp"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "Bibliothek"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "Autor"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "Autor"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "Autor"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "Autor"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "Sprache"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "Schlagwort"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "Status"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "Rollen"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "Budget"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "Quellen"
 
@@ -191,8 +191,8 @@ msgid "sound"
 msgstr "Ton"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "Film"
 
@@ -228,42 +228,42 @@ msgid "ui_language_it"
 msgstr "Italiano"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "Veröffentlichung"
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "Herstellung"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "Vertrieb"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "Entstehung"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "Ort"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "Datum"
 
@@ -347,10 +347,10 @@ msgid "Account ID"
 msgstr "Konto ID"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -427,10 +427,10 @@ msgstr "URI der Bibliothek"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -574,8 +574,8 @@ msgid "Choose a date"
 msgstr "Datum wählen"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "Anmerkung"
@@ -705,12 +705,12 @@ msgid "Rate"
 msgstr "Wechselkurs"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -997,20 +997,20 @@ msgstr "PID des Dokuments"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1065,11 +1065,11 @@ msgstr "Film"
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1097,52 +1097,54 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr "Verantwortlichkeitsangaben"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr "Verantwortlichkeitsangabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "Einheitstitel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
@@ -1151,101 +1153,101 @@ msgstr ""
 "Autoritätsdatei oder -liste kontrolliert und als zusätzlicher "
 "Sucheinstieg verwendet wird."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "Einheitstitel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "Ist Teil von"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "Titel der Reihe."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "Liste der Sprachen der Resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "Sprachen der Ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "Typ der Sprache."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "Übersetzt aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "Sprache, aus deren die Resource übersetzt wurde."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "Autoren"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 "Autor(en) der Ressource. Es können sowohl Personen als auch "
 "Körperschaften sein."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "Autor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "Person"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "Name der Person."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "Ref. MEF-Person"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1253,15 +1255,15 @@ msgstr ""
 "Informationen über die Geburt und den Tod einer Person. Hilfreich, um "
 "Menschen zu unterscheiden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "Qualifizierend"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1269,121 +1271,121 @@ msgstr ""
 "Informationen über die Person (z.B. ihren Beruf). Hilfreich, um Menschen "
 "zu unterscheiden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "Name der Körperschaft."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "Copyright-Daten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "Copyright-Datum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "Ausgabevermerke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "Ausgabevermerk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "Ausgabebezeichnungen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "Ausgabebezeichnung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "Veröffentlichung, Herstellung, Vertrieb, Entstehung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "Veröffentlichung, Herstellung, Vertrieb, Entstehung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "Orte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "Ort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "Typ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "Land"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "Kanton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "Angaben"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "Angabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 "Angabe zum Ort und Akteur von Veröffentlichung, Herstellung, Vertrieb, "
 "Entstehung."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "Akteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "Anmerkung."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "Veröffentlichungsdatum 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1394,13 +1396,13 @@ msgstr ""
 "wurde, kann im nächsten Feld ein frei gestaltetes Erscheinungsdatum "
 "hinzugefügt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "Veröffentlichungsdatum 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1411,23 +1413,23 @@ msgstr ""
 "wurde, kann im nächsten Feld ein frei gestaltetes Erscheinungsdatum "
 "hinzugefügt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "Umfang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "Umfang der Resource, z.B. Anzahl Seiten oder Bände"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "Andere Materialeigenschaften"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
@@ -1435,4988 +1437,4988 @@ msgstr ""
 "Andere Materialeigenschaften(z.B. Abbildungen, schwarz-weiss oder oder "
 "farbig)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "Formate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Format der Resource (z.B. Masse in cm)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "Zusätzliche Materialien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Begleitmaterial der Resource (z.B. Landkarten)."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "Reihe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "Reihe von der Resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "Titel der Reihe."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "Zählung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "Zählung der Resource innerhalb der Reihe."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "Anmerkung zur Resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "Abstrakts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "Abstrakt der Resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "Abstrakt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "Audioausgabennummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "Identifikator (Typ unbestimmt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "Lokaler Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "Audio matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "Musikvertriebsnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "Druckplattennummer für Noten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "Musik-Bestellnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "Verlagsnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "Videoaufzeichnungsnummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
 msgstr "Identifikatorwert"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
 msgid "Identifier value."
 msgstr "Identifikatorwert."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "Anmerkung zum Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "Erläuterung zum Identifikator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "Bezugsbedingung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "Bezugsbedingung der Resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "Herkunft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "Quelle des Identifikators."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "Status"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status des ISBN/ISSN Identifikators"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Der ISBN/ISSN-Status muss in der folgenden Liste ausgewählt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "Schlagworte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "Schlagwort der Resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "Schlagwort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informationen, die benötigt werden, um eine elektronische Resource zu "
 "finden und darauf zuzugreifen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
-msgid "Example: https://www.rero.ch/"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+msgid "Example: https://www.rero.ch/"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "Webseite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
 msgid "Is displayed next to the link, as additional information"
 msgstr ""
 "Uniform Resource Identifier (URI), der eine Standardsyntax für die "
 "Lokalisierung eines Objekts unter Verwendung vorhandener "
 "Internetprotokolle bereitstellt."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "Gesammelt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Dokument wird gesammelt oder nicht, deaktiviert Bearbeitung von Records"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "Sprachewert."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "Abchasisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "Achinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "Acholi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "Dangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "Adygeisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "Afroasiatische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "Albanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "Aleutisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "Algonkin Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "Südaltaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "Amharisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "Altenglisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "Apache Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "Reichsaramäisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "Aragonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "Armenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "Konstruierte Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "Assamesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "Athapaskische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "Australische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "Awarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "Aserbaidschanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "Banda Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "Bamileke Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "Baschkirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "Belutschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "Balinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "Basaa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "Baltische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "Bedscha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "Weissrussisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "Bengalisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "Berbersprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "Bikolano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "Edo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "Blackfoot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "Bantusprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "Braj-Bhakha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "Bretonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "Bataksprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "Burjatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "Buginesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "Bulgarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "Birmanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "Blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "Mesoamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "Karib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "Katalanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "Kaukasisch (anderes)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "Keltische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "Tschechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "Tschagataisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "Chinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "Chuukesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "Chinook Wawa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "Kirchenslawisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "Tschuwaschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "Chamische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "Montenegrinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "Kornisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "Korsisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "Englisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "Französisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "Portugiesisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "Krimtatarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "Kreol- und Pidginsprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "Kaschubisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "Kuschitische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "Tschechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "Dänisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "Darginisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "Land-Dayak-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "Delawarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "Dhivehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "Dravidische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "Niedersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "Mittelniederländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "Niederländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "Dioula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "Ägyptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "Elamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "Englisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "Mittelenglisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "Estnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "Färöisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "Fante"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "Fidschi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "Finnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "Finno-ugrische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "Französisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "Mittelfranzösisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "Altfranzösisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "Nordfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "Ostfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "Westfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "Fulfulde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "Germanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "Deutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "Geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "Kiribatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "Schottisch-gälisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "Irisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "Mittelhochdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "Althochdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "Gotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "Altgriechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "Griechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "Schweizerdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "Gwich'in (Sprache)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "Haitianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "Hawaiisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "Hebräisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "Otjiherero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "West-Paharisprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "Hethitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "Hmong-Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "Hiri-Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "Obersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "Ungarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "Hoopa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "Isländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "Ijo-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "Ilokano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "Indoarische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "Indogermanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "Inguschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "Iranische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "Irokesische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "Italienisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "Javanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "Japanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "Judäo-Persisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "Judäo-Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "Karakalpakisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "Jingpo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "Grönländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "Kikamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "Karenische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "Kaschmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "Kasachisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "Kabardinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "Khoisansprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "Khotanesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "Kirgisisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "Kikongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "Koreanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "Kosraeanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "Karatschai-balkarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "Kru-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "Kwanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "Kumykisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "Kurdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "Kutanaha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "Judenspanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "Laotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "Latein"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "Lettisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "Lesgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "Limburgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "Lingála"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "Litauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "Lomongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "Luxemburgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "Tschiluba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "Kiluba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "Chilunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "Luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "Mazedonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "Maduresisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "Magadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "Marschallesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "Makassar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "Manding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "Austronesische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "Maa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "Malaiisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "Mokschanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "Mittelirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "Míkmawísimk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "Minangkabauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "Verschiedene Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "Mon-Khmer-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "Maltesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "Mandschurisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "Meithei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "Manobo Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "Mongolisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "Mòoré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "Mehrsprachig"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "Munda-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "Muskogee-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "Mirandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "Maya Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "Ersjanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "Nordamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "Neapolitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "Nauruisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "Süd-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "Nord-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "Niederdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "Niger-Kongo-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "Niueanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "Nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "Bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "Nogaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "Altnordisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "Norwegisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "Nord-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "Nubische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "Klassisches Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "Chichewa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "Nyamwesi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "Runyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "Runyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "Nzema"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "Okzitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "Ojibwe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "Osmanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "Oto-Pame-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "Papuasprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "Pangasinensisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "Mittelpersisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "Kapampangan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "Papiamentu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "Palauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "Altpersisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "Persisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "Philippinische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "Phönizisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "Polnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "Pohnpeanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "Portugiesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "Altokzitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "Paschtunisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "Rarotonganisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "Romanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "Bündnerromanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "Rumänisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "Aromunisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "Sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "Jakutisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "Südamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "Salish-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "Samaritanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "Sizilianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "Scots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "Selkupisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "Semitische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "Altirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "Gebärdensprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "Sidama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "Singhalesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "Sioux-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "Sinotibetische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "Slawische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "Slowakisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "Slowenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "Südsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "Nordsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "Samische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "Lulesamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "Inarisamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "Samoanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "Skoltsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "Somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "Songhai-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "Sesotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "Spanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "Sardisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "Serbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "Nilosaharanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "Sundanesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "Susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "Sumerisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "Suaheli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "Schwedisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "Nordost-Neuaramäisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "Tahitianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "Tai-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "Tatarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "Temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "Terena"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "Tadschikisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "Tibetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "Tokelauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "Klingonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "Tuareg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "Tongaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "Setswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "Xitsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "Turkmenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "Tupí-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "Türkisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "Altaische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "Tuvaluisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "Tuwinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "Udmurtisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "Ugaritisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "Uigurisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "Ukrainisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "Unbekannte Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "Usbekisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "Tshivenda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "Vietnamesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "Wotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "Wakash-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "Wáray-Wáray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "Washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "Walisisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "Sorbische Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "Wallonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "Kalmückisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "Yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "Yapesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "Yupik-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "Zapotekisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "Bliss-Symbole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "Zande-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "Zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "Keine Sprachinhalte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "Zazaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "Werte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "Wert"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "Albanien (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "Ashmore und Cartierinseln (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "Australisches Hauptstadtterritorium (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "Algerien (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "Argentinien (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "Armenien (Republik) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "Armenische Sozialistische Sowjetrepublik (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "Aserbaidschan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "Aserbaidschanische Sozialistische Sowjetrepublik (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "Antigua und Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "Amerikanisch-Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "Australien (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "Österreich (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "Antarktis (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "Bahrain (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "Britisch-Kolumbien (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "Belgien (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "Bangladesch (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "Britisches Territorium im Indischen Ozean (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "Brasilien (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "Bermudainseln (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "Bosnien und Herzegowina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "Bolivien (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "Salomonen (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "Botsuana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "Bulgarien (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "Bouvetinsel (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "Weißrussland (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "Weißrussische Sozialistische Sowjetrepublik (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "Karibische Niederlande (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "Kalifornien (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "Kambodscha (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "Tschad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "Kongo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "Kongo (Demokratische Republik) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "China (Republik: 1949- ) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "Kroatien (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "Kaimaninseln (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "Kolumbien (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "Kamerun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "Kanada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "Kanton und Enderbury-Inseln (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "Komoren (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "Tschechoslowakei (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "Kuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "Kap Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "Cookinseln (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "Zentralafrikanische Republik (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "Zypern (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "Panamakanalzone (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "Dänemark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "Dominikanische Republik (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "Äquatorialguinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "Osttimor (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "England (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "Estland (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "Estnische Sozialistische Sowjetrepublik (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "Äthiopien (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "Färöer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "Französisch-Guayana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "Finnland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "Fidschi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "Falklandinseln (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "Mikronesien (Föderierten Staaten) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "Französisch-Polynesien (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "Frankreich (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "Französische Süd- und Antarktisgebiete (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "Dschibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "OstDeutschland (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "Grönland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "Gilbert- und Elliceinseln (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "Gabun (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "Griechenland (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "Georgien (Republik) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "Georgische Sozialistische Sowjetrepublik (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "Deutschland (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "Gazastreifen (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "Sonderverwaltungsregion Hongkong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "Heard und McDonald-Inseln (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "Ungarn (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "Island (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "Irland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "Indien (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "Insel Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "Indonesien (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "Italien (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "Israel-Syrien Entmilitarisierte Zonen (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "Elfenbeinküste (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "Israelisch-jordanische entmilitarisierte Zonen (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "Irak-Saudi-Arabien Neutrale Zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "Johnston-Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "Jamaika (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "Jordanien (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "Kirgisistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "Kirgisische Sozialistische Sowjetrepublik (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "Nordkorea (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "Südkorea (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "Kasachstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "Kasachische Sozialistische Sowjetrepublik (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "Libanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "Litauen (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "Litauen (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "Zentrale und südliche Linieninseln (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "Luxemburg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "Lettland (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "Lettland (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "Libyen (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "Madagaskar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "Sonderverwaltungsregion Macau (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "Mongolei (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "Marokko (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "Mauretanien (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "Republik Moldau (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "Moldauische Sozialistische Sowjetrepublik (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "Mexiko (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "Mosambik (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "Niederländische Antillen (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "Niederlande (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "Neufundland und Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "Nordirland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "Neubraunschweig (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "Neukaledonien (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "Nördliche Marianen (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "Norwegen (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "Neuschottland (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "Nordwest-Territorien (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "Nördliche Marianen (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "Norfolkinsel (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "New York (Staat) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "Neuseeland (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "Insel Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "Paracel-Inseln (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "Philippinen (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "Prinz-Edward-Insel (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "Polen (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "Papua-Neuguinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "Portugiesisch-Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "Katar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "Quebec (Provinz) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "Serbien (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "Simbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "Rumänien (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "Russland (Föderation) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "Russische Sozialistische Föderative Sowjetrepublik (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr "Ryūkyū-Inseln (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "Südafrika (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "Spitzbergen (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "Südsudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "Seychellen (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "São Tomé und Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "Spanisch Nordafrika (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "Singapur (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "Sankt Martin (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "Spanien (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "Westsahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "St. Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "Schottland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "Saudi-Arabien (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "Schwaneninseln (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "Schweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "Syrien (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "Schweiz (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "Tadschikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "Tadschikische Sozialistische Sowjetrepublik (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "Turks- und Caicosinseln (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "Tunesien (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "Turkmenische Sozialistische Sowjetrepublik (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "Tasmanien (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "Trinidad und Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "Vereinigte Arabische Emirate (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "Treuhand-Territorium der Pazifischen Inseln (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "Türkei (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "Tansania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "Ägypten (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "Vereinigte Staaten Diverses Karibische Inseln (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "Vereinigtes Königreich Diverses Inseln (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "Vereinigtes Königreich Diverses Inseln (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "Vereinigtes Königreich (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "Vereinigte Staaten Diverses Pazifische Inseln (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "Sowjetunion (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "Vereinigte Staaten (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "Usbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "Usbekische Sozialistische Sowjetrepublik (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "Britische Jungferninseln (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "Vatikanstadt (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "Amerikanische Jungferninseln (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "Vietnam, Norden (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "Verschiedene Orte (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "Vietnam, Süden (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "Washington (Staat) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "Westberlin (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "Westaustralien (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "Wallis und Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "Westjordanland (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "Wake (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "Weihnachtsinsel (Indischer Ozean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "Kokosinseln (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "Malediven (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "St. Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "Marshallinseln (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "Midway-Inseln (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "Korallenmeer-Insel-Territorium (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "St. Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "Heilige Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "St. Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "St. Pierre und Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "St. Vincent und die Grenadinen (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "Nordmazedonien (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "Neusüdwales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "Slowakei (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "Nordterritorium (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "Spratly-Insel (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "Tschechien (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "Südaustralien (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "Südgeorgien und die Südlichen Sandwichinseln (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "Slowenien (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "Kein Ort, unbekannt oder unbestimmt (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "Kanada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "Vereinigtes Königreich (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "Sowjetunion (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "Vereinigte Staaten (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "Jemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "Yukon-Territorium (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "Jemen (Demokratische Volksrepublik) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "Serbien und Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "Sambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Kantone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "AG (Aargau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "AI (Appenzell Innerrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "AR (Appenzell Ausserrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "BE (Bern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "BL (Basel-Landschaft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "BS (Basel-Stadt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "FR (Freiburg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "GE (Genf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "GL (Glarus)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "GR (Graubünden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "LU (Luzern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "NE (Neuenburg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "SG (St. Gallen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "SH (Schaffhausen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "SO (Solothurn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "TG (Thurgau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "TI (Tessin)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "VD (Waadt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "VS (Wallis)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "ZH (Zürich)"
 
@@ -6880,9 +6882,13 @@ msgstr ""
 "Der Name der expliziten Aktion, die die Transition zum aktuellen Zustand "
 "ausgelöst hat."
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "Ein anderer Online-Standort existiert bereits für diese Bibliothek"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7718,10 +7724,6 @@ msgstr "Gesamtkatalog"
 msgid "RERO ILS global"
 msgstr "RERO ILS global"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "Suche"
@@ -7738,6 +7740,10 @@ msgstr "Neu bei %(sitename)s?"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for rero-ils.
+# English translations for rero-ils.
 # Copyright (C) 2020 RERO
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
@@ -13,100 +13,99 @@
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # Bertrand Zuchuat, 2020
 # iGor milhit <igor.milhit@rero.ch>, 2020
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
+"Language: en\n"
 "Language-Team: English (https://www.transifex.com/rero/teams/77935/en/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Language: en\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "French"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "German"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italian"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "Welcome to RERO-ILS!"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "document type"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "Organisation"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "library"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "author"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "author"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "author"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "author"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "language"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "subject"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "roles"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "sources"
 
@@ -192,8 +191,8 @@ msgid "sound"
 msgstr "sound"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "video"
 
@@ -229,42 +228,42 @@ msgid "ui_language_it"
 msgstr "Italiano"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "Publication"
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "Manufacture"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "Distribution"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "Production"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "Place"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "Date"
 
@@ -348,10 +347,10 @@ msgid "Account ID"
 msgstr "Account ID"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -428,10 +427,10 @@ msgstr "Library URI"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -575,8 +574,8 @@ msgid "Choose a date"
 msgstr "Select a date"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "Notes"
@@ -706,12 +705,12 @@ msgid "Rate"
 msgstr "Rate"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -900,8 +899,7 @@ msgid "Number of days after due date"
 msgstr "Number of days after due date"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:77
-msgid ""
-"Number of days after due date for sending the first overdue notification."
+msgid "Number of days after due date for sending the first overdue notification."
 msgstr "Number of days after due date for sending the first reminder."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:83
@@ -997,20 +995,20 @@ msgstr "Document PID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1065,11 +1063,11 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1097,52 +1095,54 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr "Statements of responsibility"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr "Statement of responsibility"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "Uniform title"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
@@ -1150,99 +1150,99 @@ msgstr ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "Uniform title"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "Is part of"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "Title of the host document."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "Languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "List of languages for the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "Language"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "Languages for the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "Type of the language."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "language"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "Translated from"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "Language from which a resource is translated."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "Authors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Author(s) of the resource. Can be either persons or organisations."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "Author"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "Person"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "Person's name."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "MEF person reference"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1250,15 +1250,15 @@ msgstr ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "Qualifier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1266,161 +1266,161 @@ msgstr ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "Organisation's name."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "Copyright dates"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "Copyright Date"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "Edition statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "Edition statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "Designations of edition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "Designation of edition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "Publication, manufacture, distribution, production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "Publication, manufacture, distribution, production"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "Places"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "Place"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "Country"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "Canton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "Statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "Statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr "Statement of place and agent."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "Agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "Note."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "Date of publication 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
-"Start date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Start date of the publication. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 msgstr ""
-"Start date of the publication 1. This must be an integer, ie 1989, 453, -50."
-" Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Start date of the publication 1. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "Date of publication 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Used to sort search results. Once this field is set, a free formed date "
+"of publication can be added in the next field."
 msgstr ""
-"End date of the publication 2. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"End date of the publication 2. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "Extent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "Extent of the resource, ie number of pages or volumes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "Other Material Characteristics"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
@@ -1428,4983 +1428,4983 @@ msgstr ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "Formats"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Format of the resource, ie dimensions in cm."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "Additional materials"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Accompanying material of the resource, ie maps."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "Series"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "Series to which belongs the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "Title of the series."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "Numbering"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "Numbering of the resource within the series."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "Note on the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "Abstracts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "Abstract of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "Abstract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "Identifier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "Identifier (type undefined)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "Local identifier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "Audio matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "Plate number for notated music"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "Publisher’s number for notated music"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "Publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
 msgstr "Identifier value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
 msgid "Identifier value."
 msgstr "Identifier value."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "Note of the identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "Qualifier of the identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "Acquisition terms"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "Acquisition terms of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "Source"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "Source of the identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "Status"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status of the ISBN/ISSN identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "ISBN/ISSN status should be selected in the list below."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "Subjects"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "Subject of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "Subject"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr "Uniform Resource Locators"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Information needed to locate and access an electronic resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr "Uniform Resource Locator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
 msgstr "Record a unique URL here."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
 msgid "Example: https://www.rero.ch/"
 msgstr "Example: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr "Type of link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr "resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr "version of resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr "related resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr "hidden URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr "no info"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr "Content type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr "Is displayed as the text of the link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr "poster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr "audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr "postcard"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr "addition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr "debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr "exhibition documentation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr "erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr "bookplate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr "extract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr "educational sheet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr "illustrations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr "cover image"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr "delivery information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr "biographical information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr "introduction/preface"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr "class reading"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr "teacher's kit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr "publisher's note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr "note on content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr "title page"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr "photography"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr "summarization"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr "online resource via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr "press review"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "web site"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr "table of contents"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr "full text"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
 msgstr "Public note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
 msgid "Is displayed next to the link, as additional information"
 msgstr "Is displayed next to the link, as additional information."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr "Example: Access only from the library"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "Harvested"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Document is harvested or not, will disable record edition or similar."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "Language value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "Abkhazian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "Achinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "Acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "Adyghe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "Afroasiatic (other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "Afrihili (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "Akkadian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "Albanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "Aleut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "Algonquian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "Altai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "Amharic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "English, Old (ca. 450-1100)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "Apache languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "Arabic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "Aramaic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "Aragonese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "Armenian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "Mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "Artificial (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "Assamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "Bable"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "Athapascan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "Australian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "Avaric"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "Avestan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "Azerbaijani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "Banda languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "Bamileke languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "Bashkir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "Baluchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "Balinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "Basque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "Basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "Baltic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "Beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "Belarusian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "Bengali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "Berber (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "Bihari (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "Edo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "Bantu (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "Bosnian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "Braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "Breton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "Batak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "Buriat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "Bugis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "Bulgarian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "Burmese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "Bilin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "Central American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "Carib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "Catalan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "Caucasian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "Celtic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "Chechen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "Chinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "Chuukese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "Chinook jargon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "Church Slavic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "Chuvash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "Chamic languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "Montenegrin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "Coptic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "Corsican"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "Creoles and Pidgins, English-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "Creoles and Pidgins, French-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "Creoles and Pidgins, Portuguese-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "Crimean Tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "Creoles and Pidgins (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "Kashubian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "Cushitic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "Czech"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "Danish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "Dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "Delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "Divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "Dravidian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "Lower Sorbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "Dutch, Middle (ca. 1050-1350)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "Dutch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "Egyptian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "Elamite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "English"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "English, Middle (1100-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "Estonian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "Faroese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "Fijian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "Finnish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "Finno-Ugrian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "French"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "French, Middle (ca. 1300-1600)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "French, Old (ca. 842-1300)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "North Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "East Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "Fula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "Gã"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "Germanic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "Georgian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "Ethiopic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "Gilbertese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "Scottish Gaelic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "Irish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "Galician"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "German, Middle High (ca. 1050-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "German, Old High (ca. 750-1050)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "Gothic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "Greek, Ancient (to 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "Greek, Modern (1453- )"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "Swiss German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "Gwich'in"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "Haitian French Creole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "Hawaiian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "Hebrew"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "Herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "Western Pahari languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "Hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "Croatian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "Upper Sorbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "Hungarian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "Icelandic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "Sichuan Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "Ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "Interlingua (International Auxiliary Language Association)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "Indic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "Indonesian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "Indo-European (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "Ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "Iranian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "Iroquoian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "Javanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "Lojban (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "Japanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "Judeo-Persian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "Judeo-Arabic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "Kara-Kalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "Kabyle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "Kalâtdlisut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "Karen languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "Kashmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "Kazakh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "Kabardian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "Khoisan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "Khotanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "Kyrgyz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "Korean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "Kosraean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "Karachay-Balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "Karelian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "Kru (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "Kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "Kurdish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "Kootenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "Lahndā"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "Lamba (Zambia and Congo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "Lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "Latin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "Latvian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "Lezgian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "Limburgish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "Lithuanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "Mongo-Nkundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "Luxembourgish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "Ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "Luo (Kenya and Tanzania)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "Lushai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "Macedonian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "Madurese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "Marshallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "Makasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "Austronesian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "Maasai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "Malay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "Moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "Irish, Middle (ca. 1100-1550)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "Micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "Miscellaneous languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "Mon-Khmer (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "Maltese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "Manchu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "Manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "Manobo languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "Mongolian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "Mooré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "Multiple languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "Munda (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "Creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "Mirandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "Mayan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "Erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "North American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "Neapolitan Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "Nauru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "Ndebele (South Africa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "Ndebele (Zimbabwe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "Low German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "Niger-Kordofanian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "Niuean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "Norwegian (Nynorsk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "Norwegian (Bokmål)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "Old Norse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "Norwegian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "N'Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "Northern Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "Nubian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "Newari, Old"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "Occitan (post-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "Ossetic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "Turkish, Ottoman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "Otomian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "Papuan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "Papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "paluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "Old Persian (ca. 600-400 B.C.)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "Persian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "Philippine (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "Phoenician"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "Polish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "Pohnpeian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "Portuguese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "Prakrit languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "Provençal (to 1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "Pushto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "Romance (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "Raeto-Romance"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "Romanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "Rundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "Aromanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "Russian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "Sango (Ubangi Creole)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "Yakut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "South American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "Salishan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "Samaritan Aramaic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "Sicilian Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "Scots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "Selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "Semitic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "Irish, Old (to 1100)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "Sign languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "Sinhalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "Siouan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "Sino-Tibetan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "Slavic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "Slovak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "Slovenian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "Southern Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "Northern Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "Lule Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "Inari Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "Samoan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "Skolt Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "Sogdian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "Somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "Songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "Spanish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "Sardinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "Sranan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "Serbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "Nilo-Saharan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "Sundanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "Susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "Sumerian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "Swedish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "Syriac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "Syriac, Modern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "Tahitian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "Tai (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "Tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "Temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "Terena"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "Tajik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "Tibetan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "Tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "Tokelauan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "Klingon (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "Tonga (Nyasa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "Tongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "Turkmen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "Tupi languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "Turkish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "Altaic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "Tuvaluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "Tuvinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "Udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "Ugaritic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "Uighur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "Ukrainian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "Undetermined"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "Uzbek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "Venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "Vietnamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "Votic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "Wakashan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "Wolayta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "Waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "Washoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "Sorbian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "Walloon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "Oirat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "Yao (Africa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "Yapese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "Yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "Yupik languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "Blissymbolics"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "Zande languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "No linguistic content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "Zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "Values"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "Ashmore and Cartier Islands (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "Australian Capital Territory (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "Algeria (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "Armenia (Republic) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "Armenian S.S.R. (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "Azerbaijan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "Azerbaijan S.S.R. (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "Antigua and Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "American Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "Antarctica (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "Bahrain (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "British Columbia (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "Belgium (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "British Indian Ocean Territory (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "Brazil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "Bermuda Islands (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "Bosnia and Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "Solomon Islands (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "Bouvet Island (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "Belarus (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "Byelorussian S.S.R. (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "Caribbean Netherlands (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "California (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "Cambodia (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "Chad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "Congo (Democratic Republic) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "China (Republic : 1949- ) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "Croatia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "Cayman Islands (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "Cameroon (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "Canton and Enderbury Islands (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "Comoros (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "Czechoslovakia (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "Cabo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "Cook Islands (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "Central African Republic (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "Cyprus (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "Canal Zone (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "Denmark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "Dominican Republic (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "Equatorial Guinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "Timor-Leste (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "England (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "Estonia (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "Ethiopia (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "Faroe Islands (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "French Guiana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "Finland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "Fiji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "Falkland Islands (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "Micronesia (Federated States) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "French Polynesia (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "France (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "Germany (East) (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "Greenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "Gilbert and Ellice Islands (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "Greece (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "Georgia (Republic) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "Georgian S.S.R. (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "Germany (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "Gaza Strip (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "Heard and McDonald Islands (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "Hungary (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "Iceland (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "Ireland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "Isle of Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "Iraq (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "Italy (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "Israel-Syria Demilitarized Zones (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "Côte d'Ivoire (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "Israel-Jordan Demilitarized Zones (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "Iraq-Saudi Arabia Neutral Zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "Johnston Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "Jordan (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "Kyrgyzstan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "Kirghiz S.S.R. (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "Korea (North) (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "Korea (South) (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "Kazakhstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "Kazakh S.S.R. (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "Lebanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "Lithuania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "Lithuania (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "Central and Southern Line Islands (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "Luxembourg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "Latvia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "Latvia (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "Libya (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "Morocco (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "Moldova (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "Moldavian S.S.R. (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "Mexico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "Netherlands Antilles (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "Netherlands (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "Northern Ireland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "New Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "New Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "Northern Mariana Islands (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "Norway (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "Nova Scotia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "Northwest Territories (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "Northern Mariana Islands (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "Norfolk Island (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "New York (State) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "New Zealand (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "Pitcairn Island (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "Paracel Islands (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "Philippines (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "Prince Edward Island (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "Poland (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "Papua New Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "Portuguese Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "Romania (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "Russia (Federation) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "Russian S.F.S.R. (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr "Ryukyu Islands, Southern (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "South Africa (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "South Sudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "Sao Tome and Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "Spanish North Africa (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "Spain (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "Western Sahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "Scotland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "Saudi Arabia (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "Swan Islands (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "Sweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "Syria (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "Switzerland (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "Tajikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "Tajik S.S.R. (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "Turks and Caicos Islands (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "Tunisia (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "Turkmen S.S.R. (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "Trinidad and Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "United Arab Emirates (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "Trust Territory of the Pacific Islands (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "Turkey (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "Egypt (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "United States Misc. Caribbean Islands (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "United Kingdom Misc. Islands (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "United Kingdom Misc. Islands (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "United Kingdom (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "United States Misc. Pacific Islands (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "Soviet Union (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "United States (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "Uzbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "Uzbek S.S.R. (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "British Virgin Islands (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "Vatican City (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "Virgin Islands of the United States (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "Vietnam, North (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "Various places (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "Vietnam, South (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "Washington (State) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "West Berlin (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "Western Australia (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "Wallis and Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "West Bank of the Jordan River (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "Wake Island (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "Christmas Island (Indian Ocean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "Cocos (Keeling) Islands (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "Maldives (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "Saint Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "Marshall Islands (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "Midway Islands (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "Coral Sea Islands Territory (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "Saint Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "Saint Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "Saint Pierre and Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "Saint Vincent and the Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "North Macedonia (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "New South Wales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "Slovakia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "Northern Territory (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "Spratly Island (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "Czech Republic (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "South Australia (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "South Georgia and the South Sandwich Islands (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "Slovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "No place, unknown, or undetermined (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "United Kingdom (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "Soviet Union (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "United States (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "Yukon Territory (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "Yemen (People's Democratic Republic) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "Serbia and Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "AG (Aargau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "AI (Appenzell Innerrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "AR (Appenzell Ausserrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "BE (Bern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "BL (Basel-Country)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "BS (Basel-City)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "FR (Fribourg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "GE (Geneva)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "GL (Glarus)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "GR (Grisons)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "LU (Lucerne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "SG (St. Gallen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "SH (Shaffhouse)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "SO (Solothurn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "TG (Thurgau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "TI (Ticino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "ZH (Zurich)"
 
@@ -6867,9 +6867,13 @@ msgstr ""
 "The name of the explicit action that triggered the transition to current "
 "state"
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "Another online location exists in this library"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7705,10 +7709,6 @@ msgstr "Union catalogue"
 msgid "RERO ILS global"
 msgstr "RERO ILS global"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "Search"
@@ -7725,6 +7725,10 @@ msgstr "New to %(sitename)s?"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "Forgot password?"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format
@@ -7750,3 +7754,4 @@ msgstr "has been deleted."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Click here to reset your password"
+

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for rero-ils.
+# Spanish translations for rero-ils.
 # Copyright (C) 2020 RERO
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
@@ -8,100 +8,99 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020
 # bibsys UCL <bibsys@uclouvain.be>, 2020
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
+"Language: es\n"
 "Language-Team: Spanish (https://www.transifex.com/rero/teams/77935/es/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Francés"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Alemán"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italiano"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "RERO-ILS"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "¡Bienvenido en RERO-ILS!"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "Tipo de documento"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "organización"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "Autores"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "Autores"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "Autores"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "Autores"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "idioma"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "sujeto"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "estado"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "funcciones"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "presupuesto"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "fuentes"
 
@@ -187,8 +186,8 @@ msgid "sound"
 msgstr "sonido"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "video"
 
@@ -224,42 +223,42 @@ msgid "ui_language_it"
 msgstr "Italiano"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "Publicación"
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "Fabricación"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "Distribución"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "Producción"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "bf:Place"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "Fecha"
 
@@ -343,10 +342,10 @@ msgid "Account ID"
 msgstr "Mi cuenta"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -423,10 +422,10 @@ msgstr "URI de la biblioteca"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -570,8 +569,8 @@ msgid "Choose a date"
 msgstr "Elija una fecha"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "Notas"
@@ -701,12 +700,12 @@ msgid "Rate"
 msgstr "Tasa"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -889,16 +888,15 @@ msgstr "Nombre de días antes de la fecha de vencimiento."
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:70
 msgid "Number of days before due date for sending the due_soon notification."
 msgstr ""
-"Nombre de días antes de la fecha de vencimiento para poder enviar el aviso "
-"de cortesía."
+"Nombre de días antes de la fecha de vencimiento para poder enviar el "
+"aviso de cortesía."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:76
 msgid "Number of days after due date"
 msgstr "Nombre de días después de la fecha de vencimiento."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:77
-msgid ""
-"Number of days after due date for sending the first overdue notification."
+msgid "Number of days after due date for sending the first overdue notification."
 msgstr ""
 "Nombre de días después de la fecha de vencimiento para enviar un primer "
 "aviso."
@@ -996,20 +994,20 @@ msgstr "PID del documento"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1064,11 +1062,11 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1096,153 +1094,155 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr "Responsabilidades"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr "Responsabilidad"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "Títulos propios"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
-"Título uniforme, un título relacionado o analítico que es controlado por una"
-" lista o un fichero de autoridad, utilizado como un punto de acceso "
+"Título uniforme, un título relacionado o analítico que es controlado por "
+"una lista o un fichero de autoridad, utilizado como un punto de acceso "
 "adicional."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "Título propio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "Forma parte de"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "Título del documento anfitrión."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "Idiomas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "Lista de idiomas para el recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "Idiomas del recurso."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "Tipo de idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "Idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "Traducido de"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "Idioma desde el que se traduce un recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "Autores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Autor(es) de un recurso. Puede ser una persona o una organización."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "Autores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "Persona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "Nombre de la persona."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "Referencia de persona MEF"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1250,15 +1250,15 @@ msgstr ""
 "Informaciones sobre las fechas del nacimiento y del fallecimiento de una "
 "persona. Útil para desambiguar una persona."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "Calificador"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1266,5150 +1266,5149 @@ msgstr ""
 "Informaciones sobre la persona, por ejemplo, su profesión. Útil para "
 "desambiguar las personas."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "Nombre de la organización."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "Fechas de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "Fecha de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "Menciones de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "Mención de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "Designaciones de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "Designación de edición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "Producción, publicación, difusión, distribución, fabricación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "Producción, publicación, difusión, distribución, fabricación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "Lugares"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "Lugar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "tipo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "País"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "Municipio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "Menciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "Mención"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr "Mención"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "Agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "Nota."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "Fecha de publicación 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
-"Start date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Start date of the publication. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 msgstr ""
-"Fecha de publicación 1. Debe ser un número entero, es decir, 1989, 453, -50."
-" Se utiliza para ordenar los resultados de la búsqueda. Una vez establecido "
-"este campo, se puede añadir una fecha de publicación de forma libre en el "
-"siguiente campo."
+"Fecha de publicación 1. Debe ser un número entero, es decir, 1989, 453, "
+"-50. Se utiliza para ordenar los resultados de la búsqueda. Una vez "
+"establecido este campo, se puede añadir una fecha de publicación de forma"
+" libre en el siguiente campo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "Fecha de publicación 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Used to sort search results. Once this field is set, a free formed date "
+"of publication can be added in the next field."
 msgstr ""
-"Fecha de publicación 2. Debe ser un número entero, es decir, 1989, 453, -50."
-" Se utiliza para ordenar los resultados de la búsqueda. Una vez establecido "
-"este campo, se puede añadir una fecha de publicación de forma libre en el "
-"siguiente campo."
+"Fecha de publicación 2. Debe ser un número entero, es decir, 1989, 453, "
+"-50. Se utiliza para ordenar los resultados de la búsqueda. Una vez "
+"establecido este campo, se puede añadir una fecha de publicación de forma"
+" libre en el siguiente campo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "Importancia material"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "Importancia material, por ejemplo el número de páginas o volúmenes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "Otras características del material"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr ""
-"Otras características del material, por ejemplo las ilustraciones, negro y "
-"blanco ..."
+"Otras características del material, por ejemplo las ilustraciones, negro "
+"y blanco ..."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "Formatos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Formato del recurso, por ejemplo las dimensiones en cm."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "Materiales adicionales"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Material de acompañamiento del recurso, por ejemplo, mapas."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "Series"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "Serie a la que pertenece el recurso."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "Título de la serie."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "Numeración"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "Numeración del recurso dentro de la serie."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "Nota sobre el recurso."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "Resumenes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "Resumen del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "Resumen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "Identificador"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "Número de edicíon del audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "GTN-14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "Identificador (tipo no especificado)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "Identificador local"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "Matrix Number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "Número del distribuidor de música"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "Número de placa de la música"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "Número del editor para la música anotada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "Número del editor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "Número de grabación de video"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
-msgstr "Valor del identificador"
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
-msgid "Identifier value."
 msgstr "Valor del identificador"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+msgid "Identifier value."
+msgstr "Valor del identificador"
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "Nota sobre el identificador."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "Calificador del identificador."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "Términos de adquisición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "Términos de adquisición del recurso."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "Fuente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "Fuente del identificador."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "Estado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Estado del identificador ISBN/ISSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 "El estado del ISBN/ISSN tiene que ser seleccionado en la lista a "
 "continuación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "Sujetos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "Sujeto del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "Sujeto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr "Enlaces URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
-msgstr ""
-"Información necesaria para localizar y acceder a un recurso electrónico."
+msgstr "Información necesaria para localizar y acceder a un recurso electrónico."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr "Enlace URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr "url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
 msgstr "Registra una URL única aquí."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
 msgid "Example: https://www.rero.ch/"
 msgstr "Ejemplo: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr "Tipo de enlace"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr "recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr "versión del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr "recurso relacionado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr "Url oculto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr "no hay información"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr "Se muestra como el texto del enlace"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr "póster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr "audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr "postal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr "adición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr "informe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr "documentación de la exposición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr "erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr "placa de libro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr "extracto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr "hoja educativa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr "ilustraciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr "imagen de portada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr "información sobre la entrega"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr "información biográfica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr "introducción/prefacio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr "lectura continuada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr "paquete educativo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr "nota del editor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr "nota sobre el contenido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr "página de título "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr "fotografía"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr "resumen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr "recurso en línea a través de RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr "revista de prensa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "sitio web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr "tabla de contenidos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr "texto completo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
 msgstr "Nota pública URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
 msgid "Is displayed next to the link, as additional information"
 msgstr "Se muestra junto al enlace, como información adicional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr "Ejemplo: Acceso sólo desde la biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "Importado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "El documento importado o no, no permitirá la edición de noticia."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "Valor del idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "abjasio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "acehnés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "adigué"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "lenguas afroasiáticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "afrikáans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "acadio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "albanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "aleutiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "lenguas algonquinas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "altái meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "amárico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "inglés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "lenguas apaches"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "árabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "arameo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "aragonés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "armenio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "idiomas artificiales"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "arahuaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "asamés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "idiomas Athapaskan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "idiomas australianos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "avar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "avéstico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "avadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "aimara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "azerbaiyano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "idiomas de la banda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "lenguas bamileké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "baskir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "baluchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "balinés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "vasco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "basaa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "lenguas bálticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "bielorruso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "bengalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "lenguas bereberes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "bhoyapurí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "bicol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "lenguas bantúes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "bosnio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "bretón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "lenguas Batak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "buriato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "buginés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "búlgaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "birmano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "lenguas indígenas centroamericanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "caribe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "catalán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "lenguas celtas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "checheno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "chagatái"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "chino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "trukés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "marí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "jerga chinuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "cheroqui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "eslavo eclesiástico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "chuvasio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "cheyene"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "idioma Cham"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "copto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "córnico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "corso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "criollos y pidgins basados en el inglés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "criollos y pidgins basados en el francés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "criollos y pidgins basados en portugués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "tártaro de Crimea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "criollos y pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "casubio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "lenguajes couchiticos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "checo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "danés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "dargva"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "idiomas Land Dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "slave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "lenguas dravidianas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "bajo sorbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "neerlandés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "holandés, flamenco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "diula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "egipcio antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "elamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "inglés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "inglés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "estonio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "ewé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "feroés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "fiyiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "finés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "lenguas fino-úgricas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "francés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "francés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "francés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "frisón septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "frisón oriental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "frisón occidental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "fula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "friulano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "lenguas germánicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "alemán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "gilbertés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "gaélico escocés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "irlandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "gallego"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "manés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "alto alemán medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "alto alemán antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "gótico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "griego antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "griego moderno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "alemán suizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "guyaratí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "kutchin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "criollo haitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "hebreo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "hitita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "croata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "alto sorbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "húngaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "islandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "yi de Sichuán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "lenguas indoarias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "indonesio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "lenguas indoeuropeas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "lenguas iraníes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "lenguas iroquesas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "italiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "javanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "japonés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "judeo-persa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "judeo-árabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "karakalpako"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "cabila"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "groenlandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "canarés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "lenguas karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "cachemiro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "kazajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "kabardiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "idiomas khoisan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "jemer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "kotanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "kirguís"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "konkaní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "coreano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "kosraeano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "karachay-balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "carelio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "lenguas krou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "kurdo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "latín"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "letón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "lezgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "limburgués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "lituano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "luxemburgués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "macedonia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "madurés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "marshalés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "macasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "māori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "idiomas austronesios"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "maratí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "masái"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "malayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "irlandés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "idiomas no codificados"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "lenguas mon-Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "maltés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "manchú"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "lenguas manobo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "mongol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "varios idiomas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "lenguas funda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "mirandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "lenguas mayas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "náhuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "lenguas indígenas norteamericanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "napolitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "nauruano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "ndebele meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "ndebele septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "bajo alemán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "nepalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "lenguas nigerianas y congolesas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "niueano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "noruego nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "noruego bokmal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "nórdico antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "noruego"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "sotho septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "lenguas nubias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "newari clásico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "occitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "osético"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "turco otomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "idioma otomí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "lenguas papúes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "pangasinán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "panyabí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "persa antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "persa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "lenguas filipinas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "polaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "pohnpeiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "portugués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "prácrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "provenzal antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "pastún"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "rarotongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "lenguas románicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "romanche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "romaní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "rumano, moldavo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "arrumano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "ruso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "sakha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "lenguas indígenas sudamericanas "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "lenguas salishas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "arameo samaritano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "sánscrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "escocés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "lenguas semíticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "irlandés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "lenguaje de señas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "cingalés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "lenguas sioux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "lenguas sino-tibetanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "lenguas eslavas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "eslovaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "esloveno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "sami meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "sami septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "lenguas sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "sami lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "sami inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "samoano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "soninké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "somalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "lenguas songhay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "sotho meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "español"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "sardo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "serbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "lenguas nilo-saharianas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "suazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "sundanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "sumerio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "suajili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "sueco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "siríaco clásico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "tahitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "lenguas tai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "tártaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "tetún"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "tayiko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "tagalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "tailandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "tigriña"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "tokelauano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "tonga del Nyasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "tongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "tsimshiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "setsuana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "turcomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "lenguas tupíes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "turco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "lenguas altaicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "tuvaluano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "tuviniano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "ugarítico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "uigur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "ucraniano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "lengua desconocida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "uzbeko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "vótico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "lenguas wakash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "wolayta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "galés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "lenguas sorabas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "valón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "wólof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "yapés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "yidis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "lenguas yupik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "zapoteco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "símbolos Bliss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "zulú"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "sin contenido lingüístico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "zazaki"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "Valores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "Valor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "Islas Ashmore y Cartier (-ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "Territorio de la capital australiana (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "Argelia (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "Afganistán (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "Armenia (república) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "R.S.S. de Armenia (-air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "Azerbaiyán (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "R.S.S. de Azerbaiyán (-ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "Anguila (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "Antigua y Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "Samoa Americana (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "Antártida (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "Baréin (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "Columbia Británica (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "Bélgica (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "Bangladés (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "Belice (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "Territorio Británico del Océano Índico (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "Brasil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "Islas Bermudas (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "Bosnia y Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "Islas Salomón (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "Birmania (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "Botsuana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "Bután (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "Isla Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "Bielorrusia (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "R.S.S. de Bielorrusia (-bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "[Brunei] (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "Caribe neerlandés (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "Camboya (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "Chad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "Congo (República Democrática) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "China (República: 1949-) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "Croacia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "Islas Caimán (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "Camerún (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "Canadá (-cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "Curazao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "Islas Cantón y Enderbury (-cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "Comoras (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "Checoslovaquia (-cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "Cabo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "Islas Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "República Centroafricana (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "Chipre (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "Zona del canal (-cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "Distrito de Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "Dinamarca (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "Benín (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "República Dominicana (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "Guinea Ecuatorial (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "Timor-Leste (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "Inglaterra (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "Estonia (-err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "Etiopía (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "Islas Feroe (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "Guayana Francesa (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "Finlandia (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "Fiyi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "Islas Malvinas (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "Micronesia (Estados Federados) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "Polinesia Francesa (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "Francia (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "Tierras australes y antárticas francesas (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "Yibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "Granada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "Alemania (este) (-ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "Groenlandia (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "Islas Gilbert y Ellice (-gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "Gabón (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "Guadalupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "Grecia (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "Georgia (república) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "R.S.S. de Georgia (-gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "Alemania (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "Franja de Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "Hawai (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "R.A.E. de Hong Kong (China) (-hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "Islas Heard y McDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "Haití (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "Hungría (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "Islandia (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "Irlanda (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "Isla de Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "Italia (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "Zonas desmilitarizadas entre Israel y Siria (-iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "Costa de Marfil (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "Zonas desmilitarizadas entre Israel y Jordania (-iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "Zona neutral Iraq-Arabia Saudita (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "Japón (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "Atolón Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "Jan Mayen (-jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "Jordania (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "Kirguistán (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "R.S.S. de Kirguistán (-kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "Corea del Norte (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "Corea del Sur (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "[Kosovo] (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "Kazajistán (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "R.S.S. de Kazajstán (-kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "Luisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "Líbano (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "Lituania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "Lituania (-lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "Islas de la línea central y sur (-ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "Lesoto (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "Luxemburgo (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "Letonia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "Letonia (-lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "Libia (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "Mónaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "Mauricio (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "R.A.E. de Macao (China) (-mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "Omán (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "Misuri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "Martinica (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "Marruecos (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "Misisipí (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "Moldavia (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "R.S.S. de Moldavia (-mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "Malaui (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "México (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "Malasia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "Antillas Holandesas (-na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "Carolina del Norte (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "Dakota del Norte (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "Países Bajos (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "Níger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "Nuevo Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "Irlanda del Norte (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "Nuevo Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "Nueva Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "Islas Marianas del Norte (-nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "Nuevo Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "Noruega (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "Nueva Escocia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "Territorios del Noroeste (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "Islas Marianas del Norte (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "Isla Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "Estado de Nueva York (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "Nueva Zelanda (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "Oregón (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "Pensilvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "Isla Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "Perú (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "Islas Paracel (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "Guinea-Bisáu (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "Filipinas (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "Isla del Príncipe Eduardo (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "Pakistán (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "Polonia (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "Panamá (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "Papúa Nueva Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "Timor portugués (-pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "Palaos (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "Catar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "Quebec (provincia) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "Reunión (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "Zimbabue (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "Rumanía (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "Federacion Rusa (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "R.S.F.S. de Rusia (-rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr "Islas Ryukyu, Sur (-ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "Sudáfrica (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "Svalbard (-sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "San Bartolomé (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "Carolina del Sur (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "Sudán del Sur (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "Dakota del Sur (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "Santo Tomé y Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "África española (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "Singapur (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "Sudán (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "Sikkim (-sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "Sierra Leona (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "España (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "Esuatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "Sáhara Occidental (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "Escocia (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "Arabia Saudí (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "Islas del Cisne (-sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "Suecia (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "Siria (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "Suiza (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "Tayikistán (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "R.S.S. de Tayikistán (-tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "Islas Turcas y Caicos (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "Tailandia (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "Túnez (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "Turkmenistán (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "R.S.S. de Turkmenistán (-tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "Trinidad y Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "Emiratos Árabes Unidos (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "Territorio en Fideicomiso de las Islas del Pacífico (-tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "Turquía (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "Egipto (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "[United States Misc. Caribbean Islands] (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "Reino Unido Misc. Islas(-ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "Reino Unido Misc. Islas (-uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "Reino Unido (-uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "Ucrania (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "Ucrania (-unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "Estados Unidos Misc. Islas del pacifico (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "Unión soviética (-ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "Estados Unidos (-us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "Uzbekistán (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "R.S.S. de Uzbekistán (-uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "Islas Vírgenes Británicas (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "Ciudad del vaticano (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "Islas Vírgenes de EE. UU. (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "Vietnam del norte (-vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "Varios lugares (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "Vietnam del sur (-vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "Washington (estado) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "Berlín occidental (-wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "Australia occidental (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "Wallis y Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "Cisjordania del río Jordán (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "Isla Wake (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "Gales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "Virginia del Oeste (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "Isla Christmas (Océano Índico) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "Islas Cocos (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "Maldivas (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "San Cristóbal y Nieves (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "Islas Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "Islas Midway (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "Territorio de las Islas del Mar del Coral (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "San Cristóbal-Nevis-Anguila (-xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "Santa helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "Santa Lucía (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "San Pedro y Miquelón (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "San Vicente y las Granadinas (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "Macedonia del Norte (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "Nueva Gales del Sur (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "Eslovaquia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "Territorio del Norte (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "Isla Spratly (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "Chequia (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "Australia Meridional (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "Islas Georgia del Sur y Sandwich del Sur (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "Eslovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "Ningún lugar, desconocido o indeterminado (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "Canadá (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "Reino Unido (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "Unión soviética (-xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "Estados Unidos (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "Yukón (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "Yemen (República Democrática Popular) (-ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "Serbia y Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Cantones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "AG (Argovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "AI (Appenzell Rodas Interiores)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "AR (Appenzell Rodas Exteriores)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "BE (Berna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "BL (Basilea-Campiña)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "BS (Basilea-Ciudad)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "FR (Friburgo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "GE (Ginebra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "GL (Glaris)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "GR (Grisones)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "JU (JURA)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "LU (Lucerna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "SG (San Galo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "SH (Schaffhausen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "SO (Soleura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "TG (Turgovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "TI (Tesino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "ZH (Zúrich)"
 
@@ -6535,7 +6534,8 @@ msgid ""
 "locating an object using existing Internet protocols."
 msgstr ""
 "Uniform Resource Identifier (URI), que proporciona una sintaxis estándar "
-"para localizar un objeto utilizando los protocolos de Internet existentes."
+"para localizar un objeto utilizando los protocolos de Internet "
+"existentes."
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:83
 msgid "Source of the URI."
@@ -6870,9 +6870,13 @@ msgid ""
 "state"
 msgstr "El nombre de la acción que desencadenó la transición al estado actual"
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "Otra ubicación en línea existe en biblioteca"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7033,8 +7037,7 @@ msgstr "Fuente recolectada en línea"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
 msgid "Online harvested source as configured in ebooks server."
-msgstr ""
-"Fuente recolectada en línea como configurada en el servidor de ebooks."
+msgstr "Fuente recolectada en línea como configurada en el servidor de ebooks."
 
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:4
 msgid "PatronTransactionEvent"
@@ -7228,8 +7231,7 @@ msgstr "La reservación del ejemplar %(item_id)s ha sido cancelado."
 msgid ""
 "Error during the cancellation of the request of                 item "
 "%(item_id)s."
-msgstr ""
-"Error durante la cancelación de la reservación del ejemplar %(item_id)s."
+msgstr "Error durante la cancelación de la reservación del ejemplar %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:128
 #, python-format
@@ -7620,8 +7622,8 @@ msgid ""
 "Enter your email address below and we will send you a link to reset your "
 "password."
 msgstr ""
-"Introduce su dirección de correo electrónico a continuación y le enviaremos "
-"un enlace para restablecer su contraseña."
+"Introduce su dirección de correo electrónico a continuación y le "
+"enviaremos un enlace para restablecer su contraseña."
 
 #: rero_ils/templates/rero_ils/forgot_password.html:37
 #: rero_ils/templates/rero_ils/login_user.html:30
@@ -7687,13 +7689,11 @@ msgstr "versión"
 #: rero_ils/templates/rero_ils/frontpage.html:80
 #: rero_ils/templates/rero_ils/frontpage.html:83
 msgid "Link to the RERO ILS code source on GitHub, current used version"
-msgstr ""
-"Enlace al código fuente de RERO ILS en GitHub, versión actual utilizada"
+msgstr "Enlace al código fuente de RERO ILS en GitHub, versión actual utilizada"
 
 #: rero_ils/templates/rero_ils/frontpage.html:87
 msgid "Link to the RERO ILS UI code source on GitHub, current used version"
-msgstr ""
-"Enlace al código fuente de RERO ILS UI en GitHub, versión actual utilizada"
+msgstr "Enlace al código fuente de RERO ILS UI en GitHub, versión actual utilizada"
 
 #: rero_ils/templates/rero_ils/frontpage.html:93
 #: rero_ils/templates/rero_ils/frontpage.html:97
@@ -7712,10 +7712,6 @@ msgstr "Catálogo colectivo"
 msgid "RERO ILS global"
 msgstr "RERO ILS global"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "Buscar"
@@ -7732,6 +7728,10 @@ msgstr "Nuevo en %(sitename)s?"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "¿Se ha olvidado su contraseña?"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format
@@ -7757,3 +7757,4 @@ msgstr "está suprimido."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Haga clic aquí para restablecer su contraseña"
+

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -30,84 +30,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Français"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Allemand"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italien"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "Bienvenue sur RERO-ILS!"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "Type de document"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "organisation"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "bibliothèque"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "auteur"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "auteur"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "auteur"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "auteur"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "langue"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "sujet"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "statut"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "rôles"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "budget"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "sources"
 
@@ -193,8 +193,8 @@ msgid "sound"
 msgstr "son"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "vidéo"
 
@@ -230,42 +230,42 @@ msgid "ui_language_it"
 msgstr "Italiano"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "Publication"
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "Fabrication"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "Diffusion, distribution"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "Production"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "Lieu"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "Date"
 
@@ -349,10 +349,10 @@ msgid "Account ID"
 msgstr "Mon compte"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -429,10 +429,10 @@ msgstr "URI de la bibliothèque"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -576,8 +576,8 @@ msgid "Choose a date"
 msgstr "Choisir une date"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "Notes"
@@ -707,12 +707,12 @@ msgid "Rate"
 msgstr "taux"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -999,20 +999,20 @@ msgstr "PID du document"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1067,11 +1067,11 @@ msgstr "vidéo"
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1099,52 +1099,54 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr "Mentions de responsabilité"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr "Mention de responsabilité"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "Titres uniformes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
@@ -1152,101 +1154,101 @@ msgstr ""
 "Titre uniforme, un titre associé ou analytique, contrôlé par un fichier "
 "ou une liste d'autorités, et utilisé comme point d'accès supplémentaire."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "Titre uniforme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "Fait partie de"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "Titre du document hôte."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "Listes des langues de la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "Langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "Langues de la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "Type de la langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "Langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "Traduit de"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "Langue de laquelle la resource a été traduite."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "Auteurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 "Auteur(s) de la resource. Peut être soit une personne soit une "
 "collectivité."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "Auteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "Personne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "Nom de la personne."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "Référence de personne MEF"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -1254,15 +1256,15 @@ msgstr ""
 "Informations sur les dates de naissance et de décès d'une personne. Utile"
 " pour distinguer les homonymes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "Qualificatif"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -1270,119 +1272,119 @@ msgstr ""
 "Informations qualifiant la personne, par exemple sa profession. Utile "
 "pour distinguer les homonymes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "Nom de la collectivité"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "Dates de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "Date de copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "Mentions d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "Mention d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "Désignations d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "Désignation d'édition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "Production, publication, diffusion, distribution, fabrication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "Production, publication, diffusion, distribution, fabrication"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "Lieux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "Lieu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "Type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "Pays"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "Canton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "Mentions"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "Mention"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr "Mention"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "Agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "Note."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "Date de publication 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
@@ -1393,13 +1395,13 @@ msgstr ""
 "champ renseigné, une date de publication sous forme libre peut être "
 "ajoutée dans le champ suivant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "Date de publication 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
@@ -1410,25 +1412,25 @@ msgstr ""
 "champ renseigné, une date de publication sous forme libre peut être "
 "ajoutée dans le champ suivant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "Importance matérielle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr ""
 "Importance matérielle de la resource, par exemple le nombre de pages ou "
 "de volumes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "Autres caractéristiques matérielles"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
@@ -1436,4985 +1438,4985 @@ msgstr ""
 "Autres caractéristiques matérielles, par exemple des illustrations, noir "
 "et blanc ou en couleurs."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "Formats"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Format de la resource, par exemple les dimensions en cm."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "Matériel d'accompagnement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr ""
 "Matériel d'accompagnement de la resource, par exemple des cartes "
 "géographiques."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "Collection"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "Collection à laquelle appartient la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "Titre de la collection."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "Numérotation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "Numérotation de la resource au sein de la collection."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "Note sur la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "Résumés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "Résumé de la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "Résumé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "Identifiant"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "Numéro d'édition audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "Identifiant (type non précisé)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "Identifiant local"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "Audio matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "Cotage pour la musique notée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "Numéro d’éditeur pour la musique notée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "Numéro d’éditeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
 msgstr "Valeur de l'identifiant"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
 msgid "Identifier value."
 msgstr "Valeur de l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "Note sur l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "Qualificatif de l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "Modalité d'acquisition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "Modalité d'acquisition de la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "Source"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "Source de l'identifiant."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "Statut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Statut de l'identifiant ISBN/ISSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Le status de l'ISBN/ISSN doit être sélectionné dans la liste ci-dessous."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "Sujets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "Sujet de la resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "Sujet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Information nécessaire pour accéder à une resource électronique."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
-msgid "Example: https://www.rero.ch/"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+msgid "Example: https://www.rero.ch/"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "Site web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
-msgid "Is displayed next to the link, as additional information"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+msgid "Is displayed next to the link, as additional information"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "Importé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Document moissonné ou non, désactivera l'édition de la notice."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "Valeur de la langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "abkhaze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "aceh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "adyguéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "afro-asiatiques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "aïnou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "akkadien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "albanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "aléoute"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "algonquines, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "altaï du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "amharique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "ancien anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "apaches, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "arabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "araméen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "aragonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "arménien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "artificielles, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "assamais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "asturien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "athapascanes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "australiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "avar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "avestique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "azéri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "banda, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "bamilékés, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "bachkir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "baloutchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "balinais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "basque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "bassa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "baltes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "bedja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "biélorusse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "bengali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "berbères, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "bhodjpouri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "bichelamar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "bantoues, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "bosniaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "breton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "batak, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "bouriate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "bugi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "bulgare"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "birman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "indiennes d'Amérique centrale, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "caribe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "catalan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "caucasiens, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "celtique, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "tchétchène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "tchaghataï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "chinois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "chuuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "jargon chinook"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "slavon d’église"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "tchouvache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "monténégrin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "copte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "cornique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "corse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "créoles et pidgins anglais, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "créoles et pidgins français, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "créoles et pidgins portugais, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "turc de Crimée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "créoles et pidgins divers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "kachoube"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "couchitiques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "tchèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "danois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "Land Dayak, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "esclave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "maldivien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "dravidiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "bas-sorabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "douala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "moyen néerlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "néerlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "dioula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "éfik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "égyptien ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "ékadjouk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "élamite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "moyen anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "espéranto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "estonien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "éwé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "éwondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "féroïen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "fidjien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "finnois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "finno-ougriennnes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "moyen français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "ancien français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "frison du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "frison oriental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "frison occidental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "peul"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "frioulan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "germaniques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "géorgien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "guèze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "gilbertin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "gaélique écossais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "galicien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "mannois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "moyen haut-allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "ancien haut allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "gotique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "grec ancien (jusqu'à 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "grec moderne (après 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "suisse allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "goudjerati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "créole haïtien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "haoussa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "hawaïen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "hébreu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "héréro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "croate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "haut-sorabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "hongrois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "islandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "yi du Sichuan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "ijo, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "indo-aryennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "indonésien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "indo-européennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "ingouche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "iraniennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "iroquois, langues (famille)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "italien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "javanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "japonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "judéo-persan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "judéo-arabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "karakalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "kabyle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "groenlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "karen, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "cachemiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "kanouri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "kazakh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "kabarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "khoisan, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "khotanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "kirghize"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "kimboundou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "kikongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "coréen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "kosraéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "kpellé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "karatchaï balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "carélien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "krou, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "kouroukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "koumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "kurde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "latin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "letton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "lezghien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "limbourgeois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "lituanien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "luxembourgeois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "luba-kasaï (ciluba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "luba-katanga (kiluba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "lushaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "macédonien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "madurais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "marshallais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "maïthili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "makassar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "mandingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "malayo-polynésiennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "maasaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "malais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "mokcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "mendé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "moyen irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "diverses, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "môn-khmer, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "maltais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "mandchou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "manobo, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "mongol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "moré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "multilingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "mounda, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "muskogee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "mirandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "marwarî"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "maya, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "nahuatl, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "indiennes d'Amérique du Nord, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "napolitain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "nauruan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "ndébélé du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "ndébélé du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "bas-allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "népalais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "niha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "nigéro-congolaises,langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "niuéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "norvégien nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "norvégien bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "nogaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "vieux norrois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "norvégien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "sotho du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "nubiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "newarî classique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "chewa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "nyankolé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "nzema"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "occitan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "ossète"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "turc ottoman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "otomi, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "papoues, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "pampangan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "pendjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "paluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "persan ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "persan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "philippin, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "phénicien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "polonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "pohnpei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "portugais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "prâkrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "provençal ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "pachto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "rarotongien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "romanes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "romanche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "roumain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "roundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "aroumain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "russe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "iakoute"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "indiennes d'Amérique du Sud, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "salish, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "araméen samaritain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "sicilien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "écossais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "selkoupe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "sémitiques, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "ancien irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "langue des signes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "cingalais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "sioux, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "sino-tibétaines, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "slaves, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "slovaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "slovène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "same du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "same du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "sâmes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "same de Lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "same d’Inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "samoan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "same skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "soninké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "sogdien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "sotho du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "espagnol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "sarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "serbe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "sérère"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "nilo-sahariennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "swati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "soukouma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "soundanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "soussou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "sumérien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "suédois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "syriaque classique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "syriaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "tahitien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "tai, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "tamoul"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "télougou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "timné"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "tétoum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "tadjik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "thaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "tibétain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "tigrigna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "tamacheq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "tonga nyasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "tongien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "turkmène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "tupi, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "turc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "altaïques, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "touvain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "oudmourte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "ougaritique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "ouïghour"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "ukrainien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "langue indéterminée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "ourdou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "ouzbek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "vaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "vietnamien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "vote"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "wakashennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "walamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "gallois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "sorabes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "wallon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "kalmouk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "yapois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "yupik, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "zapotèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "symboles Bliss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "zandé, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "zoulou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "sans contenu linguistique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "zazaki"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "Valeurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "valeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "Albanie (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "Îles Ashmore-et-Cartier (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "Territoire de la capitale australienne (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "Algérie (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "Argentine (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "Arménie (République) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "R.S.S. d'Arménie (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "Azerbaïdjan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "R.S.S. d'Azerbaïjan (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "Andorre (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "Antigua-et-Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "Samoa américaines (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "Australie (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "Autriche (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "Antarctique (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "Bahreïn (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "Barbade (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "Colombie Britannique (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "Belgique (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "Territoire britannique de l’océan Indien (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "Brésil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "Îles Bermudes (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "Bosnie-Herzégovine (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "Bolivie (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "Îles Salomon (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "Birmanie (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "Bhoutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "Bulgarie (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "Île Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "Biélorussie (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "R.S.S. de Biélorussie (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "Pays-Bas caribéens  (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "Californie (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "Cambodge (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "Chine (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "Tchad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "Congo-Brazzaville (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "République démocratique du Congo (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "République populaire de Chine (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "Croatie (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "Îles Caïmans (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "Colombie (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "Chili (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "Cameroun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "Îles de Canton et Enderbury (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "Comores (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "Tchécoslovaquie (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "Cap-Vert (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "Îles Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "République centrafricaine (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "Chypre (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "Zone du Canal de Panama (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "District de Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "[Delaware] (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "Danemark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "Bénin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "Dominique (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "République dominicaine (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "Érythrée (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "Équateur (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "Guinée équatoriale (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "Timor oriental (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "Angleterre (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "Estonie (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "R.S.S. d'Estonie (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "Éthiopie (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "Îles Féroé (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "Guyane française (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "Finlande (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "Fidji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "Îles Malouines (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "Floride (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "États fédérés de Micronésie (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "Polynésie française (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "France (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "Géorgie (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "Grenade (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "Allemagne de l'Est (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "Guernesey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "Groenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "Gambie (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "Îles Gilbert et Ellice (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "Grèce (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "République de Géorgie (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "R.S.S. de Géorgie (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "Guinée (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "Allemagne (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "Guyane (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "Bande de Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "Hawaï (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "R.A.S. chinoise de Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "Îles Heard-et-MacDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "Haïti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "Hongrie (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "Islande (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "Irlande (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "Inde (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "Île de Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "Indonésie (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "Israël (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "Italie (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "Zones démilitarisées Israël-Syrie (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "Côte d’Ivoire (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "Zones démilitarisées Israël-Jordanie (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "Zone neutre Irak-Arabie saoudite (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "Japon (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "Atoll de Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "Jamaïque (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "Île Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "Jordanie (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "Kirghizistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "R.S.S. kirghize (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "Corée du Nord (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "Corée du Sud (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "Koweït (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "Kazakhstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "R.S.S. Kazakhe (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "Louisiane (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "Libéria (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "Liban (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "Lituanie (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "Lituanie (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "Îles de la Ligne Centrale et du Sud (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "Luxembourg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "Lettonie (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "Lettonie (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "Libye (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "Maurice (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "R.A.S. chinoise de Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "Malte (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "Monténégro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "Mongolie (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "Maroc (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "Mauritanie (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "Moldavie (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "R.S.S. Moldave (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "Mexique (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "Malaisie (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "Antilles néerlandaises (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "Caroline du Nord (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "Dakota du Nord (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "Pays-Bas (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "Terre-Neuve et Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "Irlande du Nord (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "Nouveau Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "Nouvelle-Calédonie (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "Îles Mariannes du Nord (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "Nouveau Mexique (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "Norvège (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "Népal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "Nigéria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "Nouvelle-Ecosse (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "Territoires du Nord-Ouest (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "Îles Mariannes du Nord (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "Île Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "État de New York (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "Nouvelle-Zélande (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "Pennsylvanie (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "Île Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "Pérou (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "Îles Paracels (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "Guinée-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "Philippines (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "Île du Prince Edouard (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "Pologne (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "Papouasie-Nouvelle-Guinée (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "Porto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "Timor portugais (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "Palaos (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "Serbie (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "La Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "Roumanie (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "Russie (Fédération) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "RSFS de Russie (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr " îles Ryūkyū du Sud (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "Afrique du Sud (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "Caroline du Sud (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "Soudan du Sud (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "Dakota du Sud (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "Sao Tomé-et-Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "Sénégal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "Afrique espagnole (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "Singapour (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "Soudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "Saint-Marin (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "Saint-Martin (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "Somalie (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "Espagne (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "Suriname (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "Sahara occidental (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "Écosse (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "Arabie saoudite (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "Îles du Cygne (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "Suède (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "Namibie (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "Syrie (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "Suisse (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "Tadjikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "R.S.S. du Tadjikistan (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "Îles Turques-et-Caïques (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "Thaïlande (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "Tunisie (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "Turkménistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "R.S.S. du Turkménistan (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "Tasmanie (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "[Tennessee] (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "Trinité-et-Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "Émirats arabes unis (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "Territoire sous tutelle des îles du Pacifique (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "Turquie (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "Tanzanie (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "Égypte (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "États-Unis, diverses îles caribéennes (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "Ouganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "Royaume-Uni, diverses îles (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "Royaume-Uni, diverses îles (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "Royaume-Uni (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "États-Unis, diverses îles du Pacifique (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "Union soviétique (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "États-Unis (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "Ouzbékistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "R.S.S. d'Ouzbékistan (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "Virginie (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "Îles Vierges britanniques (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "Vatican (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "Vénézuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "Îles Vierges des États-Unis (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "[Vietnam, North] (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "Plusieurs pays (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "Terre Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "[Vietnam, South] (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "Washington (État) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "Berlin Ouest (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "Australie-Occidentale (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "Wallis-et-Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "Cisjordanie (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "Wake (atoll) (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "Pays de Galles (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "Virginie-Occidentale (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "Île Christmas (Océan Indien) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "Îles Cocos (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "Maldives (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "Saint Kitts-et-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "Îles Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "Îles Midway (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "Territoire des îles de la mer de Corail (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "Saint Kitts-et-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "Sainte-Hélène (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "Sainte-Lucie (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "Saint-Pierre-et-Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "Saint-Vincent-et-les-Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "Macédoine du Nord (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "Nouvelle-Galles du Sud (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "Slovaquie (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "Territoire du Nord (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "Îles Spratleys (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "Tchéquie (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "Australie-Méridionale (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "Géorgie du Sud et îles Sandwich du Sud (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "Slovénie (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "Aucun pays, inconnu, indéterminé (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "Royaume-Uni (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "Union soviétique (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "États-Unis (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "Yémen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "Territoire du Yukon (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "Yémen (République démocratique populaire) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "Serbie et Monténégro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "Zambie (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "AG (Argovie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "AI (Appenzell Rhodes-Intérieures)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "AR (Appenzell Rhodes-Extérieures)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "BE (Berne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "BL (Bâle-Campagne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "BS (Bâle-Ville)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "FR (Fribourg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "GE (Genève)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "GL (Glaris)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "GR (Grisons)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "LU (Lucerne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "NW (Nidwald)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "OW (Obwald)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "SG (Saint-Gall)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "SH (Schaffhouse)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "SO (Soleure)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "SZ (Schwytz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "TG (Thurgovie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "TI (Tessin)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "ZG (Zoug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "ZH (Zurich)"
 
@@ -6875,9 +6877,13 @@ msgid ""
 "state"
 msgstr "Le nom de l'action qui a déclenché la transition vers l'état actuel"
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "Une autre localisation en ligne existe dans cette bibliothèque"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7717,10 +7723,6 @@ msgstr "Catalogue collectif"
 msgid "RERO ILS global"
 msgstr "RERO ILS global"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "Recherche"
@@ -7737,6 +7739,10 @@ msgstr "Pas encore inscrit·e sur %(sitename)s?"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "Vous avez oublié votre mot de passe?"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for rero-ils.
+# Italian translations for rero-ils.
 # Copyright (C) 2020 RERO
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
@@ -16,100 +16,99 @@
 # MarionRERO <marion.davis@rero.ch>, 2020
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # Gianni Pante <gianni.pante@rero.ch>, 2020
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Gianni Pante <gianni.pante@rero.ch>, 2020\n"
+"Language: it\n"
 "Language-Team: Italian (https://www.transifex.com/rero/teams/77935/it/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Francese"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Tedesco"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "italiano"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "Benvenuti su RERO ILS!"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "tipo di documento"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "Ente"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "biblioteca"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "autore"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "autore"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "autore"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "autore"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "lingua"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "oggetto"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "stato"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "ruoli"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "bilancio"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "fonti"
 
@@ -195,8 +194,8 @@ msgid "sound"
 msgstr "audio"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "video"
 
@@ -232,42 +231,42 @@ msgid "ui_language_it"
 msgstr "Italiano"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "Pubblicazione  "
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "Manifattura"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "Distribuzione"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "Produzione"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "Luogo"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "Data"
 
@@ -351,10 +350,10 @@ msgid "Account ID"
 msgstr "ID del conto"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -431,10 +430,10 @@ msgstr "URI della biblioteca"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -578,8 +577,8 @@ msgid "Choose a date"
 msgstr "Seleziona una data"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "Nota"
@@ -709,12 +708,12 @@ msgid "Rate"
 msgstr "Tasso di cambio"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -905,10 +904,8 @@ msgid "Number of days after due date"
 msgstr "Numero di giorni dopo la data di scadenza"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:77
-msgid ""
-"Number of days after due date for sending the first overdue notification."
-msgstr ""
-"Numero di giorni dopo la data di scadenza per mandare il primo richiamo."
+msgid "Number of days after due date for sending the first overdue notification."
+msgstr "Numero di giorni dopo la data di scadenza per mandare il primo richiamo."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:83
 msgid "The amount of reminder fee"
@@ -1003,20 +1000,20 @@ msgstr "PID di documento"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1071,11 +1068,11 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1103,5321 +1100,5323 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr "Responsabilità"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr "Formulazione di responsabilità"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "Titoli uniformi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
 "Titolo uniforme, un titolo associato o analitico, controllato da un "
-"fascicolo o da un elenco di autorità e utilizzato come ulteriore punto di "
-"accesso."
+"fascicolo o da un elenco di autorità e utilizzato come ulteriore punto di"
+" accesso."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "Titolo uniforme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "Fa parte di"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "Titolo della collezione."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "Lingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "Elenchi linguistici dell'opera."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "Lingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "Lingue della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "Tipo della lingua."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "Lingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "Tradotto da"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "Lingua da cui l'opera è stata tradotta."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "Autori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Autore o autori dell'opera. Può essere una persona o un ente."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "Autore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "Persona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "Nome della persona."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "MEF persona ref"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
-"Informazioni sulla data di nascita e di decesso di una persona. Utile per "
-"distinguere gli omonimi."
+"Informazioni sulla data di nascita e di decesso di una persona. Utile per"
+" distinguere gli omonimi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "Qualificazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
-"Informazioni che qualificano la persona, come la sua occupazione. Utile per "
-"distinguere gli omonimi."
+"Informazioni che qualificano la persona, come la sua occupazione. Utile "
+"per distinguere gli omonimi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "Nome dell'ente."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "Date di copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "Data di copyright"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "Formulazioni di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "Formulazione di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "Designazioni di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "Designazione di edizione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "Pubblicazione, manifattura, distribuzione, produzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "Pubblicazione, manifattura, distribuzione, produzione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "Luoghi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "Luogo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "tipo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "Paese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "Cantone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "Formulazioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "Formulazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr "Formulazione di luogo e agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "Agente"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "Label"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "Nota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "Data di pubblicazione 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
-"Start date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Start date of the publication. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 msgstr ""
 "Data di pubblicazione 1. Deve essere un numero intero, per esempio 1989, "
 "453, -50. Utilizzata per ordinare i risultati di una ricerca. Una volta "
 "compilato il campo, è possibile aggiungere una data di pubblicazione in "
 "forma libera nel campo successivo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "Data di pubblicazione 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Used to sort search results. Once this field is set, a free formed date "
+"of publication can be added in the next field."
 msgstr ""
 "Data di pubblicazione 2. Deve essere un numero intero, per esempio 1989, "
 "453, -50. Utilizzata per ordinare i risultati di una ricerca. Una volta "
 "compilato il campo, è possibile aggiungere una data di pubblicazione in "
 "forma libera nel campo successivo."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "Importanza materiale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
-msgstr ""
-"Importanza materiale della risorsa, ad esempio numero di pagine o volumi."
+msgstr "Importanza materiale della risorsa, ad esempio numero di pagine o volumi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "Altre caratteristiche dei materiali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr ""
-"Altre caratteristiche dei materiali, ad esempio illustrazioni, in bianco e "
-"nero o a colori."
+"Altre caratteristiche dei materiali, ad esempio illustrazioni, in bianco "
+"e nero o a colori."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "Formato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Formato della risorsa, ad esempio dimensioni in cm."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "Materiale di accompagnamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Materiali che accompagnano la risorsa, ad esempio mappe."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "Collezione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "Collezione cui appartiene la risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "Titolo della collezione."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "Numerazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "Numerazione delle risorse all'interno della raccolta."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "Nota sulla risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "Riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "Riassunto della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "Riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "Identificatore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "Identificatore (tipo non precisato)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "Locale identificatore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "Audio matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "Numero di lastra per musica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "Numero dell’editore per la musica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "Numero dell'editore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "URI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
 msgstr "Codice d'identificazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
 msgid "Identifier value."
 msgstr "Codice d'identificazione."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "Nota sull'identificatore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "Qualificatore dell'identificatore."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "Condizioni di disponibilità"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "Condizioni di disponibilità della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "Fonte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "Fonte del identificatore."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "Stato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Stato dell'identificatore ISBN/SSSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Stato del codice ISSB/ISSN deve essere selezionato nell'elenco."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "Oggetti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "Oggetto della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "Oggetto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr "Localizzazione delle risorse elettroniche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
-"Informazioni necessarie per localizzare una risorsa elettronica e accedervi."
+"Informazioni necessarie per localizzare una risorsa elettronica e "
+"accedervi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr "Collocazione electronica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr "url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
 msgstr "Registrare qui un URL univoco."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
 msgid "Example: https://www.rero.ch/"
 msgstr "Esempio: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr "Tipo di link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr "risorsa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr "versione della risorsa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr "risorsa correlata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr "Url nascosto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr "no info"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr "Tipo di contenuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr "Viene visualizzato come testo del link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr "poster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr "audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr "cartolina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr "aggiunta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr "debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr "documentazione della mostra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr "erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr "piastra per libri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr "estratto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr "scheda didattica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr "illustrazioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr "immagine di copertina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr "informazioni sulla consegna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr "informazioni biografiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr "introduzione/prefazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr "lettura di classe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr "kit per insegnanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr "nota dell'editore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr "nota sul contenuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr "frontespizio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr "fotografia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr "riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr "risorsa online tramite RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr "rassegna stampa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "sito web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr "indice dei contenuti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr "testo completo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
 msgstr "Uniform Resource Identifier Public Note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
 msgid "Is displayed next to the link, as additional information"
 msgstr "Viene visualizzato accanto al link, come informazione aggiuntiva"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr "Esempio: Accesso solo dalla biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "Raccolto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
-"Documento è stato raccolto o no, disattiva la possibilità di modificare il "
-"record o vice versa."
+"Documento è stato raccolto o no, disattiva la possibilità di modificare "
+"il record o vice versa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "Codice di lingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "abcaso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "accinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "acioli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "adyghe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "afroasiatiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "accado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "albanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "aleuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "lingue algonchine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "altai meridionale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "amarico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "inglese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "lingue apache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "arabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "aramaico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "aragonese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "armeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "lingua artificiale (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "aruaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "assamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "lingue athabaska"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "lingue australiane aborigene"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "avaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "avestan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "azerbaigiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "banda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "lingue bamileke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "baschiro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "beluci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "balinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "basco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "lingue baltiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "begia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "bielorusso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "wemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "bengalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "lingue berbere"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "bicol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "bantu (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "bosniaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "bretone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "batak (indonesia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "buriat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "bugi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "bulgaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "birmano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "indiane centro-americane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "caribico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "catalano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "lingue caucasiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "lingue celtiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "ceceno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "ciagataico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "cinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "chuukese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "gergo chinook"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "slavo della Chiesa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "ciuvascio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "copto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "cornico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "corso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "creoli e pidgin basati sull'inglese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "creoli e pidgin basati sul francese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "creoli e pidgin basati sul portoghese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "turco crimeo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "creoli e pidgin (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "kashubian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "lingue cushitiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "ceco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "danese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "slave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "dinca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "dravidiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "basso sorabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "olandese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "olandese; fiammingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "diula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "egiziano antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "ekajuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "elamitico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "inglese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "inglese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "estone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "faroese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "figiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "filippino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "finlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "ugrofinniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "francese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "francese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "francese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "frisone settentrionale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "frisone orientale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "frisone occidentale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "fulah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "friulano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "lingue germaniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "tedesco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "gilbertese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "gaelico scozzese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "irlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "galiziano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "mannese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "tedesco medio alto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "tedesco antico alto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "gotico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "greco antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "greco moderno (dal 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "tedesco svizzero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "haitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "ebraico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "ilongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "croato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "alto sorabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "ungherese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "islandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "sichuan yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "lingue indoarie (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "indonesiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "lingue indoeuropee (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "inupiak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "lingue iraniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "lingue irochesi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "italiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "giavanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "giapponese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "giudeo persiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "giudeo arabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "kara-kalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "cabilo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "groenlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "kashmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "kazako"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "cabardino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "khoisan (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "khotanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "kirghiso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "coreano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "kosraean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "karachay-Balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "careliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "kru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "curdo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "giudeo-spagnolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "latino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "lettone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "lesgo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "limburghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "lituano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "lolo bantu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "lussemburghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "luiseno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "lushai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "macedone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "madurese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "marshallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "makasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "austronesiano (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "masai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "malay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "irlandese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "menangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "mon-khmer (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "malgascio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "maltese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "manchu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "lingue manobo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "mongolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "multilingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "lingue munda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "mirandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "maya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "indiano nordamericano (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "napoletano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "nauru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "ndebele del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "ndebele del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "basso tedesco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "nepalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "niger-kordofaniane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "niue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "norvegese nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "norvegese bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "norse antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "norvegese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "sotho del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "lingue nubiane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "newari classico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "occitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "ossetico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "turco ottomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "lingue otomiane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "papuasiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "punjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "palauano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "persiano antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "persiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "filippine (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "polacco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "ponape"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "portoghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "lingue pracrite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "provenzale antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "pashto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "rarotonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "lingue romanze (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "romancio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "romeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "rundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "arumeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "russo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "yakut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "lingue indiane sudamericane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "lingue salish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "aramaico samaritano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "sanscrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "scozzese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "lingue semitiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "irlandese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "lingua dei segni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "singalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "lingue sioux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "sinotibetane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "lingue slave (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "slovacco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "sloveno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "sami del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "sami del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "lingue sami (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "sami di Lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "sami di Inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "samoano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "somalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "sotho del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "spagnolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "sardo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "serbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "lingue nilo-sahariane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "swati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "sundanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "sumero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "svedese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "siriaco classico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "taitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "thailandese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "tataro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "tagico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "tigrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "nyasa del Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "tongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "turcomanno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "lingue tupi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "turco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "altaiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "ci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "tuvinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "ugaritico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "uiguro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "ucraino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "mbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "lingua imprecisata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "uzbeco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "voto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "lingue wakash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "walamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "gallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "lingue lusaziane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "vallone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "yao (bantu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "yapese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "lingue yupik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "blissymbol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "nessun contenuto linguistico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "Valori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "valore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "Isole Ashmore e Cartier (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "Territorio della Capitale Australiana (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "Algeria (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "Armenia (Repubblica) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "R.S.S. di Armenia (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "Azerbaigian (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "R.S.S. dell' Azerbaigian (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "Antigua e Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "Samoa americane (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "Antartide (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "Bahrein (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "Columbia Britannica (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "Belgio (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "Territorio britannico dell’Oceano Indiano (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "Brasile (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "Bermuda (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "Bosnia ed Erzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "Isole Salomone (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "Birmania (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "Isola Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "Bielorussia (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "R.S.S. Bielorussia (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "Paesi Bassi caraibici (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "California (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "Cambogia (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "Cina (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "Ciad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "Congo-Brazzaville (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "Repubblica Democratica del Congo (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "Repubblica Popolare Cinese (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "Croazia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "Isole Cayman (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "Cile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "Camerun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "Isole Canton ed Enderbury (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "Comore (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "Cecoslovacchia (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "Capo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "Isole Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "Repubblica Centrafricana (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "Cipro (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "Zona del Canale di Panama (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "Distretto di Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "Danimarca (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "Repubblica Dominicana (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "Guinea Equatoriale (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "Timor Est (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "Inghilterra (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "R.S.S. di Estonia (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "Etiopia (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "Isole Fær Øer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "Guyana francese (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "Finlandia (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "Figi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "Isole Falkland (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "Stati Federati di Micronesia (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "Polinesia francese (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "Francia (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "Terre australi e antartiche francesi (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "Gibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "Repubblica Democratica Tedesca (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "Gibilterra (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "Groenlandia (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "Isole Gilbert ed Ellice (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "Guadalupa (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "Grecia (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "Georgia (Repubblica) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "R.S.S. Georgiana (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "Germania (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "Striscia di Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "RAS di Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "Isole Heard e McDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "Ungheria (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "Islanda (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "Irlanda (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "Isola di Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "Iraq (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "Iràn (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "Israele (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "Italia (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "Zone demilitarizzate Israele-Siria (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "Costa d’Avorio (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "Zone demilitarizzate Israele-Giordania (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "zona neutrale iracheno-saudita (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "Giappone (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "atollo Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "Giamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "Giordania (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "Kirghizistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "R.S.S. Kirghiza (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "Corea del Nord (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "Corea del Sud (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "Kazakistan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "R.S.S. Kazaka (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "Libano (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "Lituania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "R.S.S. Lituana (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "Sporadi Equatoriali (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "Lussemburgo (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "Lettonia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "R.S.S. Lettone (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "Libia (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "RAS di Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "Martinica (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "Marocco (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "Moldavia (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "R.S.S. Moldava (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "Messico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "Mozambico (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "Antille Olandesi (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "Carolina del Nord  (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "Dakota del Nord (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "Paesi Bassi (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "Terranova e Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "Irlanda del Nord (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "Nuovo Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "Nuova Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "Isole Marianne settentrionali (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "Nuovo Messico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "Norvegia (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "[Nova Scotia] (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "[Northwest Territories] (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "[Nunavut] (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "[Nevada] (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "Isole Marianne settentrionali (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "Isola Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "[New York (State)] (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "Nuova Zelanda (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "[Ohio] (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "[Oklahoma] (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "[Ontario] (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "[Oregon] (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "[Pitcairn Island] (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "Perù (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "[Paracel Islands] (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "Filippine (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "[Prince Edward Island] (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "Polonia (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "Panamá (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "Portogallo (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "Papua Nuova Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "Portorico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "[Portuguese Timor] (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "[Queensland] (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "[Québec (Province)] (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "Riunione (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "[Rhode Island] (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "Romania (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "[Russia (Federation)] (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "[Russian S.F.S.R.] (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr "[Ryukyu Islands, Southern] (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "Sudafrica (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "[Svalbard] (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "[Saint-Barthélemy] (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "[South Carolina] (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "Sud Sudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "[South Dakota] (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "São Tomé e Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "[Spanish North Africa] (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "[Sikkim] (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "[Sint Maarten] (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "[Saskatchewan] (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "Spagna (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "Swaziland (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "[Surinam] (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "Sahara occidentale (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "[Saint-Martin] (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "[Scotland] (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "Arabia Saudita (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "[Swan Islands] (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "Svezia (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "[Syria] (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "Svizzera (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "Tagikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "[Tajik S.S.R.] (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "Isole Turks e Caicos (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "Thailandia (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "Tunisia (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "[Turkmen S.S.R.] (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "[Tasmania] (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "[Tennessee] (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "Trinidad e Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "Emirati Arabi Uniti (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "[Trust Territory of the Pacific Islands] (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "Turchia (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "[Texas] (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "Egitto (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "[United States Misc. Caribbean Islands] (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "[United Kingdom Misc. Islands] (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "[United Kingdom Misc. Islands] (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "Regno Unito (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "Ucraina (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "Ucraina (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "[United States Misc. Pacific Islands] (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "[Soviet Union] (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "Stati Uniti (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "[Utah] (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "Uzbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "[Uzbek S.S.R.] (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "[Virginia] (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "Isole Vergini Britanniche (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "[Vatican City] (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "Isole Vergini Americane (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "[Vietnam, North] (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "[Various places] (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "[Victoria] (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "[Vietnam, South] (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "[Vermont] (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "[Washington (State)] (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "[West Berlin] (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "[Western Australia] (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "Wallis e Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "[Wisconsin] (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "[West Bank of the Jordan River] (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "[Wake Island] (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "[Wales] (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "[West Virginia] (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "[Wyoming] (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "[Christmas Island (Indian Ocean)] (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "Isole Cocos (Keeling) (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "Maldive (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "[Saint Kitts-Nevis] (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "Isole Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "[Midway Islands] (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "[Coral Sea Islands Territory] (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "[Saint Kitts-Nevis-Anguilla] (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "[Saint Helena] (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "Saint-Pierre e Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "Saint Vincent e Grenadine (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "Macedonia del Nord (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "[New South Wales] (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "Slovacchia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "[Northern Territory] (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "[Spratly Island] (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "Cechia (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "[South Australia] (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "Georgia del Sud e Sandwich australi (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "Slovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "[No place, unknown, or undetermined] (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "Regno Unito (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "[Soviet Union] (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "Stati Uniti (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "[Yukon Territory] (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "[Yemen (People's Democratic Republic)] (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "[Serbia and Montenegro] (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Cantoni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "AG (Argovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "AI (Appenzello Interno)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "AR (Appenzello Esterno)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "BE (Berna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "BL (Basilea Campagna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "BS (Basilea Città)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "FR (Friburgo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "GE (Ginevra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "GL (Glarona)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "GR (Grigioni)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "JU (Giura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "LU (Lucerna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "NW (Nidvaldo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "OW (Obvaldo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "SG (San Gallo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "SH (Sciaffusa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "SO (Soletta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "SZ (Svitto)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "TG (Turgovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "TI (Ticino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "VS (Vallese)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "ZG (Zugo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "ZH (Zurigo)"
 
@@ -6542,8 +6541,8 @@ msgid ""
 "Uniform Resource Identifier (URI), which provides standard syntax for "
 "locating an object using existing Internet protocols."
 msgstr ""
-"Uniform Resource Identifier (URI), una sintassi standard per localizzare un "
-"oggetto utilizzando i protocolli Internet esistenti."
+"Uniform Resource Identifier (URI), una sintassi standard per localizzare "
+"un oggetto utilizzando i protocolli Internet esistenti."
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:83
 msgid "Source of the URI."
@@ -6876,12 +6875,15 @@ msgstr "annulato"
 msgid ""
 "The name of the explicit action that triggered the transition to current "
 "state"
-msgstr ""
-"Il nome dell'azione che ha innescato la transizione verso lo stato attuale"
+msgstr "Il nome dell'azione che ha innescato la transizione verso lo stato attuale"
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "Un'altra localizzazione online esiste in questa biblioteca"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7236,8 +7238,7 @@ msgstr "La richiesta sull'esemplare %(item_id)s è stata annullata."
 msgid ""
 "Error during the cancellation of the request of                 item "
 "%(item_id)s."
-msgstr ""
-"Errore durante l'annullamento della richiesta sull'esemplare %(item_id)s."
+msgstr "Errore durante l'annullamento della richiesta sull'esemplare %(item_id)s."
 
 #: rero_ils/modules/patrons/views.py:128
 #, python-format
@@ -7722,10 +7723,6 @@ msgstr "Catalogo collectivo"
 msgid "RERO ILS global"
 msgstr "RERO ILS globale"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "Ricerca"
@@ -7742,6 +7739,10 @@ msgstr "Nuovo a %(sitename)s?"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "Password dimenticata?"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format
@@ -7767,3 +7768,4 @@ msgstr "è stato eliminato."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Clicca qui per reimpostare la password"
+

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,84 +16,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr ""
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr ""
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr ""
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr ""
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr ""
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr ""
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr ""
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr ""
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr ""
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr ""
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr ""
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr ""
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr ""
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr ""
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr ""
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr ""
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr ""
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr ""
 
@@ -179,8 +179,8 @@ msgid "sound"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr ""
 
@@ -216,42 +216,42 @@ msgid "ui_language_it"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr ""
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr ""
 
@@ -335,10 +335,10 @@ msgid "Account ID"
 msgstr ""
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -415,10 +415,10 @@ msgstr ""
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -562,8 +562,8 @@ msgid "Choose a date"
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr ""
@@ -693,12 +693,12 @@ msgid "Rate"
 msgstr ""
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -983,20 +983,20 @@ msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1051,11 +1051,11 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1083,5300 +1083,5302 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
-msgid "Statements"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
-msgid "Statement"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+msgid "Statements"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
+msgid "Statement"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
 "Start date of the publication. This must be an integer, ie 1989, 453, "
 "-50. Used to sort search results. Once this field is set, a free formed "
 "date of publication can be added in the next field."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
 "Used to sort search results. Once this field is set, a free formed date "
 "of publication can be added in the next field."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
-msgid "Identifier value."
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+msgid "Identifier value."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
-msgid "Acquisition terms"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
-msgid "Acquisition terms of the resource."
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+msgid "Acquisition terms"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+msgid "Acquisition terms of the resource."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
-msgid "Electronic Locations"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
-#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
-msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
+msgid "Electronic Locations"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
+msgid "Information needed to locate and access an electronic resource."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
-msgid "Example: https://www.rero.ch/"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+msgid "Example: https://www.rero.ch/"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
-msgid "Is displayed next to the link, as additional information"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+msgid "Is displayed next to the link, as additional information"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr ""
 
@@ -6835,8 +6837,12 @@ msgid ""
 "state"
 msgstr ""
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
+msgstr ""
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
 msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
@@ -7669,10 +7675,6 @@ msgstr ""
 msgid "RERO ILS global"
 msgstr ""
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr ""
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr ""
@@ -7688,6 +7690,10 @@ msgstr ""
 
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
+msgstr ""
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
 msgstr ""
 
 #: rero_ils/templates/rero_ils/register_user.html:25

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for rero-ils.
+# Dutch translations for rero-ils.
 # Copyright (C) 2020 RERO
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
@@ -7,100 +7,99 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020
 # bibsys UCL <bibsys@uclouvain.be>, 2020
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-03-30 08:13+0200\n"
+"POT-Creation-Date: 2020-04-09 15:48+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
+"Language: nl\n"
 "Language-Team: Dutch (https://www.transifex.com/rero/teams/77935/nl/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Language: nl\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: rero_ils/config.py:121
+#: rero_ils/config.py:124
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:257
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:80
 msgid "French"
 msgstr "Frans"
 
-#: rero_ils/config.py:122
+#: rero_ils/config.py:125
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:265
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:92
 msgid "German"
 msgstr "Duits"
 
-#: rero_ils/config.py:123
+#: rero_ils/config.py:126
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:269
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:88
 msgid "Italian"
 msgstr "Italiaans"
 
-#: rero_ils/config.py:162 rero_ils/config.py:166
+#: rero_ils/config.py:165 rero_ils/config.py:169
 msgid "rero-ils"
 msgstr "rero-ils"
 
-#: rero_ils/config.py:210
+#: rero_ils/config.py:213
 msgid "Welcome to RERO-ILS!"
 msgstr "Welkom bij RERO-ILS!"
 
-#: rero_ils/config.py:1091
+#: rero_ils/config.py:1094
 msgid "document_type"
 msgstr "type van document"
 
-#: rero_ils/config.py:1092
+#: rero_ils/config.py:1095
 msgid "organisation"
 msgstr "organisatie"
 
-#: rero_ils/config.py:1095 rero_ils/config.py:1139 rero_ils/config.py:1161
-#: rero_ils/config.py:1183
+#: rero_ils/config.py:1098 rero_ils/config.py:1142 rero_ils/config.py:1164
+#: rero_ils/config.py:1186
 msgid "library"
 msgstr "bibliotheek"
 
-#: rero_ils/config.py:1096
+#: rero_ils/config.py:1099
 msgid "author__en"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1097
+#: rero_ils/config.py:1100
 msgid "author__fr"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1098
+#: rero_ils/config.py:1101
 msgid "author__de"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1099
+#: rero_ils/config.py:1102
 msgid "author__it"
 msgstr "Auteurs"
 
-#: rero_ils/config.py:1100
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3646
+#: rero_ils/config.py:1103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "language"
 msgstr "taal"
 
-#: rero_ils/config.py:1101
+#: rero_ils/config.py:1104
 msgid "subject"
 msgstr "onderwerp"
 
-#: rero_ils/config.py:1102 rero_ils/config.py:1162 rero_ils/config.py:1184
+#: rero_ils/config.py:1105 rero_ils/config.py:1165 rero_ils/config.py:1187
 msgid "status"
 msgstr "status"
 
-#: rero_ils/config.py:1118
+#: rero_ils/config.py:1121
 msgid "roles"
 msgstr "rollen"
 
-#: rero_ils/config.py:1140
+#: rero_ils/config.py:1143
 msgid "budget"
 msgstr "begroting"
 
-#: rero_ils/config.py:1200
+#: rero_ils/config.py:1203
 msgid "sources"
 msgstr "bron"
 
@@ -186,8 +185,8 @@ msgid "sound"
 msgstr "geluid"
 
 #: rero_ils/manual_translations.txt:38
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1184
 msgid "video"
 msgstr "video"
 
@@ -223,42 +222,42 @@ msgid "ui_language_it"
 msgstr "Italiano"
 
 #: rero_ils/manual_translations.txt:52
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:497
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:497
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:503
 msgid "bf:Publication"
 msgstr "Publicatie"
 
 #: rero_ils/manual_translations.txt:53
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:501
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:501
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:507
 msgid "bf:Manufacture"
 msgstr "Productie"
 
 #: rero_ils/manual_translations.txt:54
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:505
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:505
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:511
 msgid "bf:Distribution"
 msgstr "Verspreiding, distributie"
 
 #: rero_ils/manual_translations.txt:55
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:509
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:509
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:515
 msgid "bf:Production"
 msgstr "Productie"
 
 #: rero_ils/manual_translations.txt:56
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:588
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:541
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:594
 msgid "bf:Place"
 msgstr "bf:Place"
 
 #: rero_ils/manual_translations.txt:57
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:596
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:602
 msgid "Date"
 msgstr "Datum"
 
@@ -342,10 +341,10 @@ msgid "Account ID"
 msgstr "Account ID"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:33
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:404
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:336
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:410
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:33
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:43
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:49
@@ -422,10 +421,10 @@ msgstr "URI van de bibliotheek"
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:397
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:376
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:397
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:403
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:93
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:165
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:27
@@ -569,8 +568,8 @@ msgid "Choose a date"
 msgstr "Kies een datum"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:729
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:120
 msgid "Notes"
 msgstr "Notas"
@@ -700,12 +699,12 @@ msgid "Rate"
 msgstr "Tarief"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:109
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:728
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:908
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:62
 msgid "Note"
@@ -888,16 +887,15 @@ msgstr "Aantal dagen voor de vervaldatum."
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:70
 msgid "Number of days before due date for sending the due_soon notification."
 msgstr ""
-"Aantal dagen voor de vervaldatum voor het verzenden van de kennisgeving van "
-"de vervaldatum."
+"Aantal dagen voor de vervaldatum voor het verzenden van de kennisgeving "
+"van de vervaldatum."
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:76
 msgid "Number of days after due date"
 msgstr "Aantal dagen na de vervaldatum"
 
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:77
-msgid ""
-"Number of days after due date for sending the first overdue notification."
+msgid "Number of days after due date for sending the first overdue notification."
 msgstr ""
 "Aantal dagen na de vervaldatum voor het verzenden van de eerste "
 "achterstallige kennisgeving."
@@ -995,20 +993,20 @@ msgstr "Document PID"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:47
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:320
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:388
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:787
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:38
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:51
@@ -1063,11 +1061,11 @@ msgstr "Video"
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:100
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:104
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:53
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:84
 msgid "Title"
@@ -1095,333 +1093,335 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:165
 msgid "Parts"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:169
 msgid "Part"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:178
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:181
 msgid "Part Number"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:190
 msgid "Part Name"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:457
 msgid "Responsibilities"
 msgstr "Verantwoordelijkheden"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:461
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:208
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:461
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:59
 msgid "Responsibility"
 msgstr "Verantwoordelijkheid"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:217
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:217
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:221
 msgid "Proper titles"
 msgstr "Eigenlijke titels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:218
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
-"Uniforme titel, een verwante of analytische titel die wordt gecontroleerd "
-"door een autoriteitsbestand of -lijst, gebruikt als een toegevoegd "
+"Uniforme titel, een verwante of analytische titel die wordt gecontroleerd"
+" door een autoriteitsbestand of -lijst, gebruikt als een toegevoegd "
 "toegangspunt."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:222
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:226
 msgid "Proper title"
 msgstr "Eigenlijke titel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:234
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:238
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:110
 msgid "Is part of"
 msgstr "Maakt deel uit van"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:239
 msgid "Title of the host document."
 msgstr "Titel van het gastheerdocument."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:247
 msgid "Languages"
 msgstr "Talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:244
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:248
 msgid "List of languages for the resource."
 msgstr "Lijst van talen voor de bron."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:250
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:254
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:140
 msgid "Language"
 msgstr "Taal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:255
 msgid "Languages for the resource."
 msgstr "Talen van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:268
 msgid "Type of the language."
 msgstr "Taaltype"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:272
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:278
 msgid "bf:Language"
 msgstr "Taal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:285
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:285
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:291
 msgid "Translated from"
 msgstr "Vertaald uit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:286
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:292
 msgid "Language from which a resource is translated."
 msgstr "Taal van waaruit een bron wordt vertaald."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:297
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:297
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:303
 msgid "Authors"
 msgstr "Auteurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:298
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:304
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Auteur(s) van de bron(nen). Kan zowel personen als organisaties zijn."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:302
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:308
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:63
 msgid "Author"
 msgstr "Auteur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:329
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:329
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:335
 #: rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html:22
 msgid "Person"
 msgstr "Persoon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:337
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:337
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:343
 msgid "Person's name."
 msgstr "Naam van de persoon."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:348
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:354
 msgid "MEF person ref"
 msgstr "MEF persoon ref"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:365
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
-"Informatie over de geboorte en de dood van een persoon. Handig om mensen te "
-"ontmaskeren."
+"Informatie over de geboorte en de dood van een persoon. Handig om mensen "
+"te ontmaskeren."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:917
 msgid "Qualifier"
 msgstr "Kwalificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:373
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
-"Informatie over de persoon, dat wil zeggen haar beroep. Handig om mensen te "
-"ontmaskeren."
+"Informatie over de persoon, dat wil zeggen haar beroep. Handig om mensen "
+"te ontmaskeren."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:405
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:411
 msgid "Organisation's name."
 msgstr "Naam van de organisatie."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:425
 msgid "Copyright Dates"
 msgstr "Datum van het auteursrecht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:430
 msgid "Copyright Date"
 msgstr "Datum van het auteursrecht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:433
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:433
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:439
 msgid "Edition statements"
 msgstr "Edition statements"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:438
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:444
 msgid "Edition statement"
 msgstr "Edition statement"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:442
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:448
 msgid "Edition designations"
 msgstr "Edition designations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:446
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:452
 msgid "Edition designation"
 msgstr "Edition designation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:466
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:472
 msgid "Provision Activities"
 msgstr "Productie, publicatie, verspreiding, distributie, verwerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:470
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:476
 msgid "Provision Activity"
 msgstr "Productie, publicatie, verspreiding, distributie, verwerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:516
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:522
 msgid "Places"
 msgstr "Plaatsen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:521
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:521
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:527
 msgid "Place"
 msgstr "Plaats"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:532
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:538
 msgid "type"
 msgstr "type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3726
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3755
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
 msgid "Country"
 msgstr "Land"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:553
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:553
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:559
 msgid "Canton"
 msgstr "Kanton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:561
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:561
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
 msgid "Statements"
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:566
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:572
 msgid "Statement"
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:573
 msgid "Statement of place and agent of the provision activity."
 msgstr "Vermelden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:592
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:598
 msgid "bf:Agent"
 msgstr "Agent"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:613
 msgid "Labels"
 msgstr "Labels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:616
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:622
 msgid "Note."
 msgstr "Nota."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:629
 msgid "Start date of publication"
 msgstr "Datum van de publicatie 1"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:624
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:630
 msgid ""
-"Start date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Start date of the publication. This must be an integer, ie 1989, 453, "
+"-50. Used to sort search results. Once this field is set, a free formed "
+"date of publication can be added in the next field."
 msgstr ""
-"Begindatum van de publicatie. Dit moet een geheel getal zijn, namelijk 1989,"
-" 453, -50, -50. Wordt gebruikt om zoekresultaten te sorteren. Zodra dit veld"
-" is ingesteld, kan een vrije datum van publicatie worden toegevoegd in het "
-"volgende veld."
+"Begindatum van de publicatie. Dit moet een geheel getal zijn, namelijk "
+"1989, 453, -50, -50. Wordt gebruikt om zoekresultaten te sorteren. Zodra "
+"dit veld is ingesteld, kan een vrije datum van publicatie worden "
+"toegevoegd in het volgende veld."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:633
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:633
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:639
 msgid "End date of publication"
 msgstr "Datum van de publicatie 2"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:634
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:640
 msgid ""
 "End date of the publication. This must be an integer, ie 1989, 453, -50. "
-"Used to sort search results. Once this field is set, a free formed date of "
-"publication can be added in the next field."
+"Used to sort search results. Once this field is set, a free formed date "
+"of publication can be added in the next field."
 msgstr ""
-"Einddatum van de publicatie. Dit moet een geheel getal zijn, namelijk 1989, "
-"453, -50. Wordt gebruikt om zoekresultaten te sorteren. Zodra dit veld is "
-"ingesteld, kan een vrije datum van publicatie worden toegevoegd in het "
-"volgende veld."
+"Einddatum van de publicatie. Dit moet een geheel getal zijn, namelijk "
+"1989, 453, -50. Wordt gebruikt om zoekresultaten te sorteren. Zodra dit "
+"veld is ingesteld, kan een vrije datum van publicatie worden toegevoegd "
+"in het volgende veld."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:652
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:658
 msgid "Extent"
 msgstr "Materieel belang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:653
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:653
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:659
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "Materieel belang van de bron, d.w.z. aantal pagina's of volumes."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:661
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:661
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
 msgid "Other Material Characteristics"
 msgstr "Andere materiaaleigenschappen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:662
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
@@ -1429,4988 +1429,4987 @@ msgstr ""
 "Andere materiaaleigenschappen, d.w.z. illustraties, zwart en met of "
 "gekleurd."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:673
 msgid "Formats"
 msgstr "Formaten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:668
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:674
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Formaat van de bron, dat wil zeggen afmetingen in cm."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:677
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:677
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:683
 msgid "Additional materials"
 msgstr "Extra materialen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:678
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:684
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Begeleidend materiaal van de bron, d.w.z. kaarten."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:686
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:686
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:698
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:100
 msgid "Series"
 msgstr "Serie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:687
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:693
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:699
 msgid "Series to which belongs the resource."
 msgstr "Serie waartoe de bron behoort."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:705
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:705
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:711
 msgid "Title of the series."
 msgstr "Titel van de serie."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:709
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:709
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:715
 msgid "Numbering"
 msgstr "Nummering"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:716
 msgid "Numbering of the resource within the series."
 msgstr "Nummering van de bron binnen de serie."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:724
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:730
 msgid "Note on the resource."
 msgstr "Opmerking over de bron."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:740
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:746
 msgid "Abstracts"
 msgstr "Abstracten"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:741
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:741
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:747
 msgid "Abstract of the resource."
 msgstr "Abstract van de bron."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:745
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:745
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:751
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:83
 msgid "Abstract"
 msgstr "Abstract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:764
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:760
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:770
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:125
 msgid "Identifier"
 msgstr "Identificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:809
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:809
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:815
 msgid "bf:AudioIssueNumber"
 msgstr "Audio issue number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:813
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:813
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:819
 msgid "bf:Doi"
 msgstr "DOI"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:817
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:817
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:823
 msgid "bf:Ean"
 msgstr "EAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:821
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:821
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:827
 msgid "bf:Gtin14Number"
 msgstr "Gtin-14 nummer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:825
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:825
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:831
 msgid "bf:Identifier"
 msgstr "Identificator (onbepaald type)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:829
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:829
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:835
 msgid "bf:Isan"
 msgstr "ISAN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:833
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:833
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:839
 msgid "bf:Isbn"
 msgstr "ISBN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:837
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:837
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:843
 msgid "bf:Ismn"
 msgstr "ISMN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:841
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:841
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:847
 msgid "bf:Isrc"
 msgstr "ISRC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:845
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:845
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:851
 msgid "bf:Issn"
 msgstr "ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:849
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:849
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:855
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:853
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:853
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:859
 msgid "bf:Local"
 msgstr "Locaal identificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:857
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:857
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:863
 msgid "bf:MatrixNumber"
 msgstr "Audio matrix number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:861
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:861
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:867
 msgid "bf:MusicDistributorNumber"
 msgstr "Music distributor number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:865
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:865
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:871
 msgid "bf:MusicPlate"
 msgstr "Music plate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:869
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:869
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:875
 msgid "bf:MusicPublisherNumber"
 msgstr "Music publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:873
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:873
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:879
 msgid "bf:PublisherNumber"
 msgstr "Publisher number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:877
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:877
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:883
 msgid "bf:Upc"
 msgstr "UPC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:881
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:881
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:887
 msgid "bf:Urn"
 msgstr "URN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:885
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:885
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:891
 msgid "bf:VideoRecordingNumber"
 msgstr "Video recording number"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:889
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:895
 msgid "uri"
 msgstr "uri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:896
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:902
 msgid "Identifier value"
 msgstr "Waarde van de identificator"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:897
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:897
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
 msgid "Identifier value."
 msgstr "Waarde van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:909
 msgid "Note of the identifier."
 msgstr "Nota van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:912
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:918
 msgid "Qualifier of the identifier."
 msgstr "Kwalificator van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:920
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
 msgid "Acquisition terms"
 msgstr "Aankoopvoorwaarden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:921
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:921
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
 msgid "Acquisition terms of the resource."
 msgstr "Aankoopvoorwaarden van de bron."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:926
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:166
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:82
 msgid "Source"
 msgstr "Bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
 msgid "Source of the identifier."
 msgstr "Bron van de identificator."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:932
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:938
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:40
 msgid "Status"
 msgstr "Status"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:933
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:933
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:939
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status van de ISBN/ISSN-identificatiecode."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:941
 msgid "ISBN/ISSN status should be selected in the list below."
-msgstr ""
-"De ISBN/ISSN-status moet in de onderstaande lijst worden geselecteerd."
+msgstr "De ISBN/ISSN-status moet in de onderstaande lijst worden geselecteerd."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:961
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:115
 msgid "Subjects"
 msgstr "Onderwerpen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:962
 msgid "Subject of the resource."
 msgstr "Onderwerp van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:960
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:966
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:972
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:64
 msgid "Electronic Locations"
 msgstr "Elektronische locaties"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:973
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:979
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:65
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informatie die nodig is om een elektronische bron te lokaliseren en te "
 "benaderen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:978
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:984
 msgid "Electronic Location"
 msgstr "Elektronische locatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:997
 msgid "url"
 msgstr "url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:992
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:998
 msgid "Record a unique URL here."
 msgstr "Neem hier een unieke URL op."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:993
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:993
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
 msgid "Example: https://www.rero.ch/"
 msgstr "Voorbeeld: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1005
 msgid "Type of link"
 msgstr "Soort link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1017
 msgid "resource"
 msgstr "bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1021
 msgid "version of resource"
 msgstr "versie van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1025
 msgid "related resource"
 msgstr "verbonden bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1029
 msgid "hidden Url"
 msgstr "verborgen Url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1033
 msgid "no info"
 msgstr "geen informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1034
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1040
 msgid "Content type"
 msgstr "Soort inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1041
 msgid "Is displayed as the text of the link"
 msgstr "Wordt weergegeven als de tekst van de link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1070
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1076
 msgid "poster"
 msgstr "affiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1074
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1080
 msgid "audio"
 msgstr "audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1078
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1084
 msgid "postcard"
 msgstr "postkaart"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1082
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1088
 msgid "addition"
 msgstr "aanvulling"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1086
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1092
 msgid "debriefing"
 msgstr "debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1090
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1096
 msgid "exhibition documentation"
 msgstr "tentoonstellingsdocumentatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1094
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1100
 msgid "erratum"
 msgstr "erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1098
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1104
 msgid "bookplate"
 msgstr "boekmerk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1102
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1108
 msgid "extract"
 msgstr "extract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1106
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1112
 msgid "educational sheet"
 msgstr "onderwijsformulier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1110
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1116
 msgid "illustrations"
 msgstr "illustraties"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1114
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1120
 msgid "cover image"
 msgstr "omslagafbeelding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1118
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1124
 msgid "delivery information"
 msgstr "leveringsinformatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1122
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1128
 msgid "biographical information"
 msgstr "biografische informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1126
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1132
 msgid "introduction/preface"
 msgstr "introductie/voorwoord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1130
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1136
 msgid "class reading"
 msgstr "class reading"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1134
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1140
 msgid "teacher's kit"
 msgstr "educatief pakket"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1138
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1144
 msgid "publisher's note"
 msgstr "uitgave opmerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1142
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1148
 msgid "note on content"
 msgstr "opmerking over de inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1146
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1152
 msgid "title page"
 msgstr "titelpagina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1150
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1156
 msgid "photography"
 msgstr "fotografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1154
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1160
 msgid "summarization"
 msgstr "samenvatting"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1158
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1164
 msgid "online resource via RERO DOC"
 msgstr "online bron via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1162
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1168
 msgid "press review"
 msgstr "persoverzicht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1166
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1172
 msgid "web site"
 msgstr "website"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1170
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1176
 msgid "table of contents"
 msgstr "inhoudsopgave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1174
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "full text"
 msgstr "integrale tekst"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1185
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1185
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
 msgid "Uniform Resource Identifier Public Note"
 msgstr "URI openbare nota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1186
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
 msgid "Is displayed next to the link, as additional information"
 msgstr "Wordt naast de link weergegeven, als extra informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1198
 msgid "Example: Access only from the library"
 msgstr "Voorbeeld: Toegang alleen vanuit de bibliotheek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
 msgid "Harvested"
 msgstr "Geoogst"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1204
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1210
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 "Document is geoogst of niet, zal de record editie of iets dergelijks "
 "uitschakelen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1217
 msgid "Language value"
 msgstr "Taalwaarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1709
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1713
 msgid "lang_abk"
 msgstr "Abchazisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1717
 msgid "lang_ace"
 msgstr "Atjehs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1721
 msgid "lang_ach"
 msgstr "Akoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1725
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1729
 msgid "lang_ady"
 msgstr "Adygees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1733
 msgid "lang_afa"
 msgstr "Afro-Aziatische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1737
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1741
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1745
 msgid "lang_ain"
 msgstr "Aino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1749
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1753
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1757
 msgid "lang_alb"
 msgstr "Albanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1761
 msgid "lang_ale"
 msgstr "Aleoetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1765
 msgid "lang_alg"
 msgstr "Algonkische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1769
 msgid "lang_alt"
 msgstr "Zuid-Altaïsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1773
 msgid "lang_amh"
 msgstr "Amhaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1777
 msgid "lang_ang"
 msgstr "Oudengels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1781
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1785
 msgid "lang_apa"
 msgstr "Na-Denétalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1789
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1793
 msgid "lang_arc"
 msgstr "Aramees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1797
 msgid "lang_arg"
 msgstr "Aragonees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1801
 msgid "lang_arm"
 msgstr "Armeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1805
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1809
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1813
 msgid "lang_art"
 msgstr "Kunsttalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1817
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1821
 msgid "lang_asm"
 msgstr "Assamees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1825
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1829
 msgid "lang_ath"
 msgstr "Athabaskische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1833
 msgid "lang_aus"
 msgstr "Australische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1837
 msgid "lang_ava"
 msgstr "Avarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1841
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1845
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1849
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1853
 msgid "lang_aze"
 msgstr "Azerbeidzjaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1857
 msgid "lang_bad"
 msgstr "Bandatalen (Centraal-Afrika)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1861
 msgid "lang_bai"
 msgstr "Bamileke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1865
 msgid "lang_bak"
 msgstr "Basjkiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1869
 msgid "lang_bal"
 msgstr "Beloetsji"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1873
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1877
 msgid "lang_ban"
 msgstr "Balinees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1881
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1885
 msgid "lang_bas"
 msgstr "Basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1889
 msgid "lang_bat"
 msgstr "Baltische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1893
 msgid "lang_bej"
 msgstr "Beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1897
 msgid "lang_bel"
 msgstr "Wit-Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1901
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1905
 msgid "lang_ben"
 msgstr "Bengaals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1909
 msgid "lang_ber"
 msgstr "Berber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1913
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1917
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1921
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1925
 msgid "lang_bin"
 msgstr "Bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1929
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1933
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1937
 msgid "lang_bnt"
 msgstr "Bantoetalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1941
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1945
 msgid "lang_bra"
 msgstr "Braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1949
 msgid "lang_bre"
 msgstr "Bretons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1953
 msgid "lang_btk"
 msgstr "Bataktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1957
 msgid "lang_bua"
 msgstr "Boerjatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1961
 msgid "lang_bug"
 msgstr "Buginees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1965
 msgid "lang_bul"
 msgstr "Bulgaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1969
 msgid "lang_bur"
 msgstr "Birmaans, Birmees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1973
 msgid "lang_byn"
 msgstr "Blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1977
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1981
 msgid "lang_cai"
 msgstr "Midden-Amerikaanse Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1985
 msgid "lang_car"
 msgstr "Caribisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1989
 msgid "lang_cat"
 msgstr "Catalaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1993
 msgid "lang_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1997
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2001
 msgid "lang_cel"
 msgstr "Keltische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2005
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2009
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2013
 msgid "lang_che"
 msgstr "Tsjetsjeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2017
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2021
 msgid "lang_chi"
 msgstr "Chinees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2025
 msgid "lang_chk"
 msgstr "Chuukees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2029
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2033
 msgid "lang_chn"
 msgstr "Chinook Jargon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2037
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2041
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2045
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2049
 msgid "lang_chu"
 msgstr "Kerkslavisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2053
 msgid "lang_chv"
 msgstr "Tsjoevasjisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2057
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2061
 msgid "lang_cmc"
 msgstr "Chamische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2065
 msgid "lang_cnr"
 msgstr "Montenegrijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2069
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2073
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2077
 msgid "lang_cos"
 msgstr "Corsicaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2081
 msgid "lang_cpe"
 msgstr "Engelse creoolse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2085
 msgid "lang_cpf"
 msgstr "Franse creoolse talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2089
 msgid "lang_cpp"
 msgstr "Portugese creoolse talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2093
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2097
 msgid "lang_crh"
 msgstr "Krim-Tataars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2101
 msgid "lang_crp"
 msgstr "Creools en Pidgin (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2105
 msgid "lang_csb"
 msgstr "Kasjoebisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2109
 msgid "lang_cus"
 msgstr "Koesjitische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2113
 msgid "lang_cze"
 msgstr "Tsjechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2117
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2121
 msgid "lang_dan"
 msgstr "Deens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2125
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2129
 msgid "lang_day"
 msgstr "Dajaktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2133
 msgid "lang_del"
 msgstr "Delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2137
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2141
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2145
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2149
 msgid "lang_div"
 msgstr "Divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2153
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2157
 msgid "lang_dra"
 msgstr "Dravidische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2161
 msgid "lang_dsb"
 msgstr "Nedersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2165
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2169
 msgid "lang_dum"
 msgstr "Middelnederlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2173
 msgid "lang_dut"
 msgstr "Nederlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2177
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2181
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2185
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2189
 msgid "lang_egy"
 msgstr "Oudegyptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2193
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2197
 msgid "lang_elx"
 msgstr "Elamitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2201
 msgid "lang_eng"
 msgstr "Engels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2205
 msgid "lang_enm"
 msgstr "Middelengels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2209
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2213
 msgid "lang_est"
 msgstr "Estisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2217
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2221
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2225
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2229
 msgid "lang_fao"
 msgstr "Faeröers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2233
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2237
 msgid "lang_fij"
 msgstr "Fijisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2241
 msgid "lang_fil"
 msgstr "Filipijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2245
 msgid "lang_fin"
 msgstr "Fins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2249
 msgid "lang_fiu"
 msgstr "Fins-Oegrische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2253
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2257
 msgid "lang_fre"
 msgstr "Frans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2261
 msgid "lang_frm"
 msgstr "Middelfrans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2265
 msgid "lang_fro"
 msgstr "Oudfrans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2269
 msgid "lang_frr"
 msgstr "Noord-Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2273
 msgid "lang_frs"
 msgstr "Oost-Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2277
 msgid "lang_fry"
 msgstr "Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2281
 msgid "lang_ful"
 msgstr "Fulah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2285
 msgid "lang_fur"
 msgstr "Friulisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2289
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2293
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2297
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2301
 msgid "lang_gem"
 msgstr "Germaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2305
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2309
 msgid "lang_ger"
 msgstr "Duits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2313
 msgid "lang_gez"
 msgstr "Ge’ez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2317
 msgid "lang_gil"
 msgstr "Gilbertees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2321
 msgid "lang_gla"
 msgstr "Schots-Gaelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2325
 msgid "lang_gle"
 msgstr "Iers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2329
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2333
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2337
 msgid "lang_gmh"
 msgstr "Middelhoogduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2341
 msgid "lang_goh"
 msgstr "Oudhoogduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2345
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2349
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2353
 msgid "lang_got"
 msgstr "Gothisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2357
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2361
 msgid "lang_grc"
 msgstr "Oudgrieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2365
 msgid "lang_gre"
 msgstr "Grieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2369
 msgid "lang_grn"
 msgstr "Guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2373
 msgid "lang_gsw"
 msgstr "Zwitserduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2377
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2381
 msgid "lang_gwi"
 msgstr "Gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2385
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2389
 msgid "lang_hat"
 msgstr "Haïtiaans Creools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2393
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2397
 msgid "lang_haw"
 msgstr "Hawaïaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2401
 msgid "lang_heb"
 msgstr "Hebreeuws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2405
 msgid "lang_her"
 msgstr "Herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2409
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2413
 msgid "lang_him"
 msgstr "Himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2417
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2421
 msgid "lang_hit"
 msgstr "Hettitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2425
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2429
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2433
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2437
 msgid "lang_hsb"
 msgstr "Oppersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2441
 msgid "lang_hun"
 msgstr "Hongaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2445
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2449
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2453
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2457
 msgid "lang_ice"
 msgstr "Ijslands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2461
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2465
 msgid "lang_iii"
 msgstr "Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2469
 msgid "lang_ijo"
 msgstr "Ijawtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2473
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2477
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2481
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2485
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2489
 msgid "lang_inc"
 msgstr "Indo-Arische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2493
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2497
 msgid "lang_ine"
 msgstr "Indo-Europese talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2501
 msgid "lang_inh"
 msgstr "Ingoesjetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2505
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2509
 msgid "lang_ira"
 msgstr "Iraanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2513
 msgid "lang_iro"
 msgstr "Irokese talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2517
 msgid "lang_ita"
 msgstr "Italiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2521
 msgid "lang_jav"
 msgstr "Javaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2525
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2529
 msgid "lang_jpn"
 msgstr "Japans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2533
 msgid "lang_jpr"
 msgstr "Judeo-Perzisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2537
 msgid "lang_jrb"
 msgstr "Judeo-Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2541
 msgid "lang_kaa"
 msgstr "Karakalpaks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2545
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2549
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2553
 msgid "lang_kal"
 msgstr "Groenlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2557
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2561
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2565
 msgid "lang_kar"
 msgstr "Karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2569
 msgid "lang_kas"
 msgstr "Kasjmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2573
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2577
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2581
 msgid "lang_kaz"
 msgstr "Kazachs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2585
 msgid "lang_kbd"
 msgstr "Kabardisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2589
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2593
 msgid "lang_khi"
 msgstr "Khoisantalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2597
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2601
 msgid "lang_kho"
 msgstr "Khotanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2605
 msgid "lang_kik"
 msgstr "Gikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2609
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2613
 msgid "lang_kir"
 msgstr "Kirgizisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2617
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2621
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2625
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2629
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2633
 msgid "lang_kor"
 msgstr "Koreaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2637
 msgid "lang_kos"
 msgstr "Kosraeaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2641
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2645
 msgid "lang_krc"
 msgstr "Karatsjaj-Balkarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2649
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2649
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2653
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2653
 msgid "lang_kro"
 msgstr "Krutalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2657
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2657
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2661
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2661
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2665
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2665
 msgid "lang_kum"
 msgstr "Koemuks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2669
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2669
 msgid "lang_kur"
 msgstr "Koerdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2673
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2673
 msgid "lang_kut"
 msgstr "Kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2677
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2677
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2681
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2681
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2685
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2685
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2689
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2689
 msgid "lang_lao"
 msgstr "Laotiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2693
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2693
 msgid "lang_lat"
 msgstr "Latijn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2697
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2697
 msgid "lang_lav"
 msgstr "Lets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2701
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2701
 msgid "lang_lez"
 msgstr "Lezgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2705
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2705
 msgid "lang_lim"
 msgstr "Limburgs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2709
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2709
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2713
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2713
 msgid "lang_lit"
 msgstr "Litouws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2717
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2717
 msgid "lang_lol"
 msgstr "Mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2721
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2725
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2725
 msgid "lang_ltz"
 msgstr "Luxemburgs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2729
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2729
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2733
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2733
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2737
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2737
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2741
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2741
 msgid "lang_lui"
 msgstr "Luiseno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2745
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2745
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2749
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2749
 msgid "lang_luo"
 msgstr "Luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2753
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2753
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2757
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2757
 msgid "lang_mac"
 msgstr "Macedonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2761
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2761
 msgid "lang_mad"
 msgstr "Madoerees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2765
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2765
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2769
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2769
 msgid "lang_mah"
 msgstr "Marshallees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2773
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2773
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2777
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2777
 msgid "lang_mak"
 msgstr "Makassaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2781
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2781
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2785
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2785
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2789
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2789
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2793
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2793
 msgid "lang_map"
 msgstr "Austronesische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2797
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2797
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2801
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2801
 msgid "lang_mas"
 msgstr "Maa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2805
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2805
 msgid "lang_may"
 msgstr "Maleis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2809
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2809
 msgid "lang_mdf"
 msgstr "Moksja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2813
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2813
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2817
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2817
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2821
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2821
 msgid "lang_mga"
 msgstr "Middeliers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2825
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2825
 msgid "lang_mic"
 msgstr "Mi’kmaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2829
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2829
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2833
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2833
 msgid "lang_mis"
 msgstr "niet gecodeerde talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2837
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2837
 msgid "lang_mkh"
 msgstr "Mon-Khmertalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2841
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2841
 msgid "lang_mlg"
 msgstr "Malagassisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2845
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2845
 msgid "lang_mlt"
 msgstr "Maltees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2849
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2849
 msgid "lang_mnc"
 msgstr "Mantsjoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2853
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2853
 msgid "lang_mni"
 msgstr "Meitei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2857
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2857
 msgid "lang_mno"
 msgstr "Manobotalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2861
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2861
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2865
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2865
 msgid "lang_mon"
 msgstr "Mongools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2869
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2869
 msgid "lang_mos"
 msgstr "Mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2873
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2873
 msgid "lang_mul"
 msgstr "Meerdere talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2877
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2877
 msgid "lang_mun"
 msgstr "Mundatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2881
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2881
 msgid "lang_mus"
 msgstr "Creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2885
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2885
 msgid "lang_mwl"
 msgstr "Mirandees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2889
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2889
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2893
 msgid "lang_myn"
 msgstr "Mayatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2897
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2897
 msgid "lang_myv"
 msgstr "Erzja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2901
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2901
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2905
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2905
 msgid "lang_nai"
 msgstr "Noord-Amerikaans Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2909
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2909
 msgid "lang_nap"
 msgstr "Napolitaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2913
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2913
 msgid "lang_nau"
 msgstr "Nauruaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2917
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2917
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2921
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2921
 msgid "lang_nbl"
 msgstr "Zuid-Ndbele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2925
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2925
 msgid "lang_nde"
 msgstr "Noord-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2929
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2929
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2933
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2933
 msgid "lang_nds"
 msgstr "Nedersaksisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2937
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2937
 msgid "lang_nep"
 msgstr "Nepalees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2941
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2941
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2945
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2949
 msgid "lang_nic"
 msgstr "Niger-Congotalen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2953
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2953
 msgid "lang_niu"
 msgstr "Niueaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2957
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2957
 msgid "lang_nno"
 msgstr "Noors - Nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2961
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2961
 msgid "lang_nob"
 msgstr "Noors - Bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2965
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2965
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2969
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2969
 msgid "lang_non"
 msgstr "Oudnoors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2973
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2973
 msgid "lang_nor"
 msgstr "Noors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2977
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2977
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2981
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2981
 msgid "lang_nso"
 msgstr "Noord-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2985
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2985
 msgid "lang_nub"
 msgstr "Nubisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2989
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2989
 msgid "lang_nwc"
 msgstr "Klassiek Nepalbhasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2993
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2993
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2997
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2997
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3001
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3001
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3005
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3005
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3009
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3009
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3013
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3013
 msgid "lang_oci"
 msgstr "Occitaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3017
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3017
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3021
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3021
 msgid "lang_ori"
 msgstr "Odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3025
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3025
 msgid "lang_orm"
 msgstr "Afaan Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3029
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3029
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3033
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3033
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3037
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3037
 msgid "lang_ota"
 msgstr "Ottomaans-Turks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3041
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3041
 msgid "lang_oto"
 msgstr "Otomi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3045
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3045
 msgid "lang_paa"
 msgstr "Papoeatalen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3049
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3049
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3053
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3053
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3057
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3057
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3061
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3061
 msgid "lang_pan"
 msgstr "Punjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3065
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3065
 msgid "lang_pap"
 msgstr "Papiaments"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3069
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3069
 msgid "lang_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3073
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3073
 msgid "lang_peo"
 msgstr "Oudperzisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3077
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3077
 msgid "lang_per"
 msgstr "Perzisch (Farsi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3081
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3081
 msgid "lang_phi"
 msgstr "Filipijns (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3085
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3085
 msgid "lang_phn"
 msgstr "Foenicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3089
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3089
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3093
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3093
 msgid "lang_pol"
 msgstr "Pools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3097
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3097
 msgid "lang_pon"
 msgstr "Pohnpeiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3101
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3101
 msgid "lang_por"
 msgstr "Portugees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3105
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3105
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3109
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3109
 msgid "lang_pro"
 msgstr "Oudprovençaals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3113
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3113
 msgid "lang_pus"
 msgstr "Pasjtoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3117
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3117
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3121
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3121
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3125
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3125
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3129
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3129
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3133
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3133
 msgid "lang_roa"
 msgstr "Romaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3137
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3137
 msgid "lang_roh"
 msgstr "Reto-Romaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3141
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3141
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3145
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3145
 msgid "lang_rum"
 msgstr "Roemeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3149
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3149
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3153
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3153
 msgid "lang_rup"
 msgstr "Aroemeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3157
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3157
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3161
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3161
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3165
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3165
 msgid "lang_sag"
 msgstr "Sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3169
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3169
 msgid "lang_sah"
 msgstr "Jakoets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3173
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3173
 msgid "lang_sai"
 msgstr "Zuid-Amerikaanse Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3177
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3177
 msgid "lang_sal"
 msgstr "Salishtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3181
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3181
 msgid "lang_sam"
 msgstr "Samaritaans-Aramees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3185
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3185
 msgid "lang_san"
 msgstr "Sanskriet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3189
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3189
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3193
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3193
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3197
 msgid "lang_scn"
 msgstr "Siciliaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3201
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3201
 msgid "lang_sco"
 msgstr "Schots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3205
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3205
 msgid "lang_sel"
 msgstr "Selkoeps"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3209
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3209
 msgid "lang_sem"
 msgstr "Semitische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3213
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3213
 msgid "lang_sga"
 msgstr "Oudiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3217
 msgid "lang_sgn"
 msgstr "Gebarentalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3221
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3221
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3225
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3225
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3229
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3229
 msgid "lang_sin"
 msgstr "Singalees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3233
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3233
 msgid "lang_sio"
 msgstr "Sioux-Catawbatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3237
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3237
 msgid "lang_sit"
 msgstr "Sino-Tibetaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3241
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3241
 msgid "lang_sla"
 msgstr "Slavische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3245
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3245
 msgid "lang_slo"
 msgstr "Slowaaks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3249
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3249
 msgid "lang_slv"
 msgstr "Sloveens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3253
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3253
 msgid "lang_sma"
 msgstr "Zuid-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3257
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3257
 msgid "lang_sme"
 msgstr "Noord-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3261
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3261
 msgid "lang_smi"
 msgstr "Samisch (Laps)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3265
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3265
 msgid "lang_smj"
 msgstr "Lule-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3269
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3269
 msgid "lang_smn"
 msgstr "Inari-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3273
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3273
 msgid "lang_smo"
 msgstr "Samoaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3277
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3277
 msgid "lang_sms"
 msgstr "Skolt-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3281
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3281
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3285
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3285
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3289
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3289
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3293
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3293
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3297
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3297
 msgid "lang_som"
 msgstr "Somalisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3301
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3301
 msgid "lang_son"
 msgstr "Songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3305
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3305
 msgid "lang_sot"
 msgstr "Zuid-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3309
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3309
 msgid "lang_spa"
 msgstr "Spaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3313
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3313
 msgid "lang_srd"
 msgstr "Sardijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3317
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3317
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3321
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3321
 msgid "lang_srp"
 msgstr "Servisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3325
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3325
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3329
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3329
 msgid "lang_ssa"
 msgstr "Nilo-Saharaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3333
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3333
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3337
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3337
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3341
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3341
 msgid "lang_sun"
 msgstr "Soendanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3345
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3345
 msgid "lang_sus"
 msgstr "Soesoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3349
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3349
 msgid "lang_sux"
 msgstr "Soemerisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3353
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3353
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3357
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3357
 msgid "lang_swe"
 msgstr "Zweeds"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3361
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3361
 msgid "lang_syc"
 msgstr "Klassiek Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3365
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3365
 msgid "lang_syr"
 msgstr "Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3369
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3369
 msgid "lang_tah"
 msgstr "Tahitiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3373
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3373
 msgid "lang_tai"
 msgstr "Taitalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3377
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3377
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3381
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3381
 msgid "lang_tat"
 msgstr "Tataars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3385
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3385
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3389
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3389
 msgid "lang_tem"
 msgstr "Timne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3393
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3393
 msgid "lang_ter"
 msgstr "Tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3397
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3397
 msgid "lang_tet"
 msgstr "Tetun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3401
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3401
 msgid "lang_tgk"
 msgstr "Tadzjieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3405
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3405
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3409
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3413
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3413
 msgid "lang_tib"
 msgstr "Tibetaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3417
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3417
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3421
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3421
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3425
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3425
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3429
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3429
 msgid "lang_tkl"
 msgstr "Tokelaus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3433
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3433
 msgid "lang_tlh"
 msgstr "Klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3437
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3437
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3441
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3441
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3445
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3445
 msgid "lang_tog"
 msgstr "Nyasa Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3449
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3449
 msgid "lang_ton"
 msgstr "Tongaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3453
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3453
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3457
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3457
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3461
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3461
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3465
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3465
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3469
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3469
 msgid "lang_tuk"
 msgstr "Turkmeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3473
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3473
 msgid "lang_tum"
 msgstr "Toemboeka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3477
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3477
 msgid "lang_tup"
 msgstr "Tupi-talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3481
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3481
 msgid "lang_tur"
 msgstr "Turks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3485
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3485
 msgid "lang_tut"
 msgstr "Altaïsche talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3489
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3489
 msgid "lang_tvl"
 msgstr "Tuvaluaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3493
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3493
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3497
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3497
 msgid "lang_tyv"
 msgstr "Toevaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3501
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3501
 msgid "lang_udm"
 msgstr "Oedmoerts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3505
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3505
 msgid "lang_uga"
 msgstr "Oegaritisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3509
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3509
 msgid "lang_uig"
 msgstr "Oeigoers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3513
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3513
 msgid "lang_ukr"
 msgstr "Oekraïens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3517
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3517
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3521
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3521
 msgid "lang_und"
 msgstr "onbekende taal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3525
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3525
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3529
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3529
 msgid "lang_uzb"
 msgstr "Oezbeeks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3533
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3533
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3537
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3537
 msgid "lang_ven"
 msgstr "Venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3541
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3541
 msgid "lang_vie"
 msgstr "Vietnamees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3545
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3545
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3549
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3549
 msgid "lang_vot"
 msgstr "Votisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3553
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3553
 msgid "lang_wak"
 msgstr "Wakashtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3557
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3557
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3561
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3561
 msgid "lang_war"
 msgstr "Waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3565
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3565
 msgid "lang_was"
 msgstr "Washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3569
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3569
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3573
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3573
 msgid "lang_wen"
 msgstr "Sorbische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3577
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3577
 msgid "lang_wln"
 msgstr "Waals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3581
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3581
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3585
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3585
 msgid "lang_xal"
 msgstr "Kalmuks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3589
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3589
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3593
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3593
 msgid "lang_yao"
 msgstr "Yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3597
 msgid "lang_yap"
 msgstr "Yapees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3601
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3601
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3605
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3605
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3609
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3609
 msgid "lang_ypk"
 msgstr "Yupiktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3613
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3613
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3617
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3617
 msgid "lang_zbl"
 msgstr "Blissymbolen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3621
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3621
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3625
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3625
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3629
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3629
 msgid "lang_znd"
 msgstr "Zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3633
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3633
 msgid "lang_zul"
 msgstr "Zoeloe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3637
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3637
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3641
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3641
 msgid "lang_zxx"
 msgstr "geen linguïstische inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3645
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3645
 msgid "lang_zza"
 msgstr "Zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3678
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3681
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3702
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3731
 msgid "Values"
 msgstr "Waarden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3689
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3713
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3721
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3742
 msgid "value"
 msgstr "Waarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4144
 msgid "country_aa"
 msgstr "Albanië (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4148
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4152
 msgid "country_ac"
 msgstr "Ashmore- en Cartier-eilanden (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4156
 msgid "country_aca"
 msgstr "Australian Capital Territory (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4160
 msgid "country_ae"
 msgstr "Algerije (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4164
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4168
 msgid "country_ag"
 msgstr "Argentinië (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4172
 msgid "country_ai"
 msgstr "Armenië (Republiek) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4176
 msgid "country_air"
 msgstr "Armeense S.S.R. (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4180
 msgid "country_aj"
 msgstr "Azerbeidzjan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4184
 msgid "country_ajr"
 msgstr "Azerbeidzjan S.S.R. (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4188
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4192
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4196
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4200
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4204
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4208
 msgid "country_aq"
 msgstr "Antigua en Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4212
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4216
 msgid "country_as"
 msgstr "Amerikaans-Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4220
 msgid "country_at"
 msgstr "Australië (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4224
 msgid "country_au"
 msgstr "Oostenrijk (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4228
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4232
 msgid "country_ay"
 msgstr "Antarctica (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4236
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4240
 msgid "country_ba"
 msgstr "Bahrein (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4244
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4248
 msgid "country_bcc"
 msgstr "British Columbia (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4252
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4256
 msgid "country_be"
 msgstr "België (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4260
 msgid "country_bf"
 msgstr "Bahama’s (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4264
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4268
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4272
 msgid "country_bi"
 msgstr "Brits Indische Oceaanterritorium (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4276
 msgid "country_bl"
 msgstr "Brazilië (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4280
 msgid "country_bm"
 msgstr "Bermuda Islands (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4284
 msgid "country_bn"
 msgstr "Bosnië en Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4288
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4292
 msgid "country_bp"
 msgstr "Salomonseilanden (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4296
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4300
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4304
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4308
 msgid "country_bu"
 msgstr "Bulgarije (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4312
 msgid "country_bv"
 msgstr "Bouveteiland (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4316
 msgid "country_bw"
 msgstr "Belarus (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4320
 msgid "country_bwr"
 msgstr "Wit-Russische S.S.R. (-bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4324
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4328
 msgid "country_ca"
 msgstr "Caribisch Nederland (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4332
 msgid "country_cau"
 msgstr "Californië (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4336
 msgid "country_cb"
 msgstr "Cambodja (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4340
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4344
 msgid "country_cd"
 msgstr "Tsjaad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4348
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4352
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4356
 msgid "country_cg"
 msgstr "Congo (Democratische Republiek) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4360
 msgid "country_ch"
 msgstr "China (Republiek: 1949-) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4364
 msgid "country_ci"
 msgstr "Kroatië (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4368
 msgid "country_cj"
 msgstr "Kaaimaneilanden (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4372
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4376
 msgid "country_cl"
 msgstr "Chili (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4380
 msgid "country_cm"
 msgstr "Kameroen (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4384
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4388
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4392
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4396
 msgid "country_cp"
 msgstr "Canton en Enderbury Islands (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4400
 msgid "country_cq"
 msgstr "Comoren (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4404
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4408
 msgid "country_cs"
 msgstr "Tsjecho-Slowakije (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4412
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4416
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4420
 msgid "country_cv"
 msgstr "Kaapverdië (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4424
 msgid "country_cw"
 msgstr "Cookeilanden (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4428
 msgid "country_cx"
 msgstr "Centraal-Afrikaanse Republiek (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4432
 msgid "country_cy"
 msgstr "Cyprus (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4436
 msgid "country_cz"
 msgstr "[Canal Zone] (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4440
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4444
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4448
 msgid "country_dk"
 msgstr "Denemarken (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4452
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4456
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4460
 msgid "country_dr"
 msgstr "Dominicaanse Republiek (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4464
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4468
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4472
 msgid "country_eg"
 msgstr "Equatoriaal-Guinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4476
 msgid "country_em"
 msgstr "Oost-Timor (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4480
 msgid "country_enk"
 msgstr "[England] (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4484
 msgid "country_er"
 msgstr "Estland (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4488
 msgid "country_err"
 msgstr "Estland (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4492
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4496
 msgid "country_et"
 msgstr "Ethiopië (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4500
 msgid "country_fa"
 msgstr "Faeröer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4504
 msgid "country_fg"
 msgstr "Frans-Guyana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4508
 msgid "country_fi"
 msgstr "Finland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4512
 msgid "country_fj"
 msgstr "Fiji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4516
 msgid "country_fk"
 msgstr "Falkland Islands (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4520
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4524
 msgid "country_fm"
 msgstr "Micronesië (Federale Staten) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4528
 msgid "country_fp"
 msgstr "Frans-Polynesië (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4532
 msgid "country_fr"
 msgstr "Frankrijk (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4536
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4540
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4544
 msgid "country_gau"
 msgstr "Georgië (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4548
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4552
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4556
 msgid "country_ge"
 msgstr "Duitsland (Oost) (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4560
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4564
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4568
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4572
 msgid "country_gl"
 msgstr "Groenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4576
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4580
 msgid "country_gn"
 msgstr "Gilbert and Ellice Islands (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4584
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4588
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4592
 msgid "country_gr"
 msgstr "Griekenland (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4596
 msgid "country_gs"
 msgstr "Georgië (Republiek) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4600
 msgid "country_gsr"
 msgstr "Georgian S.S.R. (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4604
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4608
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4612
 msgid "country_gv"
 msgstr "Guinee (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4616
 msgid "country_gw"
 msgstr "Duitsland (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4620
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4624
 msgid "country_gz"
 msgstr "Gaza Strip (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4628
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4632
 msgid "country_hk"
 msgstr "Hongkong SAR van China (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4636
 msgid "country_hm"
 msgstr "Heard and McDonald Islands (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4640
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4644
 msgid "country_ht"
 msgstr "Haïti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4648
 msgid "country_hu"
 msgstr "Hongarije (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4652
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4656
 msgid "country_ic"
 msgstr "IJsland (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4660
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4664
 msgid "country_ie"
 msgstr "Ierland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4668
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4672
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4672
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4676
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4676
 msgid "country_im"
 msgstr "Isle of Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4680
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4680
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4684
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4684
 msgid "country_io"
 msgstr "Indonesië (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4688
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4688
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4692
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4692
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4696
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4696
 msgid "country_is"
 msgstr "Israël (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4700
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4700
 msgid "country_it"
 msgstr "Italië (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4704
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4704
 msgid "country_iu"
 msgstr "Gedemilitariseerde zones Israël-Syrië (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4708
 msgid "country_iv"
 msgstr "Ivoorkust (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4712
 msgid "country_iw"
 msgstr "Gedemilitariseerde zones Israël-Jordanië (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4716
 msgid "country_iy"
 msgstr "Irak-Saoedi-Arabië Neutrale zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4720
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4724
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4728
 msgid "country_ji"
 msgstr "Johnston Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4732
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4736
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4740
 msgid "country_jo"
 msgstr "Jordanië (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4744
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4748
 msgid "country_kg"
 msgstr "Kirgizië (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4752
 msgid "country_kgr"
 msgstr "Kirghiz S.S.R. (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4756
 msgid "country_kn"
 msgstr "Korea (Noord) (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4760
 msgid "country_ko"
 msgstr "Zuid Korea (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4764
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4768
 msgid "country_ku"
 msgstr "Koeweit (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4772
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4776
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4780
 msgid "country_kz"
 msgstr "Kazachstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4784
 msgid "country_kzr"
 msgstr "Kazakh S.S.R. (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4788
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4792
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4796
 msgid "country_le"
 msgstr "Libanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4800
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4804
 msgid "country_li"
 msgstr "Litouwen (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4808
 msgid "country_lir"
 msgstr "Litouwen (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4812
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4812
 msgid "country_ln"
 msgstr "Central and Southern Line Islands (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4816
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4816
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4820
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4820
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4824
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4824
 msgid "country_lu"
 msgstr "Luxemburg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4828
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4828
 msgid "country_lv"
 msgstr "Letland (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4832
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4832
 msgid "country_lvr"
 msgstr "Letland (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4836
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4836
 msgid "country_ly"
 msgstr "Libië (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4840
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4840
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4844
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4844
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4848
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4848
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4852
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4852
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4856
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4856
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4860
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4860
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4864
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4864
 msgid "country_mg"
 msgstr "Madagaskar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4868
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4868
 msgid "country_mh"
 msgstr "Macau SAR van China (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4872
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4872
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4876
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4876
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4880
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4880
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4884
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4884
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4888
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4888
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4892
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4892
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4896
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4896
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4900
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4900
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4904
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4904
 msgid "country_mp"
 msgstr "Mongolië (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4908
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4908
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4912
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4912
 msgid "country_mr"
 msgstr "Marokko (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4916
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4916
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4920
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4920
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4924
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4924
 msgid "country_mu"
 msgstr "Mauritanië (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4928
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4928
 msgid "country_mv"
 msgstr "Moldavië (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4932
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4932
 msgid "country_mvr"
 msgstr "Moldavian S.S.R. (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4936
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4936
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4940
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4940
 msgid "country_mx"
 msgstr "Mexico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4944
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4944
 msgid "country_my"
 msgstr "Maleisië (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4948
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4948
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4952
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4952
 msgid "country_na"
 msgstr "Nederlandse Antillen (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4956
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4960
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4964
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4964
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4968
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4968
 msgid "country_ne"
 msgstr "Nederland (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4972
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4972
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4976
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4976
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4980
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4980
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4984
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4984
 msgid "country_nik"
 msgstr "Noord-Ierland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4988
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4988
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4992
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4992
 msgid "country_nkc"
 msgstr "New Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4996
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4996
 msgid "country_nl"
 msgstr "Nieuw-Caledonië (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5000
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5000
 msgid "country_nm"
 msgstr "Noordelijke Marianen (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5004
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5004
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5008
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5008
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5012
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5012
 msgid "country_no"
 msgstr "Noorwegen (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5016
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5016
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5020
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5020
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5024
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5024
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5028
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5028
 msgid "country_nsc"
 msgstr "Nova Scotia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5032
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5032
 msgid "country_ntc"
 msgstr "Northwest Territories (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5036
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5036
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5040
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5040
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5044
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5044
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5048
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5048
 msgid "country_nw"
 msgstr "Noordelijke Marianen (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5052
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5052
 msgid "country_nx"
 msgstr "Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5056
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5056
 msgid "country_nyu"
 msgstr "New York (Staat) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5060
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5060
 msgid "country_nz"
 msgstr "Nieuw-Zeeland (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5064
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5064
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5068
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5068
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5072
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5072
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5076
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5076
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5080
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5080
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5084
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5084
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5088
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5088
 msgid "country_pc"
 msgstr "Pitcairn Island (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5092
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5092
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5096
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5096
 msgid "country_pf"
 msgstr "Paracel Islands (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5100
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5100
 msgid "country_pg"
 msgstr "Guinee-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5104
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5104
 msgid "country_ph"
 msgstr "Filipijnen (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5108
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5108
 msgid "country_pic"
 msgstr "Prince Edward Island (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5112
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5112
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5116
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5116
 msgid "country_pl"
 msgstr "Polen (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5120
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5120
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5124
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5124
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5128
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5128
 msgid "country_pp"
 msgstr "Papoea-Nieuw-Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5132
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5132
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5136
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5136
 msgid "country_pt"
 msgstr "Portugees Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5140
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5140
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5144
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5144
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5148
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5148
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5152
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5152
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5156
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5156
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5160
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5160
 msgid "country_rb"
 msgstr "Servië (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5164
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5168
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5168
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5172
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5172
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5176
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5176
 msgid "country_rm"
 msgstr "Roemenië (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5180
 msgid "country_ru"
 msgstr "Rusland (Federatie) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5184
 msgid "country_rur"
 msgstr "Russische S.F.S.R. (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5188
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5188
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5192
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5192
 msgid "country_ry"
 msgstr "Ryukyu Islands, Southern (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5196
 msgid "country_sa"
 msgstr "Zuid-Afrika (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5200
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5200
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5204
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5204
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5208
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5208
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5212
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5212
 msgid "country_sd"
 msgstr "Zuid-Soedan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5216
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5220
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5220
 msgid "country_se"
 msgstr "Seychellen (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5224
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5224
 msgid "country_sf"
 msgstr "Sao Tomé en Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5228
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5228
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5232
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5232
 msgid "country_sh"
 msgstr "Spaans Noord-Afrika (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5236
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5236
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5240
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5240
 msgid "country_sj"
 msgstr "Soedan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5244
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5244
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5248
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5248
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5252
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5252
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5256
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5256
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5260
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5260
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5264
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5264
 msgid "country_so"
 msgstr "Somalië (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5268
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5268
 msgid "country_sp"
 msgstr "Spanje (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5272
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5272
 msgid "country_sq"
 msgstr "eSwatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5276
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5276
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5280
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5280
 msgid "country_ss"
 msgstr "Westelijke Sahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5284
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5284
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5288
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5288
 msgid "country_stk"
 msgstr "Schotland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5292
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5292
 msgid "country_su"
 msgstr "Saoedi-Arabië (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5296
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5296
 msgid "country_sv"
 msgstr "Swan Islands (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5300
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5300
 msgid "country_sw"
 msgstr "Zweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5304
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5304
 msgid "country_sx"
 msgstr "Namibië (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5308
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5308
 msgid "country_sy"
 msgstr "[Syria] (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5312
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5312
 msgid "country_sz"
 msgstr "Zwitserland (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5316
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5316
 msgid "country_ta"
 msgstr "Tadzjikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5320
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5320
 msgid "country_tar"
 msgstr "Tajik S.S.R. (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5324
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5324
 msgid "country_tc"
 msgstr "Turks- en Caicoseilanden (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5328
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5328
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5332
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5332
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5336
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5336
 msgid "country_ti"
 msgstr "Tunesië (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5340
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5340
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5344
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5344
 msgid "country_tkr"
 msgstr "Turkmen S.S.R. (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5348
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5348
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5352
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5352
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5356
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5356
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5360
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5364
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5364
 msgid "country_tr"
 msgstr "Trinidad en Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5368
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5368
 msgid "country_ts"
 msgstr "Verenigde Arabische Emiraten (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5372
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5372
 msgid "country_tt"
 msgstr "Trust Territory of the Pacific Islands (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5376
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5376
 msgid "country_tu"
 msgstr "Turkije (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5380
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5380
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5384
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5384
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5388
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5388
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5392
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5392
 msgid "country_ua"
 msgstr "Egypte (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5396
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5396
 msgid "country_uc"
 msgstr "Verenigde Staten Misc. Caribbean Islands (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5400
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5400
 msgid "country_ug"
 msgstr "Oeganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5404
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5404
 msgid "country_ui"
 msgstr "Verenigd Koninkrijk Misc. Islands (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5408
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5408
 msgid "country_uik"
 msgstr "Verenigd Koninkrijk Misc. Islands (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5412
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5412
 msgid "country_uk"
 msgstr "Verenigd Koninkrijk (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5416
 msgid "country_un"
 msgstr "Oekraïne (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5420
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5420
 msgid "country_unr"
 msgstr "Oekraïne (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5424
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5424
 msgid "country_up"
 msgstr "Verenigde Staten Misc. Pacific Islands (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5428
 msgid "country_ur"
 msgstr "Sovjet-Unie (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5432
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5432
 msgid "country_us"
 msgstr "Verenigde Staten (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5436
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5436
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5440
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5440
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5444
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5444
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5448
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5448
 msgid "country_uz"
 msgstr "Oezbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5452
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5452
 msgid "country_uzr"
 msgstr "Uzbek S.S.R. (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5456
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5456
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5460
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5460
 msgid "country_vb"
 msgstr "Britse Maagdeneilanden (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5464
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5464
 msgid "country_vc"
 msgstr "Vaticaanstad (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5468
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5468
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5472
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5472
 msgid "country_vi"
 msgstr "Amerikaanse Maagdeneilanden (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5476
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5476
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5480
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5480
 msgid "country_vn"
 msgstr "Vietnam, Noord (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5484
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5484
 msgid "country_vp"
 msgstr "[Verschillende plaatsen] (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5488
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5488
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5492
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5492
 msgid "country_vs"
 msgstr "Vietnam, Zuid (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5496
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5496
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5500
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5500
 msgid "country_wau"
 msgstr "Washington (Staat) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5504
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5504
 msgid "country_wb"
 msgstr "West Berlijn (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5508
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5508
 msgid "country_wea"
 msgstr "Western Australia (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5512
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5512
 msgid "country_wf"
 msgstr "Wallis en Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5516
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5516
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5520
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5520
 msgid "country_wj"
 msgstr "Westelijke Jordaanoever (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5524
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5524
 msgid "country_wk"
 msgstr "Wake Island (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5528
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5528
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5532
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5532
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5536
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5536
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5540
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5540
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5544
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5544
 msgid "country_xa"
 msgstr "Christmas Island (Indian Ocean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5548
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5548
 msgid "country_xb"
 msgstr "Cocoseilanden (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5552
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5552
 msgid "country_xc"
 msgstr "Maldiven (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5556
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5556
 msgid "country_xd"
 msgstr "Saint Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5560
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5560
 msgid "country_xe"
 msgstr "Marshalleilanden (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5564
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5564
 msgid "country_xf"
 msgstr "Midway Islands (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5568
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5568
 msgid "country_xga"
 msgstr "Coral Sea Islands Territory (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5572
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5572
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5576
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5576
 msgid "country_xi"
 msgstr "Saint Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5580
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5580
 msgid "country_xj"
 msgstr "Saint Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5584
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5584
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5588
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5588
 msgid "country_xl"
 msgstr "Saint-Pierre en Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5592
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5592
 msgid "country_xm"
 msgstr "Saint Vincent en de Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5596
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5596
 msgid "country_xn"
 msgstr "Noord-Macedonië (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5600
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5600
 msgid "country_xna"
 msgstr "New South Wales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5604
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5604
 msgid "country_xo"
 msgstr "Slowakije (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5608
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5608
 msgid "country_xoa"
 msgstr "Northern Territory (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5612
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5612
 msgid "country_xp"
 msgstr "Spratly Island (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5616
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5616
 msgid "country_xr"
 msgstr "Tsjechië (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5620
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5620
 msgid "country_xra"
 msgstr "Zuid Australië (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5624
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5624
 msgid "country_xs"
 msgstr "Zuid-Georgia en Zuidelijke Sandwicheilanden (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5628
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5628
 msgid "country_xv"
 msgstr "Slovenië (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5632
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5632
 msgid "country_xx"
 msgstr "Geen plaats, onbekend of onbepaald (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5636
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5636
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5640
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5640
 msgid "country_xxk"
 msgstr "Verenigd Koninkrijk (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5644
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5644
 msgid "country_xxr"
 msgstr "Sovjet-Unie (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5648
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5648
 msgid "country_xxu"
 msgstr "Verenigde Staten (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5652
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5652
 msgid "country_ye"
 msgstr "Jemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5656
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5656
 msgid "country_ykc"
 msgstr "Yukon-gebied (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5660
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5660
 msgid "country_ys"
 msgstr "Jemen (Democratische Volksrepubliek) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5664
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5664
 msgid "country_yu"
 msgstr "Servië en Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5668
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5668
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "Cantons"
 msgstr "Kantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5708
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5708
 msgid "canton_ag"
 msgstr "Aargau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5712
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5712
 msgid "canton_ai"
 msgstr "Appenzell Innerrhoden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5716
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5716
 msgid "canton_ar"
 msgstr "Appenzell Ausserrhoden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5720
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5720
 msgid "canton_be"
 msgstr "Bern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5724
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5724
 msgid "canton_bl"
 msgstr "Basel-Landschaft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5728
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5728
 msgid "canton_bs"
 msgstr "Basel-Stadt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5732
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5732
 msgid "canton_fr"
 msgstr "Fribourg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5736
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5736
 msgid "canton_ge"
 msgstr "Genève"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5740
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5740
 msgid "canton_gl"
 msgstr "Glarus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5744
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5744
 msgid "canton_gr"
 msgstr "Graubünden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5748
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5748
 msgid "canton_ju"
 msgstr "Jura"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5752
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5752
 msgid "canton_lu"
 msgstr "Luzern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5756
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5756
 msgid "canton_ne"
 msgstr "Neuchâtel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5760
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5760
 msgid "canton_nw"
 msgstr "Nidwalden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5764
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5764
 msgid "canton_ow"
 msgstr "Obwalden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5768
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5768
 msgid "canton_sg"
 msgstr "Sankt Gallen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5772
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5772
 msgid "canton_sh"
 msgstr "Schaffhausen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5776
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5776
 msgid "canton_so"
 msgstr "Solothurn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5780
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5780
 msgid "canton_sz"
 msgstr "Schwyz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5784
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5784
 msgid "canton_tg"
 msgstr "Thurgau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5788
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5788
 msgid "canton_ti"
 msgstr "Ticino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5792
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5792
 msgid "canton_ur"
 msgstr "Uri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5796
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5796
 msgid "canton_vd"
 msgstr "Vaud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5800
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5800
 msgid "canton_vs"
 msgstr "Valais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5804
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5804
 msgid "canton_zg"
 msgstr "Zug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5808
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5808
 msgid "canton_zh"
 msgstr "Zürich"
 
@@ -6535,8 +6534,9 @@ msgid ""
 "Uniform Resource Identifier (URI), which provides standard syntax for "
 "locating an object using existing Internet protocols."
 msgstr ""
-"Uniform Resource Identifier (URI), dat een standaard syntaxis biedt voor het"
-" lokaliseren van een object met behulp van bestaande internetprotocollen."
+"Uniform Resource Identifier (URI), dat een standaard syntaxis biedt voor "
+"het lokaliseren van een object met behulp van bestaande "
+"internetprotocollen."
 
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:83
 msgid "Source of the URI."
@@ -6870,12 +6870,16 @@ msgid ""
 "The name of the explicit action that triggered the transition to current "
 "state"
 msgstr ""
-"De naam van de actie die de overgang naar de huidige toestand in gang heeft "
-"gezet."
+"De naam van de actie die de overgang naar de huidige toestand in gang "
+"heeft gezet."
 
-#: rero_ils/modules/locations/api.py:68
+#: rero_ils/modules/locations/api.py:69
 msgid "Another online location exists in this library"
 msgstr "Een andere online locatie bestaat in deze bibliotheek"
+
+#: rero_ils/modules/locations/api.py:72
+msgid "Pickup name field is required."
+msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:5
 msgid "JSON schema for an location"
@@ -7621,8 +7625,8 @@ msgid ""
 "Enter your email address below and we will send you a link to reset your "
 "password."
 msgstr ""
-"Vul hieronder uw e-mailadres in en wij sturen u een link om uw wachtwoord "
-"opnieuw in te stellen."
+"Vul hieronder uw e-mailadres in en wij sturen u een link om uw wachtwoord"
+" opnieuw in te stellen."
 
 #: rero_ils/templates/rero_ils/forgot_password.html:37
 #: rero_ils/templates/rero_ils/login_user.html:30
@@ -7711,10 +7715,6 @@ msgstr "Union catalogus"
 msgid "RERO ILS global"
 msgstr "RERO ILS globaal"
 
-#: rero_ils/templates/rero_ils/head.html:29
-msgid "Invenio"
-msgstr "Invenio"
-
 #: rero_ils/templates/rero_ils/header.html:30
 msgid "Search"
 msgstr "Zoeken"
@@ -7731,6 +7731,10 @@ msgstr "Nieuw bij %(sitename)s?"
 #: rero_ils/templates/rero_ils/login_user.html:37
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
+
+#: rero_ils/templates/rero_ils/page.html:36
+msgid "Invenio"
+msgstr "Invenio"
 
 #: rero_ils/templates/rero_ils/register_user.html:25
 #, python-format
@@ -7756,3 +7760,4 @@ msgstr "is verwijderd."
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr "Klik hier om uw wachtwoord opnieuw in te stellen"
+

--- a/tests/unit/test_locations_jsonschema.py
+++ b/tests/unit/test_locations_jsonschema.py
@@ -52,15 +52,3 @@ def test_locations_name(location_schema, loc_public_martigny_data):
         data = copy.deepcopy(loc_public_martigny_data)
         data['name'] = 25
         validate(data, location_schema)
-
-
-def test_locations_pickup(location_schema, loc_public_martigny_data):
-    """Test pickup location behavior through jsonschemas."""
-    validate(loc_public_martigny_data, location_schema)
-
-    # If location is a pickup_location, then the pickup_name must be present.
-    with pytest.raises(ValidationError):
-        data = copy.deepcopy(loc_public_martigny_data)
-        data['is_pickup'] = True
-        del(data['pickup_name'])
-        validate(data, location_schema)


### PR DESCRIPTION
Formly doesn't like the "oneOf" statement present into the schema.
The displayed form contains some empty field for any 'oneOf' possibilities.
Removes 'oneOf' statement from schema and adds extended validation rule solves this problem.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
