### PR TITLE
setup: fix old pipenv environment variables

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -98,7 +98,7 @@ if [[ -z "${VIRTUAL_ENV}" ]]; then
 fi
 
 if $deploy  ; then
-  if !$ci ; then
+  if ! $ci ; then
       flags=("--no-dev")
   fi
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -152,8 +152,6 @@ if ! ${ENABLE_WARNINGS}
 then
     # Disables different warnings from used applications
     # --------------------------------------------------
-    # avoid 'There are .env of .flaskenv' messages
-    export FLASK_SKIP_DOTENV=1
     # avoid Python deprecation warnings
     export PYTHONWARNINGS="ignore::DeprecationWarning"
 fi


### PR DESCRIPTION
Recently RERO-ils changed pipenv to poetry. The setup used a specific
option `-w` that reduced displayed messages.

It uses FLASK_SKIP_DOTENV for that. But this variable is problematic
with the new poetry system as it skip `.env` files (used for
development, production, etc.).

This commit removes this old variable and fix a bootstrap problem too.

* Deletes FLASK_SKIP_DOTENV variable
* Fixes Travis test while bootstraping

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

While launching `poetry run setup -P -w`, the setup didn't find the `.env` file in which I add specific customization (for example for RERO_ILS_CSS or specific REDIS ports).

This comes from `FLASK_SKIP_DOTENV` used previously with pipenv. This is not needed anymore!

## How to test?

* create a `.env` with `INVENIO_INSTANCE_PATH=../var/ils`
* In `../var/ils/invenio.cfg` change a specific variable, for example `CACHE_REDIS_URL="redis://0.0.0.0:8888/0"`
* Change docker-services.yml to change REDIS port: `- 8888:6379`
* Relaunch dockers: `docker-compose down && docker-compose up -d && ./docker/wait-for-services.sh`
* Launch `poetry run setup -P -w`

It should start.

To be sure, you can test the same thing on `dev` branch.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
