### PR TITLE
item: field call number is now optional

### DIFF
--- a/rero_ils/modules/documents/listener.py
+++ b/rero_ils/modules/documents/listener.py
@@ -59,13 +59,16 @@ def enrich_document_data(sender, json=None, record=None, index=None,
                 'term', holding__pid=holding.pid
             ).scan())
             for item in es_items:
-                data.setdefault('items', []).append({
+                item_record = {
                     'pid': item.pid,
                     'barcode': item.barcode,
-                    'call_number': item.call_number,
                     'status': item.status,
                     'available': item.available
-                })
+                }
+                call_number = item.to_dict().get('call_number')
+                if call_number:
+                    item_record['call_number'] = call_number
+                data.setdefault('items', []).append(item_record)
             data['available'] = Holding.isAvailable(es_items)
 
             holdings.append(data)

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -7,9 +7,8 @@
   "required": [
     "$schema",
     "pid",
-    "barcode",
-    "call_number",
     "location",
+    "barcode",
     "item_type",
     "document",
     "status"
@@ -36,7 +35,6 @@
     },
     "barcode": {
       "title": "Barcode",
-      "description": "Barcode of the item.",
       "type": "string",
       "minLength": 4,
       "form": {
@@ -48,12 +46,14 @@
           "messages": {
             "alreadyTakenMessage": "The barcode is already taken"
           }
+        },
+        "expressionProperties": {
+          "templateOptions.required": "false"
         }
       }
     },
     "call_number": {
       "title": "Call number",
-      "description": "Call number of the item.",
       "type": "string",
       "minLength": 4
     },

--- a/rero_ils/modules/items/templates/rero_ils/detailed_view_items.html
+++ b/rero_ils/modules/items/templates/rero_ils/detailed_view_items.html
@@ -36,7 +36,10 @@
     <section class="py-4">
       <article>
         <dl class="row mb-0">
-          {{ dl(_('Call number'), record.call_number) }}
+          {% if record.call_number %}
+            {{ dl(_('Call number'), record.call_number) }}
+          {% endif %}
+  
           {{ dl(_('Type'), item_type.name) }}
           {{ dl(
             _('Document'),

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -17,7 +17,7 @@
 
 """Utilities for rero-ils editor."""
 
-from datetime import date, time
+from datetime import date, datetime, time
 from json import JSONDecodeError, JSONDecoder
 from time import sleep
 
@@ -230,6 +230,20 @@ def trim_barcode_for_record(data=None):
     """
     if data and data.get('barcode'):
         data['barcode'] = data.get('barcode').strip()
+    return data
+
+
+def generate_item_barcode(data=None):
+    """Generate a barcode for an item record that does not have one.
+
+    The generated barcode is in the format f-YYYYMMDDHHMISSSSS.
+
+    :param data: the item record
+    :return: data with a generated barcode
+    """
+    if not data.get('barcode'):
+        data['barcode'] = 'f-{}'.format(
+            datetime.now().strftime('%Y%m%d%I%M%S%f'))
     return data
 
 

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -224,20 +224,11 @@ msgstr "إنتاج"
 msgid "bf:Place"
 msgstr "مكان"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "التاريخ"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "ebibliomedia"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "mv-cantook"
 
@@ -292,7 +283,7 @@ msgstr "مخطط JSON للحساب"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -374,7 +365,7 @@ msgstr "المبلغ المخصص لحساب التزويد"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -455,7 +446,7 @@ msgstr "URI لحساب التزويد"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "المستند"
 
@@ -525,6 +516,14 @@ msgstr "تمت الموافقة"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "تم الحذف"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "التاريخ"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -967,7 +966,7 @@ msgstr "PID المستند"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "تصنيف"
@@ -6445,8 +6444,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "رقم استدعاء"
 
@@ -6461,7 +6460,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "مكان"
@@ -6603,7 +6602,7 @@ msgstr "نوع الاعارة"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "الإتاحة"
 
@@ -6618,7 +6617,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6691,25 +6690,17 @@ msgstr "النسخة"
 msgid "JSON schema for an item."
 msgstr "مخطط JSON للنسخة"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "مخطط لتدقيق تسجيلات النسخ"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "رقم النسخة"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "باركود النسخة"
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "الرقم الممغنط محجوز"
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "رقم إستدعاء النسخة"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7811,4 +7802,10 @@ msgstr "انقر هنا لإعادة تعيين كلمة المرور الخاص
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "باركود النسخة"
+
+#~ msgid "Call number of the item."
+#~ msgstr "رقم إستدعاء النسخة"
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Peter Weber <peter.weber@rero.ch>, 2020\n"
 "Language: de\n"
@@ -229,20 +229,11 @@ msgstr "Produktion"
 msgid "bf:Place"
 msgstr "Ort"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "Datum"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "Zugriff"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "Zugriff"
 
@@ -297,7 +288,7 @@ msgstr "JSON Schema für Konto"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -379,7 +370,7 @@ msgstr "Zugewiesener Betrag"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -460,7 +451,7 @@ msgstr "URI des Kontos"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Dokument"
 
@@ -530,6 +521,14 @@ msgstr "Genehmigt"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "Gelöscht"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "Datum"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -974,7 +973,7 @@ msgstr "PID des Dokuments"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Typ"
@@ -6467,8 +6466,8 @@ msgstr "Permanenter Identifikator"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Signatur"
 
@@ -6483,7 +6482,7 @@ msgstr "URI der Ausleihkategorie"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Standort"
@@ -6640,7 +6639,7 @@ msgstr "Ausleihkategorie"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
@@ -6655,7 +6654,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6728,25 +6727,17 @@ msgstr "Exemplar"
 msgid "JSON schema for an item."
 msgstr "JSON Schema für ein Exemplar"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "Schema zur Validierung von Exemplaren."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "PID des Exemplars"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "Strichcode des Exemplars."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "Der Barcode ist bereits vergeben"
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "Signatur des Exemplars"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7852,4 +7843,10 @@ msgstr "Hier klicken um Passwort zurückzusetzen."
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "Strichcode des Exemplars."
+
+#~ msgid "Call number of the item."
+#~ msgstr "Signatur des Exemplars"
 

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: en\n"
@@ -229,20 +229,11 @@ msgstr "Production"
 msgid "bf:Place"
 msgstr "Place"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "Date"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "Access"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "Access"
 
@@ -297,7 +288,7 @@ msgstr "JSON schema for an account"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -379,7 +370,7 @@ msgstr "Allocated amount."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -460,7 +451,7 @@ msgstr "Account URI"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Document"
 
@@ -530,6 +521,14 @@ msgstr "Approved"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "Deleted"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "Date"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -972,7 +971,7 @@ msgstr "Document PID"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Type"
@@ -6456,8 +6455,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Call number"
 
@@ -6472,7 +6471,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Location"
@@ -6614,7 +6613,7 @@ msgstr "Circulation category"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Availability"
 
@@ -6629,7 +6628,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6702,25 +6701,17 @@ msgstr "Item"
 msgid "JSON schema for an item."
 msgstr "JSON schema for an item."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "Schema to validate item records against."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "Item ID"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "Barcode of the item."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "The barcode is already taken"
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "Call number of the item."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7820,4 +7811,10 @@ msgstr "Click here to reset your password"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "Barcode of the item."
+
+#~ msgid "Call number of the item."
+#~ msgstr "Call number of the item."
 

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -225,20 +225,11 @@ msgstr "Producción"
 msgid "bf:Place"
 msgstr "Lugar"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "Fecha"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "Acceso"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "Acceso"
 
@@ -293,7 +284,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -375,7 +366,7 @@ msgstr "Monto asignado para la cuenta."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -456,7 +447,7 @@ msgstr "URI de la cuenta"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Documento"
 
@@ -526,6 +517,14 @@ msgstr "Aprobado"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "Suprimido"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "Fecha"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -972,7 +971,7 @@ msgstr "PID del documento"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Tipo"
@@ -6461,8 +6460,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Número de clasificación"
 
@@ -6477,7 +6476,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Depósito"
@@ -6619,7 +6618,7 @@ msgstr "Categoría de préstamo"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Disponibilidad"
 
@@ -6634,7 +6633,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6707,25 +6706,17 @@ msgstr "Ejemplar"
 msgid "JSON schema for an item."
 msgstr "Esquema JSON para el ejemplar."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "Esquema para validar la noticia del ejemplar."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "ID del ejemplar"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "Código de barras del ejemplar."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "El código de barras está utilisado."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "Número de clasificación del ejemplar"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7834,4 +7825,10 @@ msgstr "Haga clic aquí para restablecer su contraseña"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "Código de barras del ejemplar."
+
+#~ msgid "Call number of the item."
+#~ msgstr "Número de clasificación del ejemplar"
 

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -232,20 +232,11 @@ msgstr "Production"
 msgid "bf:Place"
 msgstr "Lieu"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "Date"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "Accès"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "Accès"
 
@@ -300,7 +291,7 @@ msgstr "Schéma JSON d'un compte"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -382,7 +373,7 @@ msgstr "Montant alloué"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -463,7 +454,7 @@ msgstr "URI du compte"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Document"
 
@@ -533,6 +524,14 @@ msgstr "Approuvé"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "Supprimé"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "Date"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -977,7 +976,7 @@ msgstr "PID du document"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Type"
@@ -6469,8 +6468,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Cote"
 
@@ -6485,7 +6484,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Localisation"
@@ -6627,7 +6626,7 @@ msgstr "Catégorie de prêt"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Disponibilité"
 
@@ -6642,7 +6641,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6715,25 +6714,17 @@ msgstr "Exemplaire"
 msgid "JSON schema for an item."
 msgstr "Schéma JSON d'un exemplaire."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "Schéma de validation des exemplaires."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "ID de l'exemplaire"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "Code-barres de l'exemplaire."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "Le code-barres est déjà utilisé"
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "Cote de l'exemplaire."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7843,4 +7834,10 @@ msgstr "Cliquez ici pour réinitialiser votre mot de passe"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "Code-barres de l'exemplaire."
+
+#~ msgid "Call number of the item."
+#~ msgstr "Cote de l'exemplaire."
 

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: it\n"
@@ -231,20 +231,11 @@ msgstr "Produzione"
 msgid "bf:Place"
 msgstr "Luogo"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "Data"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "Accesso"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "Accesso"
 
@@ -299,7 +290,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -381,7 +372,7 @@ msgstr "L'importo stanziato al conto."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -462,7 +453,7 @@ msgstr "URI del conto"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Documento"
 
@@ -532,6 +523,14 @@ msgstr "Approvato"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "Eliminato"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "Data"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -976,7 +975,7 @@ msgstr "PID di documento"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Tipo"
@@ -6467,8 +6466,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Segnatura"
 
@@ -6483,7 +6482,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Localizzazione"
@@ -6625,7 +6624,7 @@ msgstr "Categoria di prestito"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Disponibilità"
 
@@ -6640,7 +6639,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6713,25 +6712,17 @@ msgstr "Esemplare"
 msgid "JSON schema for an item."
 msgstr "JSON schema per un esemplare"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "Schema di convalida per esemplari"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "ID dell'esemplare"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "Codice a barre dell'esemplare."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "Il codice a barre è già utilizzato"
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "Segnatura dell'esemplare."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7844,4 +7835,10 @@ msgstr "Clicca qui per reimpostare la password"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "Codice a barre dell'esemplare."
+
+#~ msgid "Call number of the item."
+#~ msgstr "Segnatura dell'esemplare."
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -218,20 +218,11 @@ msgstr ""
 msgid "bf:Place"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr ""
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr ""
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr ""
 
@@ -286,7 +277,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -368,7 +359,7 @@ msgstr ""
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -449,7 +440,7 @@ msgstr ""
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr ""
 
@@ -518,6 +509,14 @@ msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
+msgstr ""
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
@@ -961,7 +960,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr ""
@@ -6431,8 +6430,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr ""
 
@@ -6447,7 +6446,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr ""
@@ -6589,7 +6588,7 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr ""
 
@@ -6604,7 +6603,7 @@ msgid "ID"
 msgstr ""
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6677,24 +6676,16 @@ msgstr ""
 msgid "JSON schema for an item."
 msgstr ""
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr ""
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr ""
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr ""
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
-msgstr ""
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
 msgstr ""
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-04-30 16:40+0200\n"
+"POT-Creation-Date: 2020-05-05 08:25+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -224,20 +224,11 @@ msgstr "Productie"
 msgid "bf:Place"
 msgstr "Plaats"
 
-#: rero_ils/manual_translations.txt:51
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
-msgid "Date"
-msgstr "Datum"
-
-#: rero_ils/manual_translations.txt:54
+#: rero_ils/manual_translations.txt:53
 msgid "ebibliomedia"
 msgstr "Toegang"
 
-#: rero_ils/manual_translations.txt:55
+#: rero_ils/manual_translations.txt:54
 msgid "mv-cantook"
 msgstr "Toegang"
 
@@ -292,7 +283,7 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:36
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:24
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:21
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:25
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:16
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:14
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:23
@@ -374,7 +365,7 @@ msgstr "Het toegekende bedrag voor de account."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:53
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
@@ -455,7 +446,7 @@ msgstr "Account URI"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:42
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Document"
 
@@ -525,6 +516,14 @@ msgstr "Goedgekeurd"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:146
 msgid "Deleted"
 msgstr "Verwijderd"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:597
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:360
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:597
+msgid "Date"
+msgstr "Datum"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
@@ -971,7 +970,7 @@ msgstr "Document PID"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Type"
@@ -6462,8 +6461,8 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:36
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:55
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:39
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Plaatskenmerk"
 
@@ -6478,7 +6477,7 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:49
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Locatie"
@@ -6620,7 +6619,7 @@ msgstr "Circulatie categorie"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:57
+#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
@@ -6635,7 +6634,7 @@ msgid "ID"
 msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:38
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
 #: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
@@ -6708,25 +6707,17 @@ msgstr "Exemplaar"
 msgid "JSON schema for an item."
 msgstr "JSON schema voor een kopie."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:27
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:26
 msgid "Schema to validate item records against."
 msgstr "Schema om kopiesrecords tegen te valideren."
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:33
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:32
 msgid "Item ID"
 msgstr "Kopie ID"
 
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:39
-msgid "Barcode of the item."
-msgstr "Barcode van de kopie."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:49
+#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
 msgid "The barcode is already taken"
 msgstr "De barcode is al bezet."
-
-#: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-msgid "Call number of the item."
-msgstr "Plaatskenmerk van de exemplaar."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7837,4 +7828,10 @@ msgstr "Klik hier om uw wachtwoord opnieuw in te stellen"
 
 #~ msgid "BNF"
 #~ msgstr "BNF"
+
+#~ msgid "Barcode of the item."
+#~ msgstr "Barcode van de kopie."
+
+#~ msgid "Call number of the item."
+#~ msgstr "Plaatskenmerk van de exemplaar."
 


### PR DESCRIPTION
The item call number is now an optional field in both the
item json schema and item editor. This field is not populated
if not given by the librarian.

The item barcode remains a required field in the item json schema,
on the other side, it is an optional field in the item editor.

If a librarian decides not to add an item barcode, the system
will automatically populate the barcode with the following:
f-current timestamp.

* Adapts schema, tests and files correspondingly.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Aly Badr<aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1328?milestone=263424

## How to test?

`bootstrap` + `setup`
in the UI, you should be able to add items without barcodes

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [x] Extracted translations?
