### PR TITLE
Permissions : Refactoring permissions usage

### DIFF
--- a/rero_ils/modules/documents/serializers.py
+++ b/rero_ils/modules/documents/serializers.py
@@ -69,10 +69,8 @@ class DocumentJSONSerializer(JSONSerializer):
                     if person:
                         authors.append(person.dumps_for_document())
             rec['authors'] = authors
-        data = super(JSONSerializer, self).preprocess_record(
+        return super(JSONSerializer, self).preprocess_record(
             pid=pid, record=rec, links_factory=links_factory, kwargs=kwargs)
-
-        return JSONSerializer.add_item_links_and_permissions(record, data, pid)
 
     def post_process_serialize_search(self, results, pid_fetcher):
         """Post process the search results."""

--- a/rero_ils/modules/serializers.py
+++ b/rero_ils/modules/serializers.py
@@ -17,16 +17,13 @@
 
 """Record serialization."""
 
-from flask import current_app, json, request, url_for
-from invenio_pidstore.errors import PIDDoesNotExistError
-from invenio_records_rest import current_records_rest
+from flask import json, request, url_for
 from invenio_records_rest.schemas import \
     RecordSchemaJSONV1 as _RecordSchemaJSONV1
 from invenio_records_rest.serializers.json import \
     JSONSerializer as _JSONSerializer
 from invenio_records_rest.serializers.response import record_responsify, \
     search_responsify
-from invenio_records_rest.utils import obj_or_import_string
 from marshmallow import fields
 
 
@@ -48,117 +45,36 @@ class JSONSerializer(_JSONSerializer):
         rec = record
         if request and request.args.get('resolve') == '1':
             rec = record.replace_refs()
-        data = super(JSONSerializer, self).preprocess_record(
+        return super(JSONSerializer, self).preprocess_record(
             pid=pid, record=rec, links_factory=links_factory, kwargs=kwargs)
-
-        return JSONSerializer.add_item_links_and_permissions(record, data, pid)
 
     @staticmethod
     def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
         """Prepare a record hit from Elasticsearch for serialization."""
-        from invenio_records.api import Record
-        from invenio_pidstore.models import PersistentIdentifier
-        data = super(JSONSerializer, JSONSerializer).preprocess_search_hit(
-                     pid=pid, record_hit=record_hit,
-                     links_factory=links_factory, kwargs=kwargs)
-        record_class = obj_or_import_string(
-            current_app.config
-            .get('RECORDS_REST_ENDPOINTS')
-            .get(pid.pid_type).get('record_class', Record))
-        try:
-            persistent_identifier = PersistentIdentifier.get(
-                pid.pid_type, pid.pid_value)
-            record = record_class.get_record(
-                persistent_identifier.object_uuid
-            )
-            json = JSONSerializer.add_item_links_and_permissions(
-                record, data, pid
-            )
-            permissions = json.get('permissions')
-        except PIDDoesNotExistError:
-            permissions = {
-                'cannot_update': {'permisson': 'permission denied'},
-                'cannot_delete': {'permisson': 'permission denied'}
-            }
+        super(JSONSerializer, JSONSerializer).preprocess_search_hit(
+            pid=pid,
+            record_hit=record_hit,
+            links_factory=links_factory,
+            kwargs=kwargs
+        )
         search_hit = dict(
             pid=pid,
             metadata=record_hit['_source'],
             links=links_factory(pid, record_hit=record_hit, **kwargs),
-            revision=record_hit['_version'],
-            permissions=permissions
+            revision=record_hit['_version']
         )
         if record_hit.get('_explanation'):
             search_hit['explanation'] = record_hit.get('_explanation')
         return search_hit
 
-    @staticmethod
-    def add_item_links_and_permissions(record, data, pid):
-        """Update the record with action links and permissions."""
-        # TODO: remove this function and use the permission api
-        if pid.pid_type != 'doc':
-            actions = [
-                'update',
-                'delete'
-            ]
-            permissions = {}
-            action_links = {}
-            for action in actions:
-                permission = JSONSerializer.get_permission(
-                    action, pid.pid_type)
-                if permission:
-                    can = permission(record, credentials_only=True).can()
-                    if can:
-                        action_links[action] = url_for(
-                            'invenio_records_rest.{pid_type}_item'.format(
-                                pid_type=pid.pid_type),
-                            pid_value=pid.pid_value, _external=True)
-                    else:
-                        action_key = 'cannot_{action}'.format(action=action)
-                        permissions[action_key] = {
-                            'permission': "permission denied"}
-            if not record.can_delete:
-                permissions.setdefault(
-                    'cannot_delete',
-                    {}
-                ).update(record.reasons_not_to_delete())
-            data['links'].update(action_links)
-            data['permissions'] = permissions
-        return data
-
-    @staticmethod
-    def get_permission(action, pid_type):
-        """Get the permission given an action."""
-        default_action = getattr(
-            current_records_rest,
-            '{action}_permission_factory'.format(action=action))
-        permission = obj_or_import_string(
-            current_app.config
-            .get('RECORDS_REST_ENDPOINTS')
-            .get(pid_type)
-            .get(
-                '{action}_permission_factory_imp'.format(action=action),
-                default_action))
-        return permission
-
     def post_process_serialize_search(self, results, pid_fetcher):
         """Post process the search results."""
         pid_type = pid_fetcher('foo', dict(pid='1')).pid_type
-
-        # add permissions and links actions
-        permission = self.get_permission('create', pid_type)
-        permissions = {}
-        links = {}
-        if permission:
-            can = permission(record=None).can()
-            if can:
-                links['create'] = url_for(
-                    'invenio_records_rest.{pid_type}_list'.format(
-                        pid_type=pid_type), _external=True)
-            else:
-                permissions['cannot_create'] = {
-                    'permission': "permission denied"}
-        results['permissions'] = permissions
-        results['links'].update(links)
+        results['links'].update({
+            'create': url_for('invenio_records_rest.{pid_type}_list'.format(
+                        pid_type=pid_type), _external=True
+                      )
+            })
         return results
 
     def serialize_search(self, pid_fetcher, search_result, links=None,

--- a/rero_ils/modules/utils.py
+++ b/rero_ils/modules/utils.py
@@ -110,19 +110,22 @@ def read_json_record(json_file, buf_size=1024, decoder=JSONDecoder()):
                     buffer = buffer[1:].lstrip()
 
 
-def get_record_class_update_permission_from_route(route_name):
-    """Return the record class for a given record route name."""
+def get_record_class_permissions_factories_from_route(route_name):
+    """Get record class and permission factories for a record route name."""
     endpoints = current_app.config.get('RECORDS_REST_ENDPOINTS')
     for endpoint in endpoints.items():
         record = endpoint[1]
         list_route = record.get('list_route').replace('/', '')
         if list_route == route_name:
             record_class = obj_or_import_string(record.get('record_class'))
+            create_permission = obj_or_import_string(
+                record.get('create_permission_factory_imp'))
             update_permission = obj_or_import_string(
                 record.get('update_permission_factory_imp'))
             delete_permission = obj_or_import_string(
                 record.get('delete_permission_factory_imp'))
-            return record_class, update_permission, delete_permission
+            return record_class, create_permission, \
+                update_permission, delete_permission
 
 
 def get_endpoint_configuration(module):

--- a/rero_ils/modules/views.py
+++ b/rero_ils/modules/views.py
@@ -27,7 +27,7 @@ from flask import Blueprint, abort, jsonify
 from flask_babelex import get_domain
 from flask_login import current_user
 
-from .permissions import record_update_delete_permissions
+from .permissions import record_permissions
 from ..permissions import librarian_permission
 
 api_blueprint = Blueprint(
@@ -50,16 +50,18 @@ def check_authentication(func):
     return decorated_view
 
 
-@api_blueprint.route(
-    '/permissions/<route_name>/<record_pid>', methods=['GET'])
+@api_blueprint.route('/permissions/<route_name>', methods=['GET'])
+@api_blueprint.route('/permissions/<route_name>/<record_pid>', methods=['GET'])
 @check_authentication
-def permissions(route_name, record_pid):
+def permissions(route_name, record_pid=None):
     """HTTP GET request for record permissions.
 
-    Required parameters: route_name, record_pid
+    :param route_name : the list route of the resource
+    :param record_pid : the record pid
+    :return a JSON object with create/update/delete permissions for this
+            record/resource
     """
-    return record_update_delete_permissions(
-        record_pid=record_pid, route_name=route_name)
+    return record_permissions(record_pid=record_pid, route_name=route_name)
 
 
 @api_blueprint.route('/translations/<ln>.json')

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -25,94 +25,15 @@ from utils import get_json, login_user
 def test_patrons_serializers(
     client,
     json_header,
-    patron_martigny_no_email,
     librarian_martigny_no_email,
-    librarian2_martigny_no_email,
-    librarian_saxon_no_email,
-    system_librarian_martigny_no_email,
-    system_librarian_sion_no_email,
-    librarian_sion_no_email
+    librarian2_martigny_no_email
 ):
     """Test serializers for patrons."""
-
-    # simple librarian
     login_user(client, librarian_martigny_no_email)
 
-    # should update and delete a librarian of the same library
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=librarian2_martigny_no_email.pid)
-
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    data = get_json(response)
-    assert 'cannot_delete' not in data['permissions']
-    assert 'cannot_update' not in data['permissions']
-    assert data['links']['update']
-    assert data['links']['delete']
-
-    # should not update and delete a librarian of an other library
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=librarian_saxon_no_email.pid)
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    assert 'cannot_delete' in get_json(response)['permissions']
-    assert 'cannot_update' in get_json(response)['permissions']
-
-    # should not update and delete a system librarian
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=system_librarian_martigny_no_email.pid)
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    assert 'cannot_delete' in get_json(response)['permissions']
-    assert 'cannot_update' in get_json(response)['permissions']
-
-    # simple librarian
-    login_user(client, system_librarian_martigny_no_email)
-    # should update and delete a librarian of the same library
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=librarian2_martigny_no_email.pid)
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    assert 'cannot_delete' not in get_json(response)['permissions']
-    assert 'cannot_update' not in get_json(response)['permissions']
-
-    # should update and delete a librarian of an other library
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=librarian_saxon_no_email.pid)
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    assert 'cannot_delete' not in get_json(response)['permissions']
-    assert 'cannot_update' not in get_json(response)['permissions']
-
-    # should update and delete a system librarian of the same organistion
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=system_librarian_martigny_no_email.pid)
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    assert 'cannot_delete' not in get_json(response)['permissions']
-    assert 'cannot_update' not in get_json(response)['permissions']
-
-    # should not update and delete a system librarian of an other organisation
-    item_url = url_for(
-        'invenio_records_rest.ptrn_item',
-        pid_value=system_librarian_martigny_no_email.pid)
-    response = client.get(item_url, headers=json_header)
-    assert response.status_code == 200
-    assert 'cannot_delete' not in get_json(response)['permissions']
-    assert 'cannot_update' not in get_json(response)['permissions']
-
-    list_url = url_for(
-        'invenio_records_rest.ptrn_list')
-
+    list_url = url_for('invenio_records_rest.ptrn_list')
     response = client.get(list_url, headers=json_header)
     assert response.status_code == 200
-    data = get_json(response)
 
 
 def test_items_serializers(
@@ -133,8 +54,6 @@ def test_items_serializers(
     response = client.get(item_url, headers=json_header)
     assert response.status_code == 200
     data = get_json(response)
-    assert 'cannot_delete' in data['permissions']
-    assert 'cannot_update' in data['permissions']
     assert data['metadata'].get('item_type').get('$ref')
 
     item_url = url_for(
@@ -142,8 +61,6 @@ def test_items_serializers(
     response = client.get(item_url, headers=json_header)
     assert response.status_code == 200
     data = get_json(response)
-    assert 'cannot_delete' not in data['permissions']
-    assert 'cannot_update' not in data['permissions']
     assert data['metadata'].get('item_type').get('$ref')
 
     item_url = url_for(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,7 +24,7 @@ from rero_ils.modules.patron_types.api import PatronType
 from rero_ils.modules.patrons.api import Patron
 from rero_ils.modules.utils import add_years, extracted_data_from_ref, \
     get_endpoint_configuration, get_schema_for_resource, read_json_record
-from rero_ils.utils import unique_list
+from rero_ils.utils import get_current_language, unique_list
 
 
 def test_unique_list():
@@ -92,3 +92,9 @@ def test_extract_data_from_ref(app, patron_sion_data,
     assert extracted_data_from_ref('dummy_data', data='record_class') is None
     assert extracted_data_from_ref('dummy_data', data='record') is None
     assert extracted_data_from_ref(ptty, data='dummy') is None
+
+
+def test_current_language(app):
+    """Test current language."""
+    # Just test this function return otherwise than None
+    assert get_current_language()


### PR DESCRIPTION
Remove permissions from `SearchSerializer` to improve API performance.

## How to test?

- Try to list some resources using the search API :
  * `https://localhost:5000/api/patrons`
  * `https://localhost:5000/api/documents`
  * `https://localhost:5000/api/items`
  * `https://localhost:5000/api/patrons/3`
  * `https://localhost:5000/api/items/3`
  * `https://localhost:5000/api/documents/3`


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
