### PR TITLE
setup: fix ref. prob. on responsibilityStatement

### DIFF
--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -140,7 +140,7 @@ class Notification(IlsRecord):
 
             from ..documents.views import create_title_responsibilites
             responsibility_statement = create_title_responsibilites(
-                document.get('responsibilityStatement')
+                document.get('responsibilityStatement', [])
             )
             data['loan']['document']['responsibility_statement'] = \
                 next(iter(responsibility_statement or []), '')


### PR DESCRIPTION
When you setup RERO-ils, some document don't have any
responsibilityStatement. Which make the setup failed on some loan
creation.
This commit fixes the problem.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Because of errors in SETUP (`Exception loan requested_by_others: 'NoneType' object is not iterable`).

## How to test?

`pipenv run setup`

Check that no errors (in red) appears during create_loans setup.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
