### PR TITLE
ui: move to rero-ils-ui v0.1.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -36,14 +36,6 @@
             "index": "pypi",
             "version": "==0.3"
         },
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "arrow": {
             "hashes": [
                 "sha256:5390e464e2c5f76971b60ffa7ee29c598c7501a294bc9f5e6dadcb251a5d027b",

--- a/rero_ils/bundles.py
+++ b/rero_ils/bundles.py
@@ -24,7 +24,7 @@ import os
 from invenio_assets import AngularGettextFilter, GlobBundle, NpmBundle
 from pkg_resources import resource_filename
 
-RERO_ILS_UI_VERSION = '0.0.12'
+RERO_ILS_UI_VERSION = '0.1.0'
 
 
 def catalog(domain):


### PR DESCRIPTION
* Changes rero-ils-ui dependency to version 0.1.0.
* Removes macosx specific packages from Pipefile.lock.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
