### PR TITLE
patrons: check if a patron email is unique

### DIFF
--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -78,8 +78,15 @@
       "minLength": 6,
       "form": {
         "validation": {
+          "validators": {
+            "valueAlreadyExists": {
+              "term": "email",
+              "remoteRecordType": "patrons/count"
+            }
+          },
           "messages": {
-            "pattern": "Email should have at least one <code>@</code> and one <code>.</code>"
+            "pattern": "Email should have at least one <code>@</code> and one <code>.</code>",
+            "alreadyTakenMessage": "This email is already taken."
           }
         }
       }


### PR DESCRIPTION
* Adds a new API url to check if an email address exists already. It
should be one of the following forms:
  * `/api/patrons/count/?q=email:"test@test.ch"
  * `/api/patrons/count/?q=email:"test@test.ch" NOT pid:1
* Adds a validator to the editor to check the uniqueness.
* Removes useless comment.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Implements US: https://tree.taiga.io/project/rero21-reroils/us/1065?milestone=263424

## How to test?

- Go to the editor and try to create a patron with an existing email.
- Edit an existing patron it should not complain about the email

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
