### PR TITLE
location: unique pickup location for a library

### DIFF
--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -58,7 +58,22 @@
       "title": "Is pickup location",
       "type": "boolean",
       "default": false,
-      "description": "Qualify this location as a pickup location."
+      "description": "Qualify this location as a pickup location.",
+      "form": {
+        "validation": {
+          "validators": {
+            "valueAlreadyExists": {
+              "limitToValues": [
+                true
+              ],
+              "filter": "'library.pid:' + model.library.pid"
+            }
+          },
+          "messages": {
+            "alreadyTakenMessage": "There is already one pickup location in this library."
+          }
+        }
+      }
     },
     "is_online": {
       "title": "Is online location",

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -365,9 +365,8 @@ msgstr "المبلغ المخصص لحساب التزويد"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -378,7 +377,7 @@ msgstr "مكتبة"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -446,7 +445,6 @@ msgstr "URI لحساب التزويد"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "المستند"
 
@@ -914,21 +912,21 @@ msgid "Item type URI"
 msgstr "URI لتصنيف النسخة"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "متاح"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "غيرمتاح"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "مستحق الى"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "مطلوب"
 
@@ -966,7 +964,6 @@ msgstr "PID المستند"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "تصنيف"
@@ -6412,15 +6409,15 @@ msgstr "النسخ"
 msgid "item"
 msgstr "النسخة"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "طلب"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "اختيار مكان الإستلام"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "تنسيقات التصدير"
 
@@ -6445,7 +6442,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "رقم استدعاء"
 
@@ -6460,7 +6456,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "مكان"
@@ -6602,7 +6597,6 @@ msgstr "نوع الاعارة"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "الإتاحة"
 
@@ -6618,7 +6612,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "باركود"
@@ -6940,27 +6933,31 @@ msgstr "هل مكان إستلام"
 msgid "Qualify this location as a pickup location."
 msgstr "تحديد المكان كمكان إستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "هل مكان مباشر"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "تحديد المكان كمكان مباشر"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "يوجد مكان مباشر آخر في هذه المكتبة"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "إسم مكان الإستلام"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr "إسم مكان الإستلام إذا كان مختلف عن إسم المكان."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "اسم مكان الإستلام محجوز"
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Peter Weber <peter.weber@rero.ch>, 2020\n"
 "Language: de\n"
@@ -370,9 +370,8 @@ msgstr "Zugewiesener Betrag"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -383,7 +382,7 @@ msgstr "Bibliothek"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -451,7 +450,6 @@ msgstr "URI des Kontos"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Dokument"
 
@@ -921,21 +919,21 @@ msgid "Item type URI"
 msgstr "URI des Exemplartypen"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "verfügbar"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "nicht verfügbar"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "Fällig am"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "Bestellt"
 
@@ -973,7 +971,6 @@ msgstr "PID des Dokuments"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Typ"
@@ -6434,15 +6431,15 @@ msgstr "Exemplare"
 msgid "item"
 msgstr "Exemplar"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "Bestellung"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "Abholort wählen"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "Exportformate"
 
@@ -6467,7 +6464,6 @@ msgstr "Permanenter Identifikator"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Signatur"
 
@@ -6482,7 +6478,6 @@ msgstr "URI der Ausleihkategorie"
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Standort"
@@ -6639,7 +6634,6 @@ msgstr "Ausleihkategorie"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
@@ -6655,7 +6649,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "Strichcode"
@@ -6979,29 +6972,33 @@ msgstr "Ist Abholort"
 msgid "Qualify this location as a pickup location."
 msgstr "Diesen Standort als Abholort definieren"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Ist Online-Standort"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Diesen Standort als Online-Standort definieren"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "Es gibt bereits einen Online-Standort für diese Bibliothek."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Abholortname"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Angezeigter Name des Abholortes, falls vom Namen des Standortes "
 "unterschiedlich"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "Der Name des Abhole-Standortes ist bereits vergeben."
 

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: en\n"
@@ -370,9 +370,8 @@ msgstr "Allocated amount."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -383,7 +382,7 @@ msgstr "Library"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -451,7 +450,6 @@ msgstr "Account URI"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Document"
 
@@ -919,21 +917,21 @@ msgid "Item type URI"
 msgstr "Item type URI"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "available"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "not available"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "due until"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "requested"
 
@@ -971,7 +969,6 @@ msgstr "Document PID"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Type"
@@ -6423,15 +6420,15 @@ msgstr "items"
 msgid "item"
 msgstr "item"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "Request"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "Select a Pickup Location"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "Export Formats"
 
@@ -6456,7 +6453,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Call number"
 
@@ -6471,7 +6467,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Location"
@@ -6613,7 +6608,6 @@ msgstr "Circulation category"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Availability"
 
@@ -6629,7 +6623,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "Barcode"
@@ -6953,27 +6946,31 @@ msgstr "Is pickup location"
 msgid "Qualify this location as a pickup location."
 msgstr "Qualify this location as a pickup location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr "There is already one pickup location in this library."
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Is online location"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Qualify this location as an online location."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "There is already one online location in this library."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Pickup location name"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr "Displayed pickup location name, if different from the location name."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "The pickup location name is already taken."
 

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: bibsys UCL <bibsys@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -366,9 +366,8 @@ msgstr "Monto asignado para la cuenta."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -379,7 +378,7 @@ msgstr "Biblioteca"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -447,7 +446,6 @@ msgstr "URI de la cuenta"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Documento"
 
@@ -919,21 +917,21 @@ msgid "Item type URI"
 msgstr "URI del tipo de ejemplar"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "disponible"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "no disponible"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "Para devolver el"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "Reservado"
 
@@ -971,7 +969,6 @@ msgstr "PID del documento"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Tipo"
@@ -6428,15 +6425,15 @@ msgstr "ejemplares"
 msgid "item"
 msgstr "ejemplar"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "Reservar"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "Seleccione un lugar de recogida"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "Formatos de exportación"
 
@@ -6461,7 +6458,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Número de clasificación"
 
@@ -6476,7 +6472,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Depósito"
@@ -6618,7 +6613,6 @@ msgstr "Categoría de préstamo"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Disponibilidad"
 
@@ -6634,7 +6628,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "Código de barras"
@@ -6956,29 +6949,33 @@ msgstr "Es un lugar de recogida"
 msgid "Qualify this location as a pickup location."
 msgstr "Califique este depósito como lugar de recogida."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Es una ubicación en línea"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Califique esta ubicación como una ubicación en línea."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Nombre del lugar de recogida"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nombre del lugar de recogida expuesto si es diferente del nombre del "
 "depósito."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr ""
 

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -373,9 +373,8 @@ msgstr "Montant alloué"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -386,7 +385,7 @@ msgstr "Bibliothèque"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -454,7 +453,6 @@ msgstr "URI du compte"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Document"
 
@@ -924,21 +922,21 @@ msgid "Item type URI"
 msgstr "URI du type d'exemplaire"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "disponible"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "non disponible"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "à rendre le"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "demandé"
 
@@ -976,7 +974,6 @@ msgstr "PID du document"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Type"
@@ -6436,15 +6433,15 @@ msgstr "exemplaires"
 msgid "item"
 msgstr "exemplaire"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "Demander"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "Choisir un lieu de retrait"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "Formats d'export"
 
@@ -6469,7 +6466,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Cote"
 
@@ -6484,7 +6480,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Localisation"
@@ -6626,7 +6621,6 @@ msgstr "Catégorie de prêt"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Disponibilité"
 
@@ -6642,7 +6636,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "Code-barre"
@@ -6964,29 +6957,33 @@ msgstr "Est un bureau de prêt"
 msgid "Qualify this location as a pickup location."
 msgstr "Définir cette localisation comme lieu de retrait."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Est une localisation en ligne"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Définir cette localisation comme localisation en ligne"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr "Le type d'exemplaire \"en ligne\" doit être unique par bibliothèque"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Nom du lieu de retrait"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nom du lieu de retrait affiché s'il est différent du nom de la "
 "localisation."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr "Le nom du lieu de retrait doit être unique dans votre bibliothèque."
 

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: iGor milhit <igor.milhit@rero.ch>, 2020\n"
 "Language: it\n"
@@ -372,9 +372,8 @@ msgstr "L'importo stanziato al conto."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -385,7 +384,7 @@ msgstr "Biblioteca"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -453,7 +452,6 @@ msgstr "URI del conto"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Documento"
 
@@ -923,21 +921,21 @@ msgid "Item type URI"
 msgstr "URI del tipo di esemplare"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "disponibile"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "indisponibile"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "in scadenza fino al"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "richiesto"
 
@@ -975,7 +973,6 @@ msgstr "PID di documento"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Tipo"
@@ -6434,15 +6431,15 @@ msgstr "esemplari"
 msgid "item"
 msgstr "esemplare"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "Richiedere"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "Selezionare un punto di ritiro"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "Formati di esportazione"
 
@@ -6467,7 +6464,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Segnatura"
 
@@ -6482,7 +6478,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Localizzazione"
@@ -6624,7 +6619,6 @@ msgstr "Categoria di prestito"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Disponibilità"
 
@@ -6640,7 +6634,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "Codice a barre"
@@ -6962,29 +6955,33 @@ msgstr "È punto di ritiro"
 msgid "Qualify this location as a pickup location."
 msgstr "Definire questa localizzazione come punto di ritiro."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "È una localizzazione online"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Definire questa localizzazione come localizzazione online."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Nome del punto di ritiro"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Nome del punto di ritiro visualizzato, se diverso del nome della "
 "localizzazione."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr ""
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -3,11 +3,9 @@
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
-msgid ""
-msgstr ""
-"Project-Id-Version: rero-ils 0.7.0\n"
+"Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -359,9 +357,8 @@ msgstr ""
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -372,7 +369,7 @@ msgstr ""
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -440,7 +437,6 @@ msgstr ""
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr ""
 
@@ -908,21 +904,21 @@ msgid "Item type URI"
 msgstr ""
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr ""
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr ""
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr ""
 
@@ -960,7 +956,6 @@ msgstr ""
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr ""
@@ -6398,15 +6393,15 @@ msgstr ""
 msgid "item"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr ""
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr ""
 
@@ -6431,7 +6426,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr ""
 
@@ -6446,7 +6440,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr ""
@@ -6588,7 +6581,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr ""
 
@@ -6604,7 +6596,6 @@ msgstr ""
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr ""
@@ -6926,27 +6917,31 @@ msgstr ""
 msgid "Qualify this location as a pickup location."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
-msgid "Is online location"
-msgstr ""
-
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
-msgid "Qualify this location as an online location."
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
 msgstr ""
 
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+msgid "Is online location"
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
+msgid "Qualify this location as an online location."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr ""
 

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.7.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-05 08:25+0200\n"
+"POT-Creation-Date: 2020-05-06 16:32+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -365,9 +365,8 @@ msgstr "Het toegekende bedrag voor de account."
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:56
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:106
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:121
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:61
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:161
 #: rero_ils/modules/patrons/templates/rero_ils/patron_profile.html:108
@@ -378,7 +377,7 @@ msgstr "Bibliotheek"
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:110
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:125
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:65
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:169
 msgid "Library URI"
@@ -446,7 +445,6 @@ msgstr "Account URI"
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:147
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:43
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:78
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:45
 msgid "Document"
 msgstr "Document"
 
@@ -918,21 +916,21 @@ msgid "Item type URI"
 msgstr "URI van de type van kopie"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
-#: rero_ils/modules/documents/views.py:362
+#: rero_ils/modules/documents/views.py:363
 msgid "available"
 msgstr "beschikbaar"
 
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:276
 #: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:278
-#: rero_ils/modules/documents/views.py:364
+#: rero_ils/modules/documents/views.py:365
 msgid "not available"
 msgstr "niet beschikbaar"
 
-#: rero_ils/modules/documents/views.py:371 rero_ils/modules/items/views.py:133
+#: rero_ils/modules/documents/views.py:372 rero_ils/modules/items/views.py:133
 msgid "due until"
 msgstr "verschuldigd tot"
 
-#: rero_ils/modules/documents/views.py:373
+#: rero_ils/modules/documents/views.py:374
 msgid "requested"
 msgstr "gereserveerd"
 
@@ -970,7 +968,6 @@ msgstr "Document PID"
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:781
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:113
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:58
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:43
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:48
 msgid "Type"
 msgstr "Type"
@@ -6429,15 +6426,15 @@ msgstr "exemplaren"
 msgid "item"
 msgstr "exemplaar"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:331
 msgid "Request"
 msgstr "Reserveren"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:341
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:336
 msgid "Select a Pickup Location"
 msgstr "Selecteer een afhaallocatie"
 
-#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:370
+#: rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html:365
 msgid "Export Formats"
 msgstr "Export formaten"
 
@@ -6462,7 +6459,6 @@ msgstr ""
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:40
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:72
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:56
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:40
 msgid "Call number"
 msgstr "Plaatskenmerk"
 
@@ -6477,7 +6473,6 @@ msgstr ""
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:60
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:50
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:61
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:52
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:4
 msgid "Location"
 msgstr "Locatie"
@@ -6619,7 +6614,6 @@ msgstr "Circulatie categorie"
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:55
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:78
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:80
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:60
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
@@ -6635,7 +6629,6 @@ msgstr "ID"
 
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:73
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:37
-#: rero_ils/modules/items/templates/rero_ils/detailed_view_items.html:32
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:23
 msgid "Barcode"
 msgstr "Barcode"
@@ -6959,29 +6952,33 @@ msgstr "is een afhaallocatie"
 msgid "Qualify this location as a pickup location."
 msgstr "Definieer deze locatie als een afhaallocatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:64
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:73
+msgid "There is already one pickup location in this library."
+msgstr ""
+
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
 msgid "Is online location"
 msgstr "Is online locatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:67
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:82
 msgid "Qualify this location as an online location."
 msgstr "Defineer deze locatie als een online locatie."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:79
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:94
 msgid "There is already one online location in this library."
 msgstr ""
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:85
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
 msgid "Pickup location name"
 msgstr "Naam van de afhaallocatie"
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:87
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:102
 msgid "Displayed pickup location name, if different from the location name."
 msgstr ""
 "Weergegeven naam van de afhaallocatie, indien verschillend van de "
 "locatienaam."
 
-#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:100
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:115
 msgid "The pickup location name is already taken."
 msgstr ""
 


### PR DESCRIPTION
This commit adds check to limit to only one pickup location for a library.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

Same than https://github.com/rero/rero-ils/pull/969 (closed by error)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
