### PR TITLE
holdings: add frequency field to the pattern

### DIFF
--- a/data/patterns.json
+++ b/data/patterns.json
@@ -4,6 +4,8 @@
     "rero_control_number": "R003826164",
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1010",
+      "first_expected_date": "2020-03-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -40,6 +42,8 @@
     "rero_control_number": "0866187",
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1013",
+      "first_expected_date": "2020-01-02",
       "values": [
         {
           "name": "first_enumeration",
@@ -67,6 +71,8 @@
     "rero_control_number": "1450816",
     "patterns": {
       "template": "{{first_enumeration.level_1}} Edition {{first_chronology.level_1}}",
+      "frequency": "rdafr:1013",
+      "first_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -94,6 +100,8 @@
     "rero_control_number": "R006011814",
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1014",
+      "first_expected_date": "2020-03-03",
       "values": [
         {
           "name": "first_enumeration",
@@ -135,6 +143,8 @@
     "rero_control_number": "R003301493",
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} Heft {{enumeration_chronology.level_2}} {{enumeration_chronology.level_1}}",
+      "frequency": "rdafr:1010",
+      "first_expected_date": "2020-09-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -172,6 +182,8 @@
     "rero_control_number": "1651754",
     "patterns": {
       "template": "ann\u00e9e {{first_chronology.level_1}} no {{first_enumeration.level_1}} {{second_chronology.level_2}} {{second_chronology.level_1}}",
+      "frequency": "rdafr:1010",
+      "first_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_chronology",
@@ -222,6 +234,8 @@
     "rero_control_number": "R215832460",
     "patterns": {
       "template": "N\u02da {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1012",
+      "first_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_enumeration",
@@ -256,6 +270,8 @@
     "rero_control_number": "R008447499",
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1007",
+      "first_expected_date": "2020-01-15",
       "values": [
         {
           "name": "first_enumeration",
@@ -294,6 +310,8 @@
     "rero_control_number": "R003597475",
     "patterns": {
       "template": "Ann\u00e9e {{first_enumeration.level_1}} no {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1012",
+      "first_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -341,6 +359,8 @@
     "rero_control_number": "1490336",
     "patterns": {
       "template": "Jg {{first_enumeration.level_1}} Nr {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1007",
+      "first_expected_date": "2020-01-05",
       "values": [
         {
           "name": "first_enumeration",

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -92,14 +92,25 @@ class Holding(IlsRecord):
         Ensures that holdings of type electronic are created only on
         ebooks documents i.e. harvested documents.
 
+        Ensures that for the holdings of type serials, if it has a regular
+        frequency the first_expected_date should be given.
+
         :returns: False if
             - document type is not journal and holding type is serial.
             - document type is journal and holding type is not serial.
             - document type is ebook and holding type is not electronic.
             - document type is not ebook and holding type is electronic.
+            - holding type is serial and the first_expected_date
+              is not given for a regular frequency.
         """
         document = Document.get_record_by_pid(self.document_pid)
         is_serial = self.holdings_type == 'serial'
+        if is_serial:
+            patterns = self.get('patterns', {})
+            if patterns and \
+                patterns.get('frequency') != 'rdafr:1016' \
+                    and not patterns.get('first_expected_date'):
+                return False
         is_electronic = self.holdings_type == 'electronic'
         is_issuance = document.dumps().get('issuance') == 'rdami:1003'
         return not(

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -127,10 +127,13 @@
       "type": "object",
       "required": [
         "values",
-        "template"
+        "template",
+        "frequency"
       ],
       "propertiesOrder": [
         "template",
+        "frequency",
+        "first_expected_date",
         "values"
       ],
       "additionalProperties": false,
@@ -147,6 +150,114 @@
             "validation": {
               "messages": {
                 "pattern": "Should contains at least one variable between {{ }}."
+              }
+            }
+          }
+        },
+        "frequency": {
+          "title": "Frequency",
+          "type": "string",
+          "enum": [
+            "rdafr:1001",
+            "rdafr:1002",
+            "rdafr:1003",
+            "rdafr:1004",
+            "rdafr:1005",
+            "rdafr:1006",
+            "rdafr:1007",
+            "rdafr:1008",
+            "rdafr:1009",
+            "rdafr:1010",
+            "rdafr:1011",
+            "rdafr:1012",
+            "rdafr:1013",
+            "rdafr:1014",
+            "rdafr:1015",
+            "rdafr:1016"
+          ],
+          "form": {
+            "options": [
+              {
+                "label": "Annual",
+                "value": "rdafr:1013"
+              },
+              {
+                "label": "Biennial",
+                "value": "rdafr:1014"
+              },
+              {
+                "label": "Bimonthly",
+                "value": "rdafr:1007"
+              },
+              {
+                "label": "Biweekly",
+                "value": "rdafr:1003"
+              },
+              {
+                "label": "Daily",
+                "value": "rdafr:1001"
+              },
+              {
+                "label": "Irregular",
+                "value": "rdafr:1016"
+              },
+              {
+                "label": "Monthly",
+                "value": "rdafr:1008"
+              },
+              {
+                "label": "Quarterly",
+                "value": "rdafr:1010"
+              },
+              {
+                "label": "Semiannual",
+                "value": "rdafr:1012"
+              },
+              {
+                "label": "Semimonthly",
+                "value": "rdafr:1009"
+              },
+              {
+                "label": "Semiweekly",
+                "value": "rdafr:1005"
+              },
+              {
+                "label": "Three times a month",
+                "value": "rdafr:1006"
+              },
+              {
+                "label": "Three times a week",
+                "value": "rdafr:1002"
+              },
+              {
+                "label": "Three times a year",
+                "value": "rdafr:1011"
+              },
+              {
+                "label": "Triennial",
+                "value": "rdafr:1015"
+              },
+              {
+                "label": "Weekly",
+                "value": "rdafr:1004"
+              }
+            ]
+          }
+        },
+        "first_expected_date": {
+          "type": "string",
+          "format": "date",
+          "title": "The expected date for the first issue",
+          "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
+          "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
+          "form": {
+            "type": "datepicker",
+            "wrappers": [
+              "form-field"
+            ],
+            "validation": {
+              "messages": {
+                "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
               }
             }
           }

--- a/rero_ils/modules/holdings/mappings/v6/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v6/holdings/holding-v0.0.1.json
@@ -72,6 +72,12 @@
             "template": {
               "type": "keyword"
             },
+            "frequency": {
+              "type": "keyword"
+            },
+            "first_expected_date": {
+              "type": "date"
+            },
             "values": {
               "properties": {
                 "name": {

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -309,7 +309,6 @@ class Notification(IlsRecord):
                 try:
                     pid = payload['pid']
                     notification = Notification.get_record_by_pid(pid)
-                    print('----process_notifications----:', notification)
                     Dispatcher().dispatch_notification(notification, verbose)
                     message.ack()
                     count['send'] += 1

--- a/tests/api/test_patterns.py
+++ b/tests/api/test_patterns.py
@@ -376,3 +376,29 @@ def test_automatic_item_creation_no_serials(
     assert holding.location_pid == holding_lib_martigny_w_patterns.location_pid
     assert holding.get('circulation_category') == \
         holding_lib_martigny_w_patterns.get('circulation_category')
+
+
+def test_validate_first_expected_date(
+        client, librarian_martigny_no_email,
+        journal, loc_public_sion, item_type_internal_sion, document,
+        pattern_yearly_two_times_data, json_header,
+        holding_lib_sion_w_patterns_data):
+    """Test create holding with regular frequency and missing
+
+    the first_expected_date.
+    """
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    holding = holding_lib_sion_w_patterns_data
+    holding['holdings_type'] = 'serial'
+    holding['patterns'] = \
+        pattern_yearly_two_times_data['patterns']
+    del holding['pid']
+    del holding['patterns']['first_expected_date']
+    # test will fail when the serial holding has no field
+    # first_expected_date for the regular frequency
+    with pytest.raises(RecordValidationError):
+        Holding.create(
+            data=holding,
+            delete_pid=False,
+            dbcommit=True,
+            reindex=True)

--- a/tests/data/holdings.json
+++ b/tests/data/holdings.json
@@ -207,6 +207,8 @@
     "holdings_type": "serial",
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1010",
+      "first_expected_date": "2020-03-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -242,6 +244,8 @@
     "template_name": "quarterly_one_level",
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1010",
+      "first_expected_date": "2020-03-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -277,6 +281,8 @@
     "template_name": "yearly_one_level",
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1013",
+      "first_expected_date": "2020-01-02",
       "values": [
         {
           "name": "first_enumeration",
@@ -303,6 +309,8 @@
     "template_name": "yearly_one_level_with_label",
     "patterns": {
       "template": "{{first_enumeration.level_1}} Edition {{first_chronology.level_1}}",
+      "frequency": "rdafr:1013",
+      "first_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -329,6 +337,8 @@
     "template_name": "yearly_two_times",
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1014",
+      "first_expected_date": "2020-03-03",
       "values": [
         {
           "name": "first_enumeration",
@@ -369,6 +379,8 @@
     "template_name": "quarterly_two_levels",
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} Heft {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1012",
+      "first_expected_date": "2020-09-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -405,6 +417,8 @@
     "template_name": "quarterly_two_levels_with_season",
     "patterns": {
       "template": "ann\u00e9e {{first_chronology.level_1}} no {{first_enumeration.level_1}} {{second_chronology.level_2}} {{second_chronology.level_1}}",
+      "frequency": "rdafr:1010",
+      "first_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_chronology",
@@ -454,6 +468,8 @@
     "template_name": "half_yearly_one_level",
     "patterns": {
       "template": "N\u02da {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1012",
+      "first_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_enumeration",
@@ -487,6 +503,8 @@
     "template_name": "bimonthly_every_two_months_one_level",
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1007",
+      "first_expected_date": "2020-01-15",
       "values": [
         {
           "name": "first_enumeration",
@@ -524,6 +542,8 @@
     "template_name": "half_yearly_two_levels",
     "patterns": {
       "template": "Ann\u00e9e {{first_enumeration.level_1}} no {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1012",
+      "first_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -570,6 +590,8 @@
     "template_name": "bimonthly_every_two_months_two_levels",
     "patterns": {
       "template": "Jg {{first_enumeration.level_1}} Nr {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
+      "frequency": "rdafr:1007",
+      "first_expected_date": "2020-01-05",
       "values": [
         {
           "name": "first_enumeration",

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -573,6 +573,26 @@ def holding_lib_martigny_w_patterns(
     flush_index(HoldingsSearch.Meta.index)
     return holding
 
+
+@pytest.fixture(scope="module")
+def holding_lib_sion_w_patterns_data(holdings):
+    """Load holding of sion library."""
+    return deepcopy(holdings.get('holding4'))
+
+
+@pytest.fixture(scope="module")
+def holding_lib_sion_w_patterns(
+    app, journal, holding_lib_sion_w_patterns_data,
+        loc_public_sion, item_type_internal_sion):
+    """Create holding of sion library with patterns."""
+    holding = Holding.create(
+        data=holding_lib_sion_w_patterns_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(HoldingsSearch.Meta.index)
+    return holding
+
 # --------- Pattern records -----------
 
 

--- a/tests/unit/test_holdings_jsonschema.py
+++ b/tests/unit/test_holdings_jsonschema.py
@@ -49,6 +49,17 @@ def test_required_patterns(
             holding_lib_martigny_w_patterns_data, holding_schema)
 
 
+def test_required_patterns_frequency(
+        holding_schema, holding_lib_martigny_w_patterns_data):
+    """Test required for frequency in the patterns."""
+    holding = copy.deepcopy(holding_lib_martigny_w_patterns_data)
+    del holding['patterns']['frequency']
+
+    with pytest.raises(ValidationError):
+        validate(
+            holding, holding_schema)
+
+
 def test_pid(
         holding_schema, holding_lib_martigny_w_patterns_data):
     """Test pid for holding jsonschemas."""


### PR DESCRIPTION
The frequency field indicates the publication frequency of the pattern.
Currently it is not related to any enumeration or chronology levels.

Librarian has the option to choose from a list of 15 periodicity,
annual, weekly, daily, ...etc

A new field first_expected_date is also added to indicate
the expected date of the first issue of the given pattern.

The field expected_date_for_first_issue becomes required if the
frequency is not equal to IRREGULAR.

* Adapts tests and fixtures.
* Deletes a print message from the test files

Co-Authored-by: Aly Badr<aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1481?kanban-status=1224894

## Dependencies

* rero/rero-ils-ui#dev

## How to test?

`bootstrap` + ` setup`
The patterns editor shows a new field called `frequency`, you can select the
frequency of the pattern from a list of 15 periodicity

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [ ] Extracted translations?
