### PR TITLE
location: unique pickup location for a library

### DIFF
--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -58,7 +58,22 @@
       "title": "Is pickup location",
       "type": "boolean",
       "default": false,
-      "description": "Qualify this location as a pickup location."
+      "description": "Qualify this location as a pickup location.",
+      "form": {
+        "validation": {
+          "validators": {
+            "valueAlreadyExists": {
+              "limitToValues": [
+                true
+              ],
+              "filter": "'library.pid:' + model.library.pid"
+            }
+          },
+          "messages": {
+            "alreadyTakenMessage": "There is already one pickup location in this library."
+          }
+        }
+      }
     },
     "is_online": {
       "title": "Is online location",

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -390,7 +390,7 @@ msgstr "المبلغ المخصص لحساب التزويد"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -401,7 +401,7 @@ msgstr "مكتبة"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6974,27 +6974,31 @@ msgstr "هل مكان إستلام"
 msgid "Qualify this location as a pickup location."
 msgstr "تحديد المكان كمكان إستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "هل مكان مباشر"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "تحديد المكان كمكان مباشر"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "يجب أن يكون تصنيف المباشر وحيدا لكل مكتبة"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "إسم مكان الإستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr "إسم مكان الإستلام إذا كان مختلف عن إسم المكان."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "يجب أن يكون مكان الإستلام وحيدا لكل مكتبة"
 
@@ -7820,3 +7824,4 @@ msgstr "انقر هنا لإعادة تعيين كلمة المرور الخاص
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: de\n"
@@ -396,7 +396,7 @@ msgstr "Zugewiesener Betrag"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -407,7 +407,7 @@ msgstr "Bibliothek"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6999,29 +6999,33 @@ msgstr "Ist Abholort"
 msgid "Qualify this location as a pickup location."
 msgstr "Diesen Standort als Abholort definieren"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Ist Online-Standort"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Diesen Standort als Online-Standort definieren"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "Der Typ \"online\" muss per Bibliothek eindeutig sein."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Abholortname"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Angezeigter Name des Abholortes, falls vom Namen des Standortes "
 "unterschiedlich"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "Der Abholortname muss per Bibliothek eindeutig sein."
 
@@ -7843,3 +7847,4 @@ msgstr "Hier klicken um Passwort zurückzusetzen."
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: en\n"
@@ -396,7 +396,7 @@ msgstr "Allocated amount."
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -407,7 +407,7 @@ msgstr "Library"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6988,27 +6988,31 @@ msgstr "Is pickup location"
 msgid "Qualify this location as a pickup location."
 msgstr "Qualify this location as a pickup location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr "There is already one pickup location in this library."
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Is online location"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Qualify this location as an online location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "There is already one online location in this library."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Pickup location name"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr "Displayed pickup location name, if different from the location name."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "The pickup location name must be unique in your library."
 
@@ -7832,3 +7836,4 @@ msgstr "Click here to reset your password"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -391,7 +391,7 @@ msgstr "Monto asignado para la cuenta."
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -402,7 +402,7 @@ msgstr "Biblioteca"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6990,29 +6990,33 @@ msgstr "Es un lugar de recogida"
 msgid "Qualify this location as a pickup location."
 msgstr "Califique este depósito como lugar de recogida."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Es una ubicación en línea"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Califique esta ubicación como una ubicación en línea."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "El tipo 'en línea' tiene que ser único por biblioteca."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Nombre del lugar de recogida"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nombre del lugar de recogida expuesto si es diferente del nombre del "
 "depósito."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "El nombre del lugar de recogida tiene que ser único en su biblioteca."
 
@@ -7834,3 +7838,4 @@ msgstr "Haga clic aquí para restablecer su contraseña"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.5.2\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -398,7 +398,7 @@ msgstr "Montant alloué"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -409,7 +409,7 @@ msgstr "Bibliothèque"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6998,29 +6998,33 @@ msgstr "Est un bureau de prêt"
 msgid "Qualify this location as a pickup location."
 msgstr "Définir cette localisation comme lieu de retrait."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr "Il existe déjà un autre lieu de retrait pour cette bibliothèque."
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Est une localisation en ligne"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Définir cette localisation comme localisation en ligne"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "Le type d'exemplaire \"en ligne\" doit être unique par bibliothèque"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Nom du lieu de retrait"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nom du lieu de retrait affiché s'il est différent du nom de la "
 "localisation."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "Le nom du lieu de retrait doit être unique dans votre bibliothèque."
 
@@ -7846,3 +7850,4 @@ msgstr "Cliquez ici pour réinitialiser votre mot de passe"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Gianni Pante <gianni.pante@rero.ch>, 2020\n"
 "Language: it\n"
@@ -399,7 +399,7 @@ msgstr "L'importo stanziato al conto."
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -410,7 +410,7 @@ msgstr "Biblioteca"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6998,29 +6998,33 @@ msgstr "È punto di ritiro"
 msgid "Qualify this location as a pickup location."
 msgstr "Definire questa localizzazione come punto di ritiro."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "È una localizzazione online"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Definire questa localizzazione come localizzazione online."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "C'è già una localizzazione online en questa biblioteca."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Nome del punto di ritiro"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nome del punto di ritiro visualizzato, se diverso del nome della "
 "localizzazione."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "Il nome del punto di ritiro à già utilizzato."
 
@@ -7846,3 +7850,4 @@ msgstr "Clicca qui per reimpostare la password"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -384,7 +384,7 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -395,7 +395,7 @@ msgstr ""
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6960,27 +6960,31 @@ msgstr ""
 msgid "Qualify this location as a pickup location."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
-msgid "Is online location"
-msgstr ""
-
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
-msgid "Qualify this location as an online location."
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
 msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+msgid "Is online location"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+msgid "Qualify this location as an online location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr ""
 
@@ -7791,3 +7795,4 @@ msgstr ""
 #: rero_ils/templates/security/email/reset_instructions.html:21
 msgid "Click here to reset your password"
 msgstr ""
+

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.6.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-27 12:09+0200\n"
+"POT-Creation-Date: 2020-04-30 10:20+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -390,7 +390,7 @@ msgstr "Het toegekende bedrag voor de account."
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -401,7 +401,7 @@ msgstr "Bibliotheek"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -6993,29 +6993,33 @@ msgstr "is een afhaallocatie"
 msgid "Qualify this location as a pickup location."
 msgstr "Definieer deze locatie als een afhaallocatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Is online locatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Defineer deze locatie als een online locatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "Het online type moet uniek zijn per bibliotheek"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Naam van de afhaallocatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Weergegeven naam van de afhaallocatie, indien verschillend van de "
 "locatienaam."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "De afhaalplaats moet uniek zijn per bibliotheek"
 
@@ -7837,3 +7841,4 @@ msgstr "Klik hier om uw wachtwoord opnieuw in te stellen"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+


### PR DESCRIPTION
Only one pickup location possible for a library.

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1384?kanban-status=1224894

## How to test?

- Logged as a system librarian / librarian
- Go to professional interface
- Edit your library
- Create a pickup location if no pickup location are already defined.
- Try to create/edit a location a second pickup location. The toggle switch should be red with error message (when focus is loose from toggle switch)

![image](https://user-images.githubusercontent.com/10031585/80688286-daad3500-8acb-11ea-9f89-f36aa1206100.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
