### PR TITLE
project: fix keyboard interruption for scripts

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -17,6 +17,7 @@
 
 """Poetry script utils."""
 
+import os
 import subprocess
 import sys
 
@@ -29,9 +30,6 @@ import sys
 
 def run(prg_name):  # python 3.7+, otherwise define each script manually
     def fn():
-        res = subprocess.run(
-            [prg_name] + sys.argv[1:]
-        )  # run whatever you like based on 'name
-        if res.returncode:
-            sys.exit(res.returncode)
+        # Replace current Python program by prg_name (same PID)
+        os.execvp(prg_name, [prg_name] + sys.argv[1:])
     return fn


### PR DESCRIPTION
We often run `poetry run server`. And we stop it with `Ctrl+C`. This
generally gives a keyboard interruption signal that stops the processus.

But this is broken: the processus is already runned!

This commit fixes the issue by sending again the interruption signal to
the runned script.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

The `poetry run server` often let invenio server and celery worker running (after Ctrl+C keyboard interruption). When we launch it again: it returns an error about "Port already addressed".

This PR changes the behaviour by sending an interruption signal to launched script when using a keyboard interruption command.

## How to test?

* Launch `poetry run server`
* Wait few seconds (for server to be launched)
* Interrupt the server with [Ctrl] + [C] command
* `ps aux|grep invenio` should not return any launched process
* `ps aux |grep celery` should do the same (except if you have other invenio instances launched)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
