### PR TITLE
persons: link persons to source instead of MEF

### DIFF
--- a/data/documents_big.json
+++ b/data/documents_big.json
@@ -22,7 +22,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21192720"
+        "$ref": "https://mef.rero.ch/api/idref/028739310"
       }
     ],
     "responsibilityStatement": [
@@ -127,7 +127,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28821051"
+        "$ref": "https://mef.rero.ch/api/idref/034607129"
       }
     ],
     "responsibilityStatement": [
@@ -190,7 +190,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26928987"
+        "$ref": "https://mef.rero.ch/api/idref/084565241"
       }
     ],
     "responsibilityStatement": [
@@ -303,7 +303,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19993166"
+        "$ref": "https://mef.rero.ch/api/rero/A003462134"
       }
     ],
     "responsibilityStatement": [
@@ -420,7 +420,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21958875"
+        "$ref": "https://mef.rero.ch/api/idref/08014165X"
       }
     ],
     "responsibilityStatement": [
@@ -488,7 +488,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20372862"
+        "$ref": "https://mef.rero.ch/api/idref/028608763"
       }
     ],
     "responsibilityStatement": [
@@ -580,7 +580,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8673342"
+        "$ref": "https://mef.rero.ch/api/idref/085939323"
       }
     ],
     "responsibilityStatement": [
@@ -683,15 +683,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18859031"
+        "$ref": "https://mef.rero.ch/api/idref/026698544"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31402731"
+        "$ref": "https://mef.rero.ch/api/idref/028597907"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24260704"
+        "$ref": "https://mef.rero.ch/api/idref/027116344"
       }
     ],
     "responsibilityStatement": [
@@ -801,11 +801,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22946357"
+        "$ref": "https://mef.rero.ch/api/gnd/1135687161"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20584365"
+        "$ref": "https://mef.rero.ch/api/rero/A026891074"
       }
     ],
     "responsibilityStatement": [
@@ -919,11 +919,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28162357"
+        "$ref": "https://mef.rero.ch/api/gnd/102716918X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29252924"
+        "$ref": "https://mef.rero.ch/api/rero/A021992070"
       }
     ],
     "responsibilityStatement": [
@@ -1029,15 +1029,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5822994"
+        "$ref": "https://mef.rero.ch/api/idref/07146073X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23197448"
+        "$ref": "https://mef.rero.ch/api/idref/085977268"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7790609"
+        "$ref": "https://mef.rero.ch/api/idref/031604005"
       }
     ],
     "responsibilityStatement": [
@@ -1322,7 +1322,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29187601"
+        "$ref": "https://mef.rero.ch/api/idref/026938308"
       }
     ]
   },
@@ -1345,7 +1345,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/569552"
+        "$ref": "https://mef.rero.ch/api/idref/026899744"
       }
     ],
     "responsibilityStatement": [
@@ -1437,11 +1437,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10915154"
+        "$ref": "https://mef.rero.ch/api/gnd/1103504657"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29170088"
+        "$ref": "https://mef.rero.ch/api/idref/030724392"
       }
     ],
     "responsibilityStatement": [
@@ -1580,7 +1580,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1711526"
+        "$ref": "https://mef.rero.ch/api/idref/184243556"
       }
     ],
     "responsibilityStatement": [
@@ -1697,11 +1697,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29110121"
+        "$ref": "https://mef.rero.ch/api/idref/026662019"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23697096"
+        "$ref": "https://mef.rero.ch/api/idref/02873789X"
       }
     ],
     "responsibilityStatement": [
@@ -1911,11 +1911,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21931597"
+        "$ref": "https://mef.rero.ch/api/rero/A003007766"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4785148"
+        "$ref": "https://mef.rero.ch/api/idref/095972277"
       }
     ],
     "responsibilityStatement": [
@@ -2015,11 +2015,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5850347"
+        "$ref": "https://mef.rero.ch/api/idref/149657986"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7701656"
+        "$ref": "https://mef.rero.ch/api/idref/052477878"
       }
     ],
     "responsibilityStatement": [
@@ -2302,7 +2302,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3141684"
+        "$ref": "https://mef.rero.ch/api/rero/A000053044"
       }
     ],
     "responsibilityStatement": [
@@ -2399,7 +2399,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4850824"
+        "$ref": "https://mef.rero.ch/api/idref/027066185"
       }
     ],
     "responsibilityStatement": [
@@ -2486,7 +2486,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6512749"
+        "$ref": "https://mef.rero.ch/api/idref/102534063"
       }
     ],
     "responsibilityStatement": [
@@ -2596,11 +2596,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8526211"
+        "$ref": "https://mef.rero.ch/api/idref/115098364"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5316522"
+        "$ref": "https://mef.rero.ch/api/idref/20183152X"
       }
     ],
     "responsibilityStatement": [
@@ -2688,11 +2688,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30412250"
+        "$ref": "https://mef.rero.ch/api/idref/028188012"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21721474"
+        "$ref": "https://mef.rero.ch/api/idref/094513627"
       }
     ],
     "responsibilityStatement": [
@@ -2834,11 +2834,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2859681"
+        "$ref": "https://mef.rero.ch/api/idref/035681837"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13937083"
+        "$ref": "https://mef.rero.ch/api/idref/121936856"
       }
     ],
     "responsibilityStatement": [
@@ -3054,7 +3054,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28000744"
+        "$ref": "https://mef.rero.ch/api/rero/A003361480"
       }
     ],
     "responsibilityStatement": [
@@ -3305,7 +3305,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17222070"
+        "$ref": "https://mef.rero.ch/api/idref/050746731"
       }
     ],
     "responsibilityStatement": [
@@ -3401,11 +3401,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31804051"
+        "$ref": "https://mef.rero.ch/api/idref/151179786"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31941775"
+        "$ref": "https://mef.rero.ch/api/gnd/12023615X"
       }
     ],
     "responsibilityStatement": [
@@ -3521,7 +3521,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16486866"
+        "$ref": "https://mef.rero.ch/api/idref/086264028"
       }
     ],
     "responsibilityStatement": [
@@ -3626,11 +3626,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18614411"
+        "$ref": "https://mef.rero.ch/api/idref/028601238"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17871611"
+        "$ref": "https://mef.rero.ch/api/idref/027154947"
       }
     ],
     "responsibilityStatement": [
@@ -3893,11 +3893,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9184026"
+        "$ref": "https://mef.rero.ch/api/idref/029100291"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20587829"
+        "$ref": "https://mef.rero.ch/api/idref/028432266"
       }
     ]
   },
@@ -4001,7 +4001,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20424489"
+        "$ref": "https://mef.rero.ch/api/idref/033591067"
       },
       {
         "type": "organisation",
@@ -4111,7 +4111,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12013112"
+        "$ref": "https://mef.rero.ch/api/rero/A011549626"
       }
     ],
     "responsibilityStatement": [
@@ -4174,7 +4174,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9181094"
+        "$ref": "https://mef.rero.ch/api/idref/03017595X"
       }
     ],
     "responsibilityStatement": [
@@ -4270,7 +4270,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2119731"
+        "$ref": "https://mef.rero.ch/api/rero/A011530636"
       }
     ],
     "responsibilityStatement": [
@@ -4440,11 +4440,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27718318"
+        "$ref": "https://mef.rero.ch/api/idref/033603901"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17284712"
+        "$ref": "https://mef.rero.ch/api/idref/033589194"
       }
     ],
     "responsibilityStatement": [
@@ -4558,11 +4558,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19633872"
+        "$ref": "https://mef.rero.ch/api/idref/134232240"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27099987"
+        "$ref": "https://mef.rero.ch/api/rero/A006071570"
       }
     ],
     "responsibilityStatement": [
@@ -4657,7 +4657,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18350613"
+        "$ref": "https://mef.rero.ch/api/gnd/119295873"
       }
     ],
     "responsibilityStatement": [
@@ -4764,11 +4764,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5354433"
+        "$ref": "https://mef.rero.ch/api/idref/027120449"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9850282"
+        "$ref": "https://mef.rero.ch/api/rero/A003811654"
       }
     ],
     "responsibilityStatement": [
@@ -4873,11 +4873,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31371883"
+        "$ref": "https://mef.rero.ch/api/idref/095969314"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15397284"
+        "$ref": "https://mef.rero.ch/api/idref/095969357"
       }
     ],
     "responsibilityStatement": [
@@ -4997,11 +4997,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11140658"
+        "$ref": "https://mef.rero.ch/api/gnd/143750283"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26388067"
+        "$ref": "https://mef.rero.ch/api/idref/034819088"
       }
     ],
     "responsibilityStatement": [
@@ -5193,11 +5193,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30015171"
+        "$ref": "https://mef.rero.ch/api/idref/053424522"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28011997"
+        "$ref": "https://mef.rero.ch/api/idref/087655543"
       }
     ],
     "responsibilityStatement": [
@@ -5310,7 +5310,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11552919"
+        "$ref": "https://mef.rero.ch/api/idref/033372284"
       }
     ],
     "responsibilityStatement": [
@@ -5406,7 +5406,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11951550"
+        "$ref": "https://mef.rero.ch/api/idref/064814165"
       },
       {
         "type": "organisation",
@@ -5659,11 +5659,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7293035"
+        "$ref": "https://mef.rero.ch/api/idref/02831316X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19675186"
+        "$ref": "https://mef.rero.ch/api/idref/027976955"
       }
     ],
     "responsibilityStatement": [
@@ -5752,7 +5752,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12809924"
+        "$ref": "https://mef.rero.ch/api/gnd/123889324"
       }
     ],
     "responsibilityStatement": [
@@ -5854,7 +5854,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16484457"
+        "$ref": "https://mef.rero.ch/api/gnd/120658054"
       }
     ],
     "responsibilityStatement": [
@@ -6030,11 +6030,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13306768"
+        "$ref": "https://mef.rero.ch/api/gnd/122742850"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15283722"
+        "$ref": "https://mef.rero.ch/api/gnd/134341031"
       }
     ]
   },
@@ -6066,7 +6066,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/669910"
+        "$ref": "https://mef.rero.ch/api/idref/032104561"
       }
     ],
     "responsibilityStatement": [
@@ -6171,7 +6171,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21761301"
+        "$ref": "https://mef.rero.ch/api/idref/028965892"
       }
     ],
     "responsibilityStatement": [
@@ -6363,7 +6363,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13524292"
+        "$ref": "https://mef.rero.ch/api/rero/A003623651"
       }
     ]
   },
@@ -6395,11 +6395,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13494953"
+        "$ref": "https://mef.rero.ch/api/idref/196182123"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17613684"
+        "$ref": "https://mef.rero.ch/api/idref/196182131"
       }
     ],
     "responsibilityStatement": [
@@ -6498,7 +6498,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/493042"
+        "$ref": "https://mef.rero.ch/api/gnd/14019763X"
       }
     ],
     "responsibilityStatement": [
@@ -6663,7 +6663,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22400074"
+        "$ref": "https://mef.rero.ch/api/rero/A003143126"
       }
     ],
     "responsibilityStatement": [
@@ -6771,15 +6771,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/200104"
+        "$ref": "https://mef.rero.ch/api/rero/A000015097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9984525"
+        "$ref": "https://mef.rero.ch/api/idref/083581049"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11716737"
+        "$ref": "https://mef.rero.ch/api/idref/076443930"
       }
     ],
     "responsibilityStatement": [
@@ -7032,7 +7032,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3873270"
+        "$ref": "https://mef.rero.ch/api/idref/087110350"
       }
     ],
     "responsibilityStatement": [
@@ -7119,11 +7119,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15085825"
+        "$ref": "https://mef.rero.ch/api/idref/026727587"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2376090"
+        "$ref": "https://mef.rero.ch/api/idref/027062260"
       }
     ],
     "responsibilityStatement": [
@@ -7305,7 +7305,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5800211"
+        "$ref": "https://mef.rero.ch/api/idref/030267021"
       }
     ],
     "responsibilityStatement": [
@@ -7378,7 +7378,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14905836"
+        "$ref": "https://mef.rero.ch/api/idref/077364333"
       }
     ],
     "responsibilityStatement": [
@@ -7525,7 +7525,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14918864"
+        "$ref": "https://mef.rero.ch/api/idref/026736381"
       }
     ],
     "responsibilityStatement": [
@@ -7642,7 +7642,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25847389"
+        "$ref": "https://mef.rero.ch/api/idref/153235217"
       }
     ],
     "responsibilityStatement": [
@@ -7738,7 +7738,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19092254"
+        "$ref": "https://mef.rero.ch/api/idref/026716976"
       }
     ],
     "responsibilityStatement": [
@@ -7835,7 +7835,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32712176"
+        "$ref": "https://mef.rero.ch/api/idref/189518294"
       }
     ],
     "responsibilityStatement": [
@@ -7931,11 +7931,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5811053"
+        "$ref": "https://mef.rero.ch/api/rero/A018891364"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30823705"
+        "$ref": "https://mef.rero.ch/api/gnd/173759424"
       }
     ],
     "responsibilityStatement": [
@@ -8048,7 +8048,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -8154,7 +8154,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21072321"
+        "$ref": "https://mef.rero.ch/api/idref/150361025"
       }
     ],
     "responsibilityStatement": [
@@ -8268,7 +8268,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7365722"
+        "$ref": "https://mef.rero.ch/api/idref/177252871"
       }
     ],
     "responsibilityStatement": [
@@ -8370,19 +8370,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1571427"
+        "$ref": "https://mef.rero.ch/api/idref/027152596"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14635837"
+        "$ref": "https://mef.rero.ch/api/idref/033183139"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12663017"
+        "$ref": "https://mef.rero.ch/api/idref/026773252"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18613808"
+        "$ref": "https://mef.rero.ch/api/idref/032410182"
       }
     ],
     "responsibilityStatement": [
@@ -8577,7 +8577,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20260042"
+        "$ref": "https://mef.rero.ch/api/rero/A027558786"
       }
     ],
     "responsibilityStatement": [
@@ -8676,7 +8676,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15060466"
+        "$ref": "https://mef.rero.ch/api/gnd/12742590X"
       }
     ],
     "responsibilityStatement": [
@@ -8829,7 +8829,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25742875"
+        "$ref": "https://mef.rero.ch/api/idref/035713801"
       }
     ],
     "responsibilityStatement": [
@@ -9002,11 +9002,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29752548"
+        "$ref": "https://mef.rero.ch/api/gnd/125002327"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25805901"
+        "$ref": "https://mef.rero.ch/api/rero/A019039954"
       }
     ]
   },
@@ -9107,11 +9107,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26995520"
+        "$ref": "https://mef.rero.ch/api/idref/074039040"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8114150"
+        "$ref": "https://mef.rero.ch/api/idref/066953863"
       }
     ]
   },
@@ -9143,7 +9143,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29028079"
+        "$ref": "https://mef.rero.ch/api/idref/031846068"
       }
     ],
     "responsibilityStatement": [
@@ -9232,11 +9232,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31931217"
+        "$ref": "https://mef.rero.ch/api/idref/151293716"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/814308"
+        "$ref": "https://mef.rero.ch/api/rero/A005614839"
       },
       {
         "type": "organisation",
@@ -9391,7 +9391,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22214594"
+        "$ref": "https://mef.rero.ch/api/idref/031515207"
       }
     ],
     "responsibilityStatement": [
@@ -9570,7 +9570,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26498598"
+        "$ref": "https://mef.rero.ch/api/idref/026725428"
       }
     ]
   },
@@ -9597,7 +9597,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14954498"
+        "$ref": "https://mef.rero.ch/api/idref/026793016"
       }
     ],
     "responsibilityStatement": [
@@ -9764,7 +9764,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23448883"
+        "$ref": "https://mef.rero.ch/api/idref/154767891"
       }
     ],
     "responsibilityStatement": [
@@ -9841,11 +9841,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32799035"
+        "$ref": "https://mef.rero.ch/api/idref/130471127"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29748963"
+        "$ref": "https://mef.rero.ch/api/idref/031773974"
       }
     ],
     "responsibilityStatement": [
@@ -10029,7 +10029,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2940291"
+        "$ref": "https://mef.rero.ch/api/rero/A003849279"
       }
     ]
   },
@@ -10056,7 +10056,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22627757"
+        "$ref": "https://mef.rero.ch/api/gnd/137992629"
       }
     ],
     "responsibilityStatement": [
@@ -10156,7 +10156,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20865662"
+        "$ref": "https://mef.rero.ch/api/idref/028340493"
       }
     ],
     "responsibilityStatement": [
@@ -10359,7 +10359,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/517063"
+        "$ref": "https://mef.rero.ch/api/idref/095906886"
       }
     ],
     "responsibilityStatement": [
@@ -10557,7 +10557,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28244128"
+        "$ref": "https://mef.rero.ch/api/gnd/170145530"
       }
     ],
     "responsibilityStatement": [
@@ -10745,7 +10745,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18535221"
+        "$ref": "https://mef.rero.ch/api/gnd/1120711266"
       }
     ]
   },
@@ -10853,7 +10853,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10880951"
+        "$ref": "https://mef.rero.ch/api/rero/A006321059"
       }
     ]
   },
@@ -11128,7 +11128,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9663467"
+        "$ref": "https://mef.rero.ch/api/idref/030266246"
       }
     ],
     "responsibilityStatement": [
@@ -11196,7 +11196,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22202235"
+        "$ref": "https://mef.rero.ch/api/gnd/112610579"
       }
     ],
     "responsibilityStatement": [
@@ -11309,7 +11309,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3934157"
+        "$ref": "https://mef.rero.ch/api/idref/027055752"
       }
     ],
     "responsibilityStatement": [
@@ -11415,19 +11415,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29764724"
+        "$ref": "https://mef.rero.ch/api/idref/030260868"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/309046"
+        "$ref": "https://mef.rero.ch/api/idref/172774004"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25478396"
+        "$ref": "https://mef.rero.ch/api/gnd/124095739"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11109101"
+        "$ref": "https://mef.rero.ch/api/gnd/1160612242"
       }
     ],
     "responsibilityStatement": [
@@ -11558,7 +11558,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5972227"
+        "$ref": "https://mef.rero.ch/api/idref/032657986"
       }
     ],
     "responsibilityStatement": [
@@ -11718,7 +11718,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1042791"
+        "$ref": "https://mef.rero.ch/api/rero/A011522961"
       }
     ],
     "responsibilityStatement": [
@@ -11794,7 +11794,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14385541"
+        "$ref": "https://mef.rero.ch/api/idref/134328884"
       }
     ],
     "responsibilityStatement": [
@@ -11888,7 +11888,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24137851"
+        "$ref": "https://mef.rero.ch/api/idref/059315156"
       }
     ],
     "responsibilityStatement": [
@@ -11966,27 +11966,27 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18512274"
+        "$ref": "https://mef.rero.ch/api/idref/028320549"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3118365"
+        "$ref": "https://mef.rero.ch/api/idref/079000169"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1292121"
+        "$ref": "https://mef.rero.ch/api/idref/07950535X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5984493"
+        "$ref": "https://mef.rero.ch/api/gnd/134882644"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26407135"
+        "$ref": "https://mef.rero.ch/api/idref/060995254"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30898769"
+        "$ref": "https://mef.rero.ch/api/idref/079505341"
       },
       {
         "type": "organisation",
@@ -12090,7 +12090,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5982646"
+        "$ref": "https://mef.rero.ch/api/idref/032147317"
       }
     ],
     "responsibilityStatement": [
@@ -12215,11 +12215,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1181779"
+        "$ref": "https://mef.rero.ch/api/idref/150336551"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15502525"
+        "$ref": "https://mef.rero.ch/api/idref/150336500"
       }
     ],
     "responsibilityStatement": [
@@ -12317,7 +12317,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9329449"
+        "$ref": "https://mef.rero.ch/api/rero/A006010680"
       }
     ],
     "responsibilityStatement": [
@@ -12566,7 +12566,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25248040"
+        "$ref": "https://mef.rero.ch/api/idref/10378747X"
       },
       {
         "type": "organisation",
@@ -12606,11 +12606,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28568226"
+        "$ref": "https://mef.rero.ch/api/idref/028283120"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18645885"
+        "$ref": "https://mef.rero.ch/api/idref/026932040"
       }
     ],
     "responsibilityStatement": [
@@ -12701,7 +12701,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29988424"
+        "$ref": "https://mef.rero.ch/api/idref/057218005"
       }
     ],
     "responsibilityStatement": [
@@ -12803,11 +12803,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12895199"
+        "$ref": "https://mef.rero.ch/api/idref/028806964"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8148123"
+        "$ref": "https://mef.rero.ch/api/idref/028597249"
       }
     ],
     "responsibilityStatement": [
@@ -12924,7 +12924,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27640753"
+        "$ref": "https://mef.rero.ch/api/idref/197930182"
       }
     ],
     "responsibilityStatement": [
@@ -13062,7 +13062,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4915093"
+        "$ref": "https://mef.rero.ch/api/idref/02691784X"
       }
     ],
     "responsibilityStatement": [
@@ -13152,7 +13152,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30325680"
+        "$ref": "https://mef.rero.ch/api/idref/15549239X"
       }
     ],
     "responsibilityStatement": [
@@ -13266,7 +13266,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13111431"
+        "$ref": "https://mef.rero.ch/api/idref/053424948"
       }
     ],
     "responsibilityStatement": [
@@ -13364,7 +13364,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15240000"
+        "$ref": "https://mef.rero.ch/api/idref/069182892"
       }
     ],
     "responsibilityStatement": [
@@ -13456,7 +13456,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13937415"
+        "$ref": "https://mef.rero.ch/api/idref/070532753"
       }
     ],
     "responsibilityStatement": [
@@ -13598,7 +13598,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17386816"
+        "$ref": "https://mef.rero.ch/api/idref/028536398"
       }
     ],
     "responsibilityStatement": [
@@ -13661,7 +13661,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/899158"
+        "$ref": "https://mef.rero.ch/api/idref/077873106"
       }
     ],
     "responsibilityStatement": [
@@ -13729,15 +13729,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/631548"
+        "$ref": "https://mef.rero.ch/api/idref/10924785X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20130329"
+        "$ref": "https://mef.rero.ch/api/idref/185544207"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17110543"
+        "$ref": "https://mef.rero.ch/api/idref/185544266"
       }
     ],
     "responsibilityStatement": [
@@ -14030,7 +14030,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1874070"
+        "$ref": "https://mef.rero.ch/api/idref/035573473"
       }
     ],
     "responsibilityStatement": [
@@ -14125,11 +14125,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2207150"
+        "$ref": "https://mef.rero.ch/api/idref/026910586"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25076006"
+        "$ref": "https://mef.rero.ch/api/rero/A003018348"
       }
     ],
     "responsibilityStatement": [
@@ -14245,7 +14245,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1914953"
+        "$ref": "https://mef.rero.ch/api/idref/034965106"
       }
     ],
     "responsibilityStatement": [
@@ -14353,15 +14353,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4304254"
+        "$ref": "https://mef.rero.ch/api/idref/026995255"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9163141"
+        "$ref": "https://mef.rero.ch/api/idref/060921315"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27627167"
+        "$ref": "https://mef.rero.ch/api/rero/A019073850"
       }
     ],
     "responsibilityStatement": [
@@ -14504,11 +14504,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12494867"
+        "$ref": "https://mef.rero.ch/api/rero/A000072554"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21673041"
+        "$ref": "https://mef.rero.ch/api/idref/029820324"
       }
     ],
     "responsibilityStatement": [
@@ -14720,11 +14720,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3196912"
+        "$ref": "https://mef.rero.ch/api/idref/104483059"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32381176"
+        "$ref": "https://mef.rero.ch/api/idref/176683127"
       },
       {
         "type": "organisation",
@@ -14837,11 +14837,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19630814"
+        "$ref": "https://mef.rero.ch/api/idref/028819373"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24710171"
+        "$ref": "https://mef.rero.ch/api/idref/057752346"
       }
     ],
     "responsibilityStatement": [
@@ -14936,11 +14936,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23531680"
+        "$ref": "https://mef.rero.ch/api/rero/A018889642"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11805128"
+        "$ref": "https://mef.rero.ch/api/idref/026808811"
       }
     ],
     "responsibilityStatement": [
@@ -15092,11 +15092,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14656908"
+        "$ref": "https://mef.rero.ch/api/gnd/1175141984"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28292963"
+        "$ref": "https://mef.rero.ch/api/rero/A026980552"
       }
     ]
   },
@@ -15119,7 +15119,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19133348"
+        "$ref": "https://mef.rero.ch/api/gnd/170091317"
       }
     ],
     "responsibilityStatement": [
@@ -15217,11 +15217,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26303461"
+        "$ref": "https://mef.rero.ch/api/idref/085789690"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/601438"
+        "$ref": "https://mef.rero.ch/api/idref/127757562"
       }
     ],
     "responsibilityStatement": [
@@ -15465,7 +15465,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11153746"
+        "$ref": "https://mef.rero.ch/api/idref/028264185"
       }
     ],
     "responsibilityStatement": [
@@ -15571,7 +15571,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4918887"
+        "$ref": "https://mef.rero.ch/api/idref/061637254"
       }
     ],
     "responsibilityStatement": [
@@ -15681,7 +15681,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1623279"
+        "$ref": "https://mef.rero.ch/api/idref/079286224"
       }
     ],
     "responsibilityStatement": [
@@ -15790,7 +15790,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24493020"
+        "$ref": "https://mef.rero.ch/api/idref/086955748"
       }
     ],
     "responsibilityStatement": [
@@ -15988,7 +15988,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32619267"
+        "$ref": "https://mef.rero.ch/api/idref/082279942"
       }
     ],
     "responsibilityStatement": [
@@ -16083,11 +16083,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21631800"
+        "$ref": "https://mef.rero.ch/api/rero/A003012998"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18997758"
+        "$ref": "https://mef.rero.ch/api/gnd/118869736"
       }
     ],
     "responsibilityStatement": [
@@ -16211,11 +16211,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/200104"
+        "$ref": "https://mef.rero.ch/api/rero/A000015097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3836257"
+        "$ref": "https://mef.rero.ch/api/idref/066924502"
       }
     ],
     "responsibilityStatement": [
@@ -16325,7 +16325,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/328204"
+        "$ref": "https://mef.rero.ch/api/idref/057607044"
       }
     ],
     "responsibilityStatement": [
@@ -16436,11 +16436,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20156531"
+        "$ref": "https://mef.rero.ch/api/idref/070439451"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1875105"
+        "$ref": "https://mef.rero.ch/api/idref/167836420"
       }
     ],
     "responsibilityStatement": [
@@ -16554,7 +16554,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5758426"
+        "$ref": "https://mef.rero.ch/api/idref/153399775"
       }
     ],
     "responsibilityStatement": [
@@ -16650,11 +16650,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10165739"
+        "$ref": "https://mef.rero.ch/api/idref/077349970"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10814430"
+        "$ref": "https://mef.rero.ch/api/gnd/130200646"
       }
     ],
     "responsibilityStatement": [
@@ -16755,11 +16755,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18599920"
+        "$ref": "https://mef.rero.ch/api/idref/027120392"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19656530"
+        "$ref": "https://mef.rero.ch/api/idref/127949976"
       }
     ],
     "responsibilityStatement": [
@@ -16863,11 +16863,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8312379"
+        "$ref": "https://mef.rero.ch/api/idref/03020027X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11724433"
+        "$ref": "https://mef.rero.ch/api/idref/031386725"
       }
     ],
     "title": [
@@ -16990,7 +16990,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28618073"
+        "$ref": "https://mef.rero.ch/api/idref/028308867"
       }
     ],
     "responsibilityStatement": [
@@ -17103,11 +17103,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21729890"
+        "$ref": "https://mef.rero.ch/api/idref/031847447"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5557460"
+        "$ref": "https://mef.rero.ch/api/idref/032592264"
       }
     ],
     "responsibilityStatement": [
@@ -17224,7 +17224,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25742875"
+        "$ref": "https://mef.rero.ch/api/idref/035713801"
       }
     ],
     "responsibilityStatement": [
@@ -17318,11 +17318,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20869592"
+        "$ref": "https://mef.rero.ch/api/idref/027320723"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15062400"
+        "$ref": "https://mef.rero.ch/api/idref/032734255"
       }
     ],
     "responsibilityStatement": [
@@ -17439,11 +17439,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13268138"
+        "$ref": "https://mef.rero.ch/api/idref/02827850X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14100346"
+        "$ref": "https://mef.rero.ch/api/idref/029743508"
       }
     ],
     "responsibilityStatement": [
@@ -17544,7 +17544,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6096164"
+        "$ref": "https://mef.rero.ch/api/idref/050543954"
       }
     ],
     "responsibilityStatement": [
@@ -17638,7 +17638,7 @@
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32745853"
+        "$ref": "https://mef.rero.ch/api/rero/A019068961"
       }
     ],
     "responsibilityStatement": [
@@ -17731,11 +17731,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28048748"
+        "$ref": "https://mef.rero.ch/api/idref/034348379"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32137371"
+        "$ref": "https://mef.rero.ch/api/idref/057223920"
       }
     ],
     "responsibilityStatement": [
@@ -17897,11 +17897,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/143141"
+        "$ref": "https://mef.rero.ch/api/idref/028448464"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11463384"
+        "$ref": "https://mef.rero.ch/api/idref/081834616"
       }
     ]
   },
@@ -17933,11 +17933,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11669821"
+        "$ref": "https://mef.rero.ch/api/idref/057707219"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29994984"
+        "$ref": "https://mef.rero.ch/api/rero/A005618566"
       }
     ],
     "responsibilityStatement": [
@@ -18100,7 +18100,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32048274"
+        "$ref": "https://mef.rero.ch/api/idref/120232944"
       }
     ]
   },
@@ -18127,7 +18127,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29294248"
+        "$ref": "https://mef.rero.ch/api/rero/A006550480"
       }
     ],
     "responsibilityStatement": [
@@ -18214,7 +18214,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4565670"
+        "$ref": "https://mef.rero.ch/api/idref/031442277"
       }
     ],
     "responsibilityStatement": [
@@ -18281,7 +18281,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29915155"
+        "$ref": "https://mef.rero.ch/api/idref/026881241"
       }
     ],
     "responsibilityStatement": [
@@ -18471,7 +18471,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22422710"
+        "$ref": "https://mef.rero.ch/api/idref/079487440"
       }
     ],
     "responsibilityStatement": [
@@ -18717,7 +18717,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24824467"
+        "$ref": "https://mef.rero.ch/api/idref/035168773"
       }
     ],
     "responsibilityStatement": [
@@ -18806,11 +18806,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12865045"
+        "$ref": "https://mef.rero.ch/api/idref/057372896"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4292233"
+        "$ref": "https://mef.rero.ch/api/idref/057432457"
       }
     ],
     "responsibilityStatement": [
@@ -18927,7 +18927,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14061136"
+        "$ref": "https://mef.rero.ch/api/idref/200744275"
       }
     ],
     "responsibilityStatement": [
@@ -19090,7 +19090,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12119853"
+        "$ref": "https://mef.rero.ch/api/gnd/133458466"
       }
     ],
     "responsibilityStatement": [
@@ -19391,7 +19391,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7576847"
+        "$ref": "https://mef.rero.ch/api/gnd/121098664"
       }
     ],
     "responsibilityStatement": [
@@ -19458,11 +19458,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32216319"
+        "$ref": "https://mef.rero.ch/api/idref/057589445"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26143881"
+        "$ref": "https://mef.rero.ch/api/idref/02881925X"
       }
     ],
     "responsibilityStatement": [
@@ -19650,7 +19650,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12436989"
+        "$ref": "https://mef.rero.ch/api/idref/027133257"
       }
     ],
     "responsibilityStatement": [
@@ -19845,7 +19845,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13540681"
+        "$ref": "https://mef.rero.ch/api/gnd/113845081"
       }
     ]
   },
@@ -19872,7 +19872,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24493810"
+        "$ref": "https://mef.rero.ch/api/idref/029404053"
       }
     ],
     "responsibilityStatement": [
@@ -19969,7 +19969,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7168358"
+        "$ref": "https://mef.rero.ch/api/idref/034995293"
       }
     ],
     "responsibilityStatement": [
@@ -20065,7 +20065,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/402894"
+        "$ref": "https://mef.rero.ch/api/idref/056792948"
       }
     ],
     "responsibilityStatement": [
@@ -20128,7 +20128,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15666246"
+        "$ref": "https://mef.rero.ch/api/idref/19463762X"
       }
     ],
     "responsibilityStatement": [
@@ -20364,7 +20364,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7701751"
+        "$ref": "https://mef.rero.ch/api/idref/112520642"
       },
       {
         "type": "organisation",
@@ -20396,11 +20396,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/645480"
+        "$ref": "https://mef.rero.ch/api/idref/028197747"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30824962"
+        "$ref": "https://mef.rero.ch/api/idref/02684382X"
       }
     ],
     "responsibilityStatement": [
@@ -20493,15 +20493,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7271656"
+        "$ref": "https://mef.rero.ch/api/idref/026839806"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31402731"
+        "$ref": "https://mef.rero.ch/api/idref/028597907"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24260704"
+        "$ref": "https://mef.rero.ch/api/idref/027116344"
       }
     ],
     "responsibilityStatement": [
@@ -20697,11 +20697,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3520733"
+        "$ref": "https://mef.rero.ch/api/idref/026817756"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23537395"
+        "$ref": "https://mef.rero.ch/api/idref/02976615X"
       }
     ],
     "responsibilityStatement": [
@@ -20799,7 +20799,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16922108"
+        "$ref": "https://mef.rero.ch/api/idref/129896586"
       }
     ],
     "responsibilityStatement": [
@@ -20975,11 +20975,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25984439"
+        "$ref": "https://mef.rero.ch/api/idref/050700022"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7871129"
+        "$ref": "https://mef.rero.ch/api/rero/A003985808"
       }
     ]
   },
@@ -21002,11 +21002,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27540961"
+        "$ref": "https://mef.rero.ch/api/rero/A016493170"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19418756"
+        "$ref": "https://mef.rero.ch/api/idref/132953226"
       }
     ],
     "responsibilityStatement": [
@@ -21120,7 +21120,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28905447"
+        "$ref": "https://mef.rero.ch/api/idref/027191451"
       }
     ],
     "responsibilityStatement": [
@@ -21251,7 +21251,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20940318"
+        "$ref": "https://mef.rero.ch/api/rero/A018882760"
       }
     ],
     "responsibilityStatement": [
@@ -21348,7 +21348,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21115001"
+        "$ref": "https://mef.rero.ch/api/idref/027055965"
       }
     ],
     "responsibilityStatement": [
@@ -21411,7 +21411,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12443783"
+        "$ref": "https://mef.rero.ch/api/idref/030415225"
       }
     ],
     "responsibilityStatement": [
@@ -21483,11 +21483,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15247862"
+        "$ref": "https://mef.rero.ch/api/idref/056874073"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18441853"
+        "$ref": "https://mef.rero.ch/api/idref/055278302"
       }
     ],
     "responsibilityStatement": [
@@ -21661,7 +21661,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31135801"
+        "$ref": "https://mef.rero.ch/api/idref/190656573"
       }
     ],
     "responsibilityStatement": [
@@ -21767,7 +21767,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22979046"
+        "$ref": "https://mef.rero.ch/api/idref/028754638"
       }
     ],
     "responsibilityStatement": [
@@ -21960,11 +21960,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26369628"
+        "$ref": "https://mef.rero.ch/api/idref/067132790"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6210729"
+        "$ref": "https://mef.rero.ch/api/gnd/1056569611"
       }
     ]
   },
@@ -22070,11 +22070,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32584332"
+        "$ref": "https://mef.rero.ch/api/gnd/120672197"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5726350"
+        "$ref": "https://mef.rero.ch/api/gnd/11813728X"
       }
     ]
   },
@@ -22106,7 +22106,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14745894"
+        "$ref": "https://mef.rero.ch/api/idref/056737009"
       }
     ],
     "responsibilityStatement": [
@@ -22213,7 +22213,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27043297"
+        "$ref": "https://mef.rero.ch/api/idref/030326737"
       }
     ],
     "responsibilityStatement": [
@@ -22303,11 +22303,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22422422"
+        "$ref": "https://mef.rero.ch/api/idref/028451643"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14457973"
+        "$ref": "https://mef.rero.ch/api/rero/A003452669"
       }
     ],
     "responsibilityStatement": [
@@ -22421,15 +22421,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32472692"
+        "$ref": "https://mef.rero.ch/api/idref/026684217"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4101700"
+        "$ref": "https://mef.rero.ch/api/idref/076314464"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22012189"
+        "$ref": "https://mef.rero.ch/api/idref/028522508"
       }
     ],
     "responsibilityStatement": [
@@ -22538,7 +22538,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1546069"
+        "$ref": "https://mef.rero.ch/api/idref/179898582"
       }
     ],
     "responsibilityStatement": [
@@ -22647,15 +22647,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31246254"
+        "$ref": "https://mef.rero.ch/api/rero/A006039544"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14336991"
+        "$ref": "https://mef.rero.ch/api/rero/A006039548"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3856475"
+        "$ref": "https://mef.rero.ch/api/rero/A006039549"
       }
     ],
     "responsibilityStatement": [
@@ -22918,7 +22918,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3232825"
+        "$ref": "https://mef.rero.ch/api/idref/029957885"
       }
     ],
     "responsibilityStatement": [
@@ -23091,7 +23091,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12367183"
+        "$ref": "https://mef.rero.ch/api/gnd/172825229"
       }
     ]
   },
@@ -23201,11 +23201,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12706676"
+        "$ref": "https://mef.rero.ch/api/idref/028617355"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12043890"
+        "$ref": "https://mef.rero.ch/api/idref/028603575"
       }
     ],
     "responsibilityStatement": [
@@ -23300,11 +23300,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4425954"
+        "$ref": "https://mef.rero.ch/api/idref/026659050"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10415422"
+        "$ref": "https://mef.rero.ch/api/idref/028436156"
       }
     ],
     "responsibilityStatement": [
@@ -23472,11 +23472,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24247228"
+        "$ref": "https://mef.rero.ch/api/idref/030031966"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25050160"
+        "$ref": "https://mef.rero.ch/api/idref/03003194X"
       }
     ]
   },
@@ -23508,11 +23508,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/720315"
+        "$ref": "https://mef.rero.ch/api/idref/029325056"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21722084"
+        "$ref": "https://mef.rero.ch/api/idref/030695058"
       },
       {
         "type": "organisation",
@@ -23700,7 +23700,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8585427"
+        "$ref": "https://mef.rero.ch/api/rero/A005913787"
       }
     ],
     "responsibilityStatement": [
@@ -23806,7 +23806,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9164371"
+        "$ref": "https://mef.rero.ch/api/idref/032014201"
       }
     ],
     "responsibilityStatement": [
@@ -23995,7 +23995,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30732703"
+        "$ref": "https://mef.rero.ch/api/idref/19011746X"
       },
       {
         "type": "organisation",
@@ -24027,7 +24027,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17043011"
+        "$ref": "https://mef.rero.ch/api/idref/127493603"
       }
     ],
     "responsibilityStatement": [
@@ -24117,7 +24117,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9177045"
+        "$ref": "https://mef.rero.ch/api/idref/055677401"
       }
     ],
     "responsibilityStatement": [
@@ -24210,7 +24210,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21011258"
+        "$ref": "https://mef.rero.ch/api/idref/153169303"
       }
     ],
     "responsibilityStatement": [
@@ -24378,7 +24378,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21957230"
+        "$ref": "https://mef.rero.ch/api/idref/139843418"
       }
     ]
   },
@@ -24410,7 +24410,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1571410"
+        "$ref": "https://mef.rero.ch/api/idref/026932997"
       }
     ],
     "responsibilityStatement": [
@@ -24511,7 +24511,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1914953"
+        "$ref": "https://mef.rero.ch/api/idref/034965106"
       }
     ],
     "responsibilityStatement": [
@@ -24618,7 +24618,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18842475"
+        "$ref": "https://mef.rero.ch/api/idref/074722212"
       }
     ],
     "responsibilityStatement": [
@@ -24718,7 +24718,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16477354"
+        "$ref": "https://mef.rero.ch/api/idref/02835012X"
       }
     ],
     "responsibilityStatement": [
@@ -24816,11 +24816,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23534509"
+        "$ref": "https://mef.rero.ch/api/idref/027039145"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16263757"
+        "$ref": "https://mef.rero.ch/api/idref/026897717"
       }
     ],
     "responsibilityStatement": [
@@ -25022,7 +25022,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2294955"
+        "$ref": "https://mef.rero.ch/api/idref/026918471"
       }
     ],
     "responsibilityStatement": [
@@ -25187,7 +25187,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18525905"
+        "$ref": "https://mef.rero.ch/api/idref/028578198"
       }
     ],
     "responsibilityStatement": [
@@ -25378,7 +25378,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5777557"
+        "$ref": "https://mef.rero.ch/api/idref/086132598"
       }
     ],
     "responsibilityStatement": [
@@ -25577,19 +25577,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24668082"
+        "$ref": "https://mef.rero.ch/api/idref/186402163"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6133255"
+        "$ref": "https://mef.rero.ch/api/idref/186402376"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1902151"
+        "$ref": "https://mef.rero.ch/api/idref/186402627"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31294294"
+        "$ref": "https://mef.rero.ch/api/idref/18640266X"
       }
     ]
   },
@@ -25617,7 +25617,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22451682"
+        "$ref": "https://mef.rero.ch/api/idref/142336726"
       }
     ],
     "responsibilityStatement": [
@@ -25725,11 +25725,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26835132"
+        "$ref": "https://mef.rero.ch/api/idref/02714769X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14959294"
+        "$ref": "https://mef.rero.ch/api/idref/056965737"
       }
     ],
     "responsibilityStatement": [
@@ -25843,7 +25843,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18850605"
+        "$ref": "https://mef.rero.ch/api/idref/142712663"
       }
     ],
     "responsibilityStatement": [
@@ -26126,7 +26126,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7004294"
+        "$ref": "https://mef.rero.ch/api/idref/03464086X"
       }
     ],
     "responsibilityStatement": [
@@ -26258,11 +26258,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1772825"
+        "$ref": "https://mef.rero.ch/api/idref/030688361"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10448331"
+        "$ref": "https://mef.rero.ch/api/idref/050740709"
       }
     ],
     "responsibilityStatement": [
@@ -26454,11 +26454,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12969790"
+        "$ref": "https://mef.rero.ch/api/idref/114480532"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11404455"
+        "$ref": "https://mef.rero.ch/api/gnd/1103529471"
       }
     ],
     "responsibilityStatement": [
@@ -26658,11 +26658,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11227694"
+        "$ref": "https://mef.rero.ch/api/idref/028278992"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27041068"
+        "$ref": "https://mef.rero.ch/api/idref/050510479"
       }
     ],
     "responsibilityStatement": [
@@ -26850,7 +26850,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9593224"
+        "$ref": "https://mef.rero.ch/api/idref/027281744"
       }
     ]
   },
@@ -26987,7 +26987,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19310886"
+        "$ref": "https://mef.rero.ch/api/idref/060853123"
       }
     ],
     "responsibilityStatement": [
@@ -27086,7 +27086,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9834430"
+        "$ref": "https://mef.rero.ch/api/idref/082091765"
       }
     ],
     "responsibilityStatement": [
@@ -27226,7 +27226,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32270092"
+        "$ref": "https://mef.rero.ch/api/idref/158757262"
       }
     ],
     "responsibilityStatement": [
@@ -27366,7 +27366,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13837429"
+        "$ref": "https://mef.rero.ch/api/idref/033721009"
       }
     ],
     "responsibilityStatement": [
@@ -27462,7 +27462,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11389299"
+        "$ref": "https://mef.rero.ch/api/rero/A011536058"
       }
     ],
     "responsibilityStatement": [
@@ -27610,7 +27610,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17241492"
+        "$ref": "https://mef.rero.ch/api/idref/084433043"
       }
     ],
     "responsibilityStatement": [
@@ -27687,7 +27687,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26713975"
+        "$ref": "https://mef.rero.ch/api/idref/050769561"
       }
     ],
     "responsibilityStatement": [
@@ -27892,7 +27892,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23102539"
+        "$ref": "https://mef.rero.ch/api/idref/074504878"
       }
     ],
     "responsibilityStatement": [
@@ -27990,7 +27990,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20242515"
+        "$ref": "https://mef.rero.ch/api/idref/112408125"
       }
     ],
     "responsibilityStatement": [
@@ -28093,7 +28093,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18159357"
+        "$ref": "https://mef.rero.ch/api/idref/157843289"
       }
     ],
     "responsibilityStatement": [
@@ -28185,7 +28185,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27584234"
+        "$ref": "https://mef.rero.ch/api/idref/032823266"
       }
     ],
     "responsibilityStatement": [
@@ -28276,11 +28276,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7078257"
+        "$ref": "https://mef.rero.ch/api/idref/069496838"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2703324"
+        "$ref": "https://mef.rero.ch/api/rero/A011574536"
       }
     ],
     "responsibilityStatement": [
@@ -28348,7 +28348,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27716367"
+        "$ref": "https://mef.rero.ch/api/idref/028339819"
       }
     ],
     "responsibilityStatement": [
@@ -28448,7 +28448,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28977080"
+        "$ref": "https://mef.rero.ch/api/gnd/1033027529"
       }
     ],
     "responsibilityStatement": [
@@ -28511,7 +28511,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11382649"
+        "$ref": "https://mef.rero.ch/api/idref/083338497"
       }
     ],
     "responsibilityStatement": [
@@ -28729,7 +28729,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14602697"
+        "$ref": "https://mef.rero.ch/api/rero/A027375153"
       }
     ],
     "responsibilityStatement": [
@@ -28832,7 +28832,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/200104"
+        "$ref": "https://mef.rero.ch/api/rero/A000015097"
       }
     ],
     "responsibilityStatement": [
@@ -28926,7 +28926,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19354060"
+        "$ref": "https://mef.rero.ch/api/idref/027944336"
       }
     ],
     "responsibilityStatement": [
@@ -29016,7 +29016,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18517283"
+        "$ref": "https://mef.rero.ch/api/rero/A011540400"
       }
     ],
     "responsibilityStatement": [
@@ -29088,7 +29088,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1772825"
+        "$ref": "https://mef.rero.ch/api/idref/030688361"
       }
     ],
     "responsibilityStatement": [
@@ -29185,7 +29185,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20489728"
+        "$ref": "https://mef.rero.ch/api/idref/116434503"
       }
     ],
     "responsibilityStatement": [
@@ -29294,7 +29294,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25324399"
+        "$ref": "https://mef.rero.ch/api/idref/080712509"
       }
     ],
     "responsibilityStatement": [
@@ -29473,7 +29473,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30337710"
+        "$ref": "https://mef.rero.ch/api/rero/A011546579"
       }
     ],
     "responsibilityStatement": [
@@ -29545,11 +29545,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1571410"
+        "$ref": "https://mef.rero.ch/api/idref/026932997"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23931344"
+        "$ref": "https://mef.rero.ch/api/rero/A003766597"
       }
     ],
     "responsibilityStatement": [
@@ -29646,7 +29646,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16058906"
+        "$ref": "https://mef.rero.ch/api/idref/066958970"
       },
       {
         "type": "organisation",
@@ -29755,7 +29755,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26238983"
+        "$ref": "https://mef.rero.ch/api/idref/028520246"
       }
     ],
     "responsibilityStatement": [
@@ -29843,11 +29843,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8525451"
+        "$ref": "https://mef.rero.ch/api/idref/029037964"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3912639"
+        "$ref": "https://mef.rero.ch/api/idref/033157758"
       }
     ],
     "responsibilityStatement": [
@@ -29953,7 +29953,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6287927"
+        "$ref": "https://mef.rero.ch/api/idref/033077657"
       }
     ],
     "responsibilityStatement": [
@@ -30045,11 +30045,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2609223"
+        "$ref": "https://mef.rero.ch/api/idref/083885102"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32639297"
+        "$ref": "https://mef.rero.ch/api/idref/027156192"
       }
     ],
     "responsibilityStatement": [
@@ -30142,11 +30142,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11186748"
+        "$ref": "https://mef.rero.ch/api/rero/A003651121"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25822803"
+        "$ref": "https://mef.rero.ch/api/idref/14558934X"
       }
     ],
     "responsibilityStatement": [
@@ -30269,7 +30269,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2944515"
+        "$ref": "https://mef.rero.ch/api/idref/086136496"
       }
     ],
     "responsibilityStatement": [
@@ -30367,7 +30367,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6512749"
+        "$ref": "https://mef.rero.ch/api/idref/102534063"
       }
     ],
     "responsibilityStatement": [
@@ -30476,11 +30476,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12281914"
+        "$ref": "https://mef.rero.ch/api/idref/086146203"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20706298"
+        "$ref": "https://mef.rero.ch/api/idref/139199500"
       }
     ],
     "responsibilityStatement": [
@@ -30668,11 +30668,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9413609"
+        "$ref": "https://mef.rero.ch/api/idref/026934329"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18960732"
+        "$ref": "https://mef.rero.ch/api/idref/032499612"
       }
     ],
     "responsibilityStatement": [
@@ -30854,7 +30854,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8899748"
+        "$ref": "https://mef.rero.ch/api/rero/A019020831"
       }
     ],
     "responsibilityStatement": [
@@ -30953,7 +30953,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5944739"
+        "$ref": "https://mef.rero.ch/api/gnd/121373517"
       }
     ],
     "responsibilityStatement": [
@@ -31026,7 +31026,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10982202"
+        "$ref": "https://mef.rero.ch/api/idref/028741285"
       }
     ],
     "responsibilityStatement": [
@@ -31116,11 +31116,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4338546"
+        "$ref": "https://mef.rero.ch/api/idref/02665234X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20171404"
+        "$ref": "https://mef.rero.ch/api/idref/074540394"
       }
     ],
     "responsibilityStatement": [
@@ -31226,7 +31226,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26944851"
+        "$ref": "https://mef.rero.ch/api/idref/034638865"
       }
     ],
     "responsibilityStatement": [
@@ -31450,7 +31450,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8915565"
+        "$ref": "https://mef.rero.ch/api/idref/117974323"
       }
     ],
     "responsibilityStatement": [
@@ -31540,7 +31540,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28703923"
+        "$ref": "https://mef.rero.ch/api/idref/026647796"
       }
     ],
     "responsibilityStatement": [
@@ -31626,7 +31626,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21729512"
+        "$ref": "https://mef.rero.ch/api/idref/026668408"
       }
     ],
     "responsibilityStatement": [
@@ -31753,7 +31753,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9663467"
+        "$ref": "https://mef.rero.ch/api/idref/030266246"
       }
     ],
     "responsibilityStatement": [
@@ -31820,7 +31820,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9221635"
+        "$ref": "https://mef.rero.ch/api/idref/027164322"
       }
     ],
     "responsibilityStatement": [
@@ -32037,11 +32037,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7199900"
+        "$ref": "https://mef.rero.ch/api/gnd/1146234244"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8482624"
+        "$ref": "https://mef.rero.ch/api/rero/A013065996"
       }
     ]
   },
@@ -32073,7 +32073,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5073549"
+        "$ref": "https://mef.rero.ch/api/idref/120241102"
       }
     ],
     "responsibilityStatement": [
@@ -32167,7 +32167,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13145425"
+        "$ref": "https://mef.rero.ch/api/idref/028369807"
       }
     ],
     "responsibilityStatement": [
@@ -32332,7 +32332,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5563138"
+        "$ref": "https://mef.rero.ch/api/idref/027066444"
       }
     ]
   },
@@ -32355,7 +32355,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21286777"
+        "$ref": "https://mef.rero.ch/api/gnd/1056794674"
       }
     ],
     "responsibilityStatement": [
@@ -32519,7 +32519,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7199919"
+        "$ref": "https://mef.rero.ch/api/gnd/1119964989"
       }
     ],
     "responsibilityStatement": [
@@ -32664,7 +32664,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18441774"
+        "$ref": "https://mef.rero.ch/api/rero/A022902314"
       }
     ],
     "responsibilityStatement": [
@@ -32775,15 +32775,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31467616"
+        "$ref": "https://mef.rero.ch/api/idref/066912342"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1151799"
+        "$ref": "https://mef.rero.ch/api/idref/032287542"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23552331"
+        "$ref": "https://mef.rero.ch/api/idref/072311398"
       }
     ],
     "responsibilityStatement": [
@@ -32903,7 +32903,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13197904"
+        "$ref": "https://mef.rero.ch/api/idref/035707119"
       }
     ],
     "responsibilityStatement": [
@@ -32995,11 +32995,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31230431"
+        "$ref": "https://mef.rero.ch/api/idref/060824069"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1233948"
+        "$ref": "https://mef.rero.ch/api/rero/A012506149"
       }
     ],
     "responsibilityStatement": [
@@ -33102,7 +33102,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13849952"
+        "$ref": "https://mef.rero.ch/api/idref/050347764"
       }
     ],
     "responsibilityStatement": [
@@ -33187,11 +33187,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8943799"
+        "$ref": "https://mef.rero.ch/api/gnd/142191760"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6791017"
+        "$ref": "https://mef.rero.ch/api/gnd/13181477X"
       }
     ],
     "responsibilityStatement": [
@@ -33287,7 +33287,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32372838"
+        "$ref": "https://mef.rero.ch/api/idref/028301943"
       }
     ],
     "responsibilityStatement": [
@@ -33384,7 +33384,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4344443"
+        "$ref": "https://mef.rero.ch/api/idref/029832535"
       }
     ],
     "responsibilityStatement": [
@@ -33475,7 +33475,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15363126"
+        "$ref": "https://mef.rero.ch/api/rero/A003427027"
       }
     ],
     "responsibilityStatement": [
@@ -33581,7 +33581,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23293916"
+        "$ref": "https://mef.rero.ch/api/idref/193340011"
       }
     ],
     "responsibilityStatement": [
@@ -33668,7 +33668,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11816281"
+        "$ref": "https://mef.rero.ch/api/rero/A014123047"
       }
     ],
     "responsibilityStatement": [
@@ -33776,7 +33776,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25422133"
+        "$ref": "https://mef.rero.ch/api/idref/061712965"
       }
     ],
     "responsibilityStatement": [
@@ -33868,11 +33868,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21892150"
+        "$ref": "https://mef.rero.ch/api/idref/027069427"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16226518"
+        "$ref": "https://mef.rero.ch/api/idref/026822180"
       }
     ],
     "responsibilityStatement": [
@@ -33972,11 +33972,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/318606"
+        "$ref": "https://mef.rero.ch/api/idref/029679400"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15976466"
+        "$ref": "https://mef.rero.ch/api/idref/029679508"
       }
     ],
     "responsibilityStatement": [
@@ -34207,11 +34207,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9656298"
+        "$ref": "https://mef.rero.ch/api/idref/079001270"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30114190"
+        "$ref": "https://mef.rero.ch/api/idref/029432081"
       }
     ],
     "responsibilityStatement": [
@@ -34310,7 +34310,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32148274"
+        "$ref": "https://mef.rero.ch/api/idref/034113428"
       }
     ],
     "responsibilityStatement": [
@@ -34406,11 +34406,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24010605"
+        "$ref": "https://mef.rero.ch/api/idref/028260945"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31558056"
+        "$ref": "https://mef.rero.ch/api/idref/194824799"
       }
     ],
     "responsibilityStatement": [
@@ -34519,7 +34519,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17079168"
+        "$ref": "https://mef.rero.ch/api/idref/139501827"
       }
     ],
     "responsibilityStatement": [
@@ -34661,7 +34661,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25988263"
+        "$ref": "https://mef.rero.ch/api/rero/A011552779"
       }
     ],
     "responsibilityStatement": [
@@ -34825,7 +34825,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7818628"
+        "$ref": "https://mef.rero.ch/api/idref/200411101"
       }
     ],
     "responsibilityStatement": [
@@ -34918,11 +34918,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14109959"
+        "$ref": "https://mef.rero.ch/api/idref/093644701"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10126214"
+        "$ref": "https://mef.rero.ch/api/idref/137401922"
       }
     ],
     "responsibilityStatement": [
@@ -35025,11 +35025,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32121459"
+        "$ref": "https://mef.rero.ch/api/idref/028738381"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29108159"
+        "$ref": "https://mef.rero.ch/api/idref/02830568X"
       }
     ],
     "responsibilityStatement": [
@@ -35296,11 +35296,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29252602"
+        "$ref": "https://mef.rero.ch/api/idref/158715241"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10166642"
+        "$ref": "https://mef.rero.ch/api/idref/234931639"
       }
     ],
     "responsibilityStatement": [
@@ -35414,11 +35414,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29923123"
+        "$ref": "https://mef.rero.ch/api/idref/027186717"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23898019"
+        "$ref": "https://mef.rero.ch/api/idref/026989212"
       }
     ],
     "responsibilityStatement": [
@@ -35595,7 +35595,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28796468"
+        "$ref": "https://mef.rero.ch/api/idref/19973044X"
       }
     ]
   },
@@ -35631,11 +35631,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12113630"
+        "$ref": "https://mef.rero.ch/api/idref/144207001"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21756412"
+        "$ref": "https://mef.rero.ch/api/idref/144207087"
       }
     ],
     "responsibilityStatement": [
@@ -35747,11 +35747,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24284536"
+        "$ref": "https://mef.rero.ch/api/idref/057405441"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4463584"
+        "$ref": "https://mef.rero.ch/api/idref/029296218"
       }
     ],
     "responsibilityStatement": [
@@ -35920,15 +35920,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13027412"
+        "$ref": "https://mef.rero.ch/api/idref/081526393"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11316789"
+        "$ref": "https://mef.rero.ch/api/rero/A016369653"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1747333"
+        "$ref": "https://mef.rero.ch/api/idref/028301471"
       }
     ]
   },
@@ -35951,7 +35951,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27815869"
+        "$ref": "https://mef.rero.ch/api/gnd/143183907"
       }
     ],
     "responsibilityStatement": [
@@ -36066,7 +36066,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21547063"
+        "$ref": "https://mef.rero.ch/api/idref/034883568"
       }
     ],
     "responsibilityStatement": [
@@ -36147,11 +36147,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11045901"
+        "$ref": "https://mef.rero.ch/api/idref/030580390"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4915093"
+        "$ref": "https://mef.rero.ch/api/idref/02691784X"
       }
     ],
     "responsibilityStatement": [
@@ -36369,7 +36369,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2606281"
+        "$ref": "https://mef.rero.ch/api/idref/11291019X"
       }
     ],
     "responsibilityStatement": [
@@ -36475,7 +36475,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7169622"
+        "$ref": "https://mef.rero.ch/api/idref/029882419"
       }
     ],
     "responsibilityStatement": [
@@ -36570,11 +36570,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3971777"
+        "$ref": "https://mef.rero.ch/api/gnd/102423059"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24877139"
+        "$ref": "https://mef.rero.ch/api/idref/028501462"
       }
     ],
     "responsibilityStatement": [
@@ -36684,7 +36684,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23971657"
+        "$ref": "https://mef.rero.ch/api/idref/128825308"
       }
     ],
     "responsibilityStatement": [
@@ -36805,7 +36805,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6890001"
+        "$ref": "https://mef.rero.ch/api/rero/A017188049"
       }
     ],
     "title": [
@@ -36885,7 +36885,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3436348"
+        "$ref": "https://mef.rero.ch/api/rero/A011548703"
       }
     ],
     "responsibilityStatement": [
@@ -36957,7 +36957,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8809774"
+        "$ref": "https://mef.rero.ch/api/idref/074541196"
       }
     ],
     "responsibilityStatement": [
@@ -37136,7 +37136,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27378873"
+        "$ref": "https://mef.rero.ch/api/idref/026868024"
       }
     ],
     "responsibilityStatement": [
@@ -37232,7 +37232,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5488200"
+        "$ref": "https://mef.rero.ch/api/rero/A011575920"
       }
     ],
     "responsibilityStatement": [
@@ -37414,7 +37414,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23768254"
+        "$ref": "https://mef.rero.ch/api/idref/057579954"
       }
     ],
     "responsibilityStatement": [
@@ -37521,7 +37521,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19593476"
+        "$ref": "https://mef.rero.ch/api/idref/079481698"
       }
     ],
     "responsibilityStatement": [
@@ -37619,7 +37619,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6869940"
+        "$ref": "https://mef.rero.ch/api/idref/026875454"
       }
     ],
     "responsibilityStatement": [
@@ -37807,11 +37807,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25608518"
+        "$ref": "https://mef.rero.ch/api/idref/026803097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1545640"
+        "$ref": "https://mef.rero.ch/api/idref/059643307"
       }
     ]
   },
@@ -37834,7 +37834,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5856796"
+        "$ref": "https://mef.rero.ch/api/idref/070417008"
       }
     ],
     "responsibilityStatement": [
@@ -37985,7 +37985,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4908049"
+        "$ref": "https://mef.rero.ch/api/idref/079887317"
       }
     ],
     "electronicLocator": [
@@ -38014,11 +38014,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10743262"
+        "$ref": "https://mef.rero.ch/api/rero/A003582021"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12955555"
+        "$ref": "https://mef.rero.ch/api/idref/087743736"
       }
     ],
     "responsibilityStatement": [
@@ -38121,11 +38121,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/821455"
+        "$ref": "https://mef.rero.ch/api/idref/030430402"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28191309"
+        "$ref": "https://mef.rero.ch/api/idref/057349312"
       }
     ],
     "responsibilityStatement": [
@@ -38206,7 +38206,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17290163"
+        "$ref": "https://mef.rero.ch/api/idref/050305255"
       }
     ],
     "responsibilityStatement": [
@@ -38268,11 +38268,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17484009"
+        "$ref": "https://mef.rero.ch/api/idref/033963584"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6950722"
+        "$ref": "https://mef.rero.ch/api/idref/050835750"
       }
     ],
     "responsibilityStatement": [
@@ -38364,7 +38364,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29256923"
+        "$ref": "https://mef.rero.ch/api/idref/027203166"
       }
     ],
     "responsibilityStatement": [
@@ -38461,11 +38461,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1964628"
+        "$ref": "https://mef.rero.ch/api/rero/A003690426"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10395971"
+        "$ref": "https://mef.rero.ch/api/idref/057373728"
       }
     ],
     "responsibilityStatement": [
@@ -38568,27 +38568,27 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6148908"
+        "$ref": "https://mef.rero.ch/api/idref/030690609"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5060367"
+        "$ref": "https://mef.rero.ch/api/idref/064815846"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1542120"
+        "$ref": "https://mef.rero.ch/api/idref/032316992"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20110162"
+        "$ref": "https://mef.rero.ch/api/idref/030835801"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12526643"
+        "$ref": "https://mef.rero.ch/api/idref/064816125"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10730881"
+        "$ref": "https://mef.rero.ch/api/idref/145599671"
       }
     ],
     "title": [
@@ -38680,11 +38680,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31772233"
+        "$ref": "https://mef.rero.ch/api/idref/138871981"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9082353"
+        "$ref": "https://mef.rero.ch/api/idref/027037258"
       }
     ],
     "responsibilityStatement": [
@@ -38780,7 +38780,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1914953"
+        "$ref": "https://mef.rero.ch/api/idref/034965106"
       }
     ],
     "responsibilityStatement": [
@@ -38884,11 +38884,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32702266"
+        "$ref": "https://mef.rero.ch/api/idref/034086226"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8108939"
+        "$ref": "https://mef.rero.ch/api/idref/027023931"
       }
     ],
     "responsibilityStatement": [
@@ -38975,7 +38975,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2761400"
+        "$ref": "https://mef.rero.ch/api/idref/192160184"
       }
     ],
     "responsibilityStatement": [
@@ -39042,7 +39042,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1542603"
+        "$ref": "https://mef.rero.ch/api/rero/A002997518"
       }
     ],
     "title": [
@@ -39141,7 +39141,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13403164"
+        "$ref": "https://mef.rero.ch/api/idref/202640698"
       }
     ],
     "responsibilityStatement": [
@@ -39223,7 +39223,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3966999"
+        "$ref": "https://mef.rero.ch/api/gnd/1064704794"
       }
     ],
     "responsibilityStatement": [
@@ -39331,11 +39331,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16399784"
+        "$ref": "https://mef.rero.ch/api/idref/069784175"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6724302"
+        "$ref": "https://mef.rero.ch/api/idref/069784256"
       }
     ],
     "responsibilityStatement": [
@@ -39422,7 +39422,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29094937"
+        "$ref": "https://mef.rero.ch/api/idref/077249593"
       }
     ],
     "responsibilityStatement": [
@@ -39489,11 +39489,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24096236"
+        "$ref": "https://mef.rero.ch/api/idref/188346767"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3669390"
+        "$ref": "https://mef.rero.ch/api/gnd/118621017"
       }
     ],
     "responsibilityStatement": [
@@ -39631,11 +39631,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21154222"
+        "$ref": "https://mef.rero.ch/api/idref/079334946"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25729162"
+        "$ref": "https://mef.rero.ch/api/idref/079334962"
       }
     ],
     "responsibilityStatement": [
@@ -39838,7 +39838,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/357984"
+        "$ref": "https://mef.rero.ch/api/idref/121101282"
       }
     ]
   },
@@ -39865,7 +39865,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17539757"
+        "$ref": "https://mef.rero.ch/api/idref/032450877"
       }
     ],
     "responsibilityStatement": [
@@ -39967,11 +39967,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29764724"
+        "$ref": "https://mef.rero.ch/api/idref/030260868"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18802674"
+        "$ref": "https://mef.rero.ch/api/idref/078617960"
       },
       {
         "type": "organisation",
@@ -40065,7 +40065,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6768633"
+        "$ref": "https://mef.rero.ch/api/rero/A003312334"
       }
     ],
     "responsibilityStatement": [
@@ -40295,11 +40295,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18425291"
+        "$ref": "https://mef.rero.ch/api/rero/A003766258"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32367230"
+        "$ref": "https://mef.rero.ch/api/idref/067150861"
       }
     ]
   },
@@ -40322,7 +40322,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19257617"
+        "$ref": "https://mef.rero.ch/api/idref/030771064"
       }
     ],
     "responsibilityStatement": [
@@ -40594,7 +40594,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/92903"
+        "$ref": "https://mef.rero.ch/api/idref/028870778"
       }
     ]
   },
@@ -40617,7 +40617,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15982097"
+        "$ref": "https://mef.rero.ch/api/rero/A011545824"
       }
     ],
     "responsibilityStatement": [
@@ -40689,7 +40689,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10168771"
+        "$ref": "https://mef.rero.ch/api/idref/031613438"
       }
     ],
     "responsibilityStatement": [
@@ -40786,7 +40786,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22617136"
+        "$ref": "https://mef.rero.ch/api/rero/A011575004"
       }
     ],
     "responsibilityStatement": [
@@ -40857,7 +40857,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22978317"
+        "$ref": "https://mef.rero.ch/api/idref/132234599"
       }
     ],
     "responsibilityStatement": [
@@ -40952,7 +40952,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31659140"
+        "$ref": "https://mef.rero.ch/api/idref/030681413"
       }
     ],
     "responsibilityStatement": [
@@ -41044,7 +41044,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6711713"
+        "$ref": "https://mef.rero.ch/api/rero/A011543920"
       }
     ],
     "responsibilityStatement": [
@@ -41111,7 +41111,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7295994"
+        "$ref": "https://mef.rero.ch/api/idref/152195238"
       }
     ],
     "responsibilityStatement": [
@@ -41215,7 +41215,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6956099"
+        "$ref": "https://mef.rero.ch/api/gnd/129709913"
       }
     ],
     "responsibilityStatement": [
@@ -41407,7 +41407,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19593476"
+        "$ref": "https://mef.rero.ch/api/idref/079481698"
       }
     ],
     "responsibilityStatement": [
@@ -41501,7 +41501,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/69507"
+        "$ref": "https://mef.rero.ch/api/gnd/132551128"
       }
     ],
     "responsibilityStatement": [
@@ -41786,7 +41786,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19509374"
+        "$ref": "https://mef.rero.ch/api/rero/A003013903"
       }
     ],
     "responsibilityStatement": [
@@ -41903,19 +41903,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13428758"
+        "$ref": "https://mef.rero.ch/api/idref/026668521"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21304528"
+        "$ref": "https://mef.rero.ch/api/rero/A026890623"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4261381"
+        "$ref": "https://mef.rero.ch/api/idref/136495788"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15886750"
+        "$ref": "https://mef.rero.ch/api/idref/03252823X"
       }
     ],
     "responsibilityStatement": [
@@ -42107,7 +42107,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17584098"
+        "$ref": "https://mef.rero.ch/api/idref/060230746"
       }
     ],
     "responsibilityStatement": [
@@ -42311,15 +42311,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8858326"
+        "$ref": "https://mef.rero.ch/api/idref/194056627"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14835365"
+        "$ref": "https://mef.rero.ch/api/rero/A003095361"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22034455"
+        "$ref": "https://mef.rero.ch/api/rero/A005635399"
       }
     ],
     "responsibilityStatement": [
@@ -42423,11 +42423,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/573187"
+        "$ref": "https://mef.rero.ch/api/rero/A009248210"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11913304"
+        "$ref": "https://mef.rero.ch/api/idref/057632499"
       }
     ],
     "responsibilityStatement": [
@@ -42537,7 +42537,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14891685"
+        "$ref": "https://mef.rero.ch/api/idref/194616991"
       }
     ],
     "responsibilityStatement": [
@@ -42640,7 +42640,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4745240"
+        "$ref": "https://mef.rero.ch/api/idref/027176118"
       }
     ],
     "responsibilityStatement": [
@@ -42740,7 +42740,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32263426"
+        "$ref": "https://mef.rero.ch/api/rero/A000098356"
       }
     ],
     "responsibilityStatement": [
@@ -42832,7 +42832,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6302460"
+        "$ref": "https://mef.rero.ch/api/idref/027155811"
       }
     ],
     "responsibilityStatement": [
@@ -42955,7 +42955,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21774788"
+        "$ref": "https://mef.rero.ch/api/rero/A017410686"
       },
       {
         "type": "organisation",
@@ -43107,7 +43107,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31313669"
+        "$ref": "https://mef.rero.ch/api/idref/026719959"
       }
     ]
   },
@@ -43212,7 +43212,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12191031"
+        "$ref": "https://mef.rero.ch/api/idref/152390774"
       }
     ],
     "titlesProper": [
@@ -43337,7 +43337,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2294955"
+        "$ref": "https://mef.rero.ch/api/idref/026918471"
       }
     ],
     "responsibilityStatement": [
@@ -43430,7 +43430,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27062362"
+        "$ref": "https://mef.rero.ch/api/idref/029201241"
       }
     ],
     "responsibilityStatement": [
@@ -43533,7 +43533,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14898972"
+        "$ref": "https://mef.rero.ch/api/idref/028028945"
       }
     ],
     "responsibilityStatement": [
@@ -44050,7 +44050,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13713547"
+        "$ref": "https://mef.rero.ch/api/rero/A003232676"
       }
     ],
     "electronicLocator": [
@@ -44174,7 +44174,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8101262"
+        "$ref": "https://mef.rero.ch/api/idref/082965471"
       }
     ],
     "responsibilityStatement": [
@@ -44246,7 +44246,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17703741"
+        "$ref": "https://mef.rero.ch/api/rero/A003084243"
       }
     ],
     "responsibilityStatement": [
@@ -44339,7 +44339,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30825185"
+        "$ref": "https://mef.rero.ch/api/gnd/118596004"
       }
     ],
     "responsibilityStatement": [
@@ -44484,11 +44484,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/60554"
+        "$ref": "https://mef.rero.ch/api/gnd/115785655"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13393759"
+        "$ref": "https://mef.rero.ch/api/gnd/143392905"
       }
     ],
     "responsibilityStatement": [
@@ -44593,7 +44593,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22828179"
+        "$ref": "https://mef.rero.ch/api/idref/071396020"
       }
     ],
     "responsibilityStatement": [
@@ -44797,7 +44797,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13610129"
+        "$ref": "https://mef.rero.ch/api/idref/088056457"
       }
     ]
   },
@@ -44824,11 +44824,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18036111"
+        "$ref": "https://mef.rero.ch/api/idref/035724536"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31308008"
+        "$ref": "https://mef.rero.ch/api/idref/030765498"
       }
     ],
     "responsibilityStatement": [
@@ -45047,7 +45047,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32263426"
+        "$ref": "https://mef.rero.ch/api/rero/A000098356"
       }
     ],
     "responsibilityStatement": [
@@ -45139,7 +45139,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25148848"
+        "$ref": "https://mef.rero.ch/api/idref/029058937"
       }
     ],
     "responsibilityStatement": [
@@ -45202,7 +45202,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30074520"
+        "$ref": "https://mef.rero.ch/api/rero/A011766479"
       }
     ],
     "responsibilityStatement": [
@@ -45387,11 +45387,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29527355"
+        "$ref": "https://mef.rero.ch/api/idref/078197104"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8298484"
+        "$ref": "https://mef.rero.ch/api/idref/174111819"
       }
     ]
   },
@@ -45524,11 +45524,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7534798"
+        "$ref": "https://mef.rero.ch/api/idref/113528361"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12855810"
+        "$ref": "https://mef.rero.ch/api/idref/177589310"
       }
     ],
     "responsibilityStatement": [
@@ -45613,11 +45613,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/977602"
+        "$ref": "https://mef.rero.ch/api/idref/026690276"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3501304"
+        "$ref": "https://mef.rero.ch/api/idref/029617286"
       }
     ],
     "responsibilityStatement": [
@@ -45827,7 +45827,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32348141"
+        "$ref": "https://mef.rero.ch/api/idref/111086035"
       }
     ],
     "responsibilityStatement": [
@@ -45952,11 +45952,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14735641"
+        "$ref": "https://mef.rero.ch/api/idref/127839852"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11315855"
+        "$ref": "https://mef.rero.ch/api/gnd/136985378"
       }
     ],
     "responsibilityStatement": [
@@ -46059,7 +46059,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26898613"
+        "$ref": "https://mef.rero.ch/api/gnd/106411234X"
       }
     ],
     "responsibilityStatement": [
@@ -46267,11 +46267,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31874912"
+        "$ref": "https://mef.rero.ch/api/gnd/124847706"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23248918"
+        "$ref": "https://mef.rero.ch/api/gnd/1075056098"
       }
     ]
   },
@@ -46298,7 +46298,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7192053"
+        "$ref": "https://mef.rero.ch/api/idref/198276958"
       }
     ],
     "responsibilityStatement": [
@@ -46414,7 +46414,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8195829"
+        "$ref": "https://mef.rero.ch/api/idref/030728819"
       }
     ],
     "responsibilityStatement": [
@@ -46651,7 +46651,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31678648"
+        "$ref": "https://mef.rero.ch/api/idref/144501104"
       }
     ],
     "responsibilityStatement": [
@@ -46841,15 +46841,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24422864"
+        "$ref": "https://mef.rero.ch/api/idref/030782805"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22874152"
+        "$ref": "https://mef.rero.ch/api/idref/028443829"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/106437"
+        "$ref": "https://mef.rero.ch/api/gnd/172048850"
       }
     ]
   },
@@ -46954,7 +46954,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16628339"
+        "$ref": "https://mef.rero.ch/api/idref/120356082"
       }
     ]
   },
@@ -47118,19 +47118,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9510951"
+        "$ref": "https://mef.rero.ch/api/idref/050345095"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23200839"
+        "$ref": "https://mef.rero.ch/api/idref/05765025X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29875011"
+        "$ref": "https://mef.rero.ch/api/idref/057223688"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9021159"
+        "$ref": "https://mef.rero.ch/api/idref/032768214"
       }
     ]
   },
@@ -47157,7 +47157,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26232438"
+        "$ref": "https://mef.rero.ch/api/idref/029148529"
       }
     ],
     "title": [
@@ -47248,7 +47248,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3262379"
+        "$ref": "https://mef.rero.ch/api/idref/050655205"
       }
     ],
     "responsibilityStatement": [
@@ -47345,11 +47345,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27015923"
+        "$ref": "https://mef.rero.ch/api/idref/05691329X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14265652"
+        "$ref": "https://mef.rero.ch/api/idref/03182823X"
       }
     ],
     "responsibilityStatement": [
@@ -47460,7 +47460,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12028740"
+        "$ref": "https://mef.rero.ch/api/idref/029093147"
       }
     ],
     "responsibilityStatement": [
@@ -47557,11 +47557,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23355381"
+        "$ref": "https://mef.rero.ch/api/idref/034753346"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21475932"
+        "$ref": "https://mef.rero.ch/api/idref/057419558"
       }
     ],
     "responsibilityStatement": [
@@ -47739,11 +47739,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15649868"
+        "$ref": "https://mef.rero.ch/api/idref/073697354"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11466490"
+        "$ref": "https://mef.rero.ch/api/idref/028550749"
       },
       {
         "type": "organisation",
@@ -47778,7 +47778,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1060919"
+        "$ref": "https://mef.rero.ch/api/idref/031698298"
       }
     ],
     "responsibilityStatement": [
@@ -47874,7 +47874,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -47976,7 +47976,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11951309"
+        "$ref": "https://mef.rero.ch/api/idref/028293746"
       }
     ],
     "responsibilityStatement": [
@@ -48039,7 +48039,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2401521"
+        "$ref": "https://mef.rero.ch/api/gnd/1146423047"
       }
     ],
     "responsibilityStatement": [
@@ -48339,11 +48339,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16386979"
+        "$ref": "https://mef.rero.ch/api/idref/027746569"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8392637"
+        "$ref": "https://mef.rero.ch/api/idref/069894531"
       }
     ]
   },
@@ -48379,11 +48379,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20035619"
+        "$ref": "https://mef.rero.ch/api/gnd/112060234"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28759548"
+        "$ref": "https://mef.rero.ch/api/gnd/1061808637"
       }
     ],
     "responsibilityStatement": [
@@ -48567,7 +48567,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28072843"
+        "$ref": "https://mef.rero.ch/api/idref/028438833"
       }
     ]
   },
@@ -48594,7 +48594,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28313858"
+        "$ref": "https://mef.rero.ch/api/idref/056904304"
       }
     ],
     "responsibilityStatement": [
@@ -48701,7 +48701,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4308045"
+        "$ref": "https://mef.rero.ch/api/idref/139530088"
       }
     ],
     "responsibilityStatement": [
@@ -48804,11 +48804,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4374410"
+        "$ref": "https://mef.rero.ch/api/idref/05961448X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11404455"
+        "$ref": "https://mef.rero.ch/api/gnd/1103529471"
       }
     ],
     "responsibilityStatement": [
@@ -48900,7 +48900,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3933377"
+        "$ref": "https://mef.rero.ch/api/idref/026922290"
       }
     ],
     "responsibilityStatement": [
@@ -48988,7 +48988,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1997215"
+        "$ref": "https://mef.rero.ch/api/idref/072643609"
       }
     ],
     "responsibilityStatement": [
@@ -49091,11 +49091,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24636784"
+        "$ref": "https://mef.rero.ch/api/idref/073311855"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5485677"
+        "$ref": "https://mef.rero.ch/api/idref/031601375"
       }
     ],
     "responsibilityStatement": [
@@ -49185,15 +49185,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9135703"
+        "$ref": "https://mef.rero.ch/api/idref/070192979"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30682398"
+        "$ref": "https://mef.rero.ch/api/idref/05737841X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4686906"
+        "$ref": "https://mef.rero.ch/api/idref/052496767"
       }
     ],
     "responsibilityStatement": [
@@ -49297,7 +49297,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6350070"
+        "$ref": "https://mef.rero.ch/api/idref/033053413"
       }
     ],
     "responsibilityStatement": [
@@ -49491,7 +49491,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16135672"
+        "$ref": "https://mef.rero.ch/api/idref/111742714"
       }
     ],
     "titlesProper": [
@@ -49518,7 +49518,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32508596"
+        "$ref": "https://mef.rero.ch/api/gnd/130121363"
       }
     ],
     "responsibilityStatement": [
@@ -49581,7 +49581,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4924368"
+        "$ref": "https://mef.rero.ch/api/rero/A013496535"
       }
     ],
     "responsibilityStatement": [
@@ -49856,11 +49856,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22864010"
+        "$ref": "https://mef.rero.ch/api/idref/050805916"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26769359"
+        "$ref": "https://mef.rero.ch/api/rero/A006052444"
       }
     ]
   },
@@ -50059,11 +50059,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21967618"
+        "$ref": "https://mef.rero.ch/api/idref/026951738"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8212775"
+        "$ref": "https://mef.rero.ch/api/idref/035573139"
       }
     ],
     "responsibilityStatement": [
@@ -50250,7 +50250,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2944214"
+        "$ref": "https://mef.rero.ch/api/idref/028417232"
       }
     ]
   },
@@ -50273,7 +50273,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12378917"
+        "$ref": "https://mef.rero.ch/api/rero/A012325194"
       }
     ],
     "responsibilityStatement": [
@@ -50451,11 +50451,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27210995"
+        "$ref": "https://mef.rero.ch/api/gnd/129734845"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/812341"
+        "$ref": "https://mef.rero.ch/api/gnd/129734853"
       }
     ],
     "responsibilityStatement": [
@@ -50571,7 +50571,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29901633"
+        "$ref": "https://mef.rero.ch/api/rero/A018871003"
       }
     ],
     "responsibilityStatement": [
@@ -50847,7 +50847,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11816281"
+        "$ref": "https://mef.rero.ch/api/rero/A014123047"
       }
     ],
     "responsibilityStatement": [
@@ -51062,7 +51062,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31180674"
+        "$ref": "https://mef.rero.ch/api/idref/034645438"
       }
     ],
     "responsibilityStatement": [
@@ -51229,7 +51229,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16072928"
+        "$ref": "https://mef.rero.ch/api/idref/026794780"
       },
       {
         "type": "organisation",
@@ -51430,7 +51430,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27144545"
+        "$ref": "https://mef.rero.ch/api/idref/029906369"
       }
     ],
     "responsibilityStatement": [
@@ -51529,11 +51529,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32702266"
+        "$ref": "https://mef.rero.ch/api/idref/034086226"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10798052"
+        "$ref": "https://mef.rero.ch/api/idref/067011926"
       }
     ],
     "responsibilityStatement": [
@@ -51692,7 +51692,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30215511"
+        "$ref": "https://mef.rero.ch/api/rero/A018880647"
       }
     ],
     "responsibilityStatement": [
@@ -51788,11 +51788,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27547259"
+        "$ref": "https://mef.rero.ch/api/idref/028592484"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29010527"
+        "$ref": "https://mef.rero.ch/api/idref/028275055"
       }
     ],
     "responsibilityStatement": [
@@ -51986,7 +51986,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17987022"
+        "$ref": "https://mef.rero.ch/api/idref/050144618"
       }
     ],
     "responsibilityStatement": [
@@ -52078,11 +52078,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30507342"
+        "$ref": "https://mef.rero.ch/api/idref/027076164"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17197823"
+        "$ref": "https://mef.rero.ch/api/idref/026753618"
       }
     ],
     "responsibilityStatement": [
@@ -52190,7 +52190,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24411417"
+        "$ref": "https://mef.rero.ch/api/idref/031054552"
       }
     ],
     "responsibilityStatement": [
@@ -52354,27 +52354,27 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15118314"
+        "$ref": "https://mef.rero.ch/api/idref/026776510"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1231020"
+        "$ref": "https://mef.rero.ch/api/idref/028193997"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30846570"
+        "$ref": "https://mef.rero.ch/api/idref/02691395X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32554258"
+        "$ref": "https://mef.rero.ch/api/idref/028605675"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28532760"
+        "$ref": "https://mef.rero.ch/api/idref/026941120"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27786610"
+        "$ref": "https://mef.rero.ch/api/idref/078528267"
       }
     ],
     "is_part_of": "Opus international : revue trimestrielle"
@@ -52407,11 +52407,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7203632"
+        "$ref": "https://mef.rero.ch/api/idref/180106082"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5861058"
+        "$ref": "https://mef.rero.ch/api/idref/165783389"
       }
     ],
     "responsibilityStatement": [
@@ -52545,7 +52545,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26081618"
+        "$ref": "https://mef.rero.ch/api/idref/052586987"
       }
     ],
     "responsibilityStatement": [
@@ -52641,7 +52641,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30898056"
+        "$ref": "https://mef.rero.ch/api/idref/035673702"
       }
     ],
     "responsibilityStatement": [
@@ -52825,7 +52825,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6720083"
+        "$ref": "https://mef.rero.ch/api/idref/027009211"
       }
     ],
     "responsibilityStatement": [
@@ -52945,11 +52945,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12193726"
+        "$ref": "https://mef.rero.ch/api/idref/030174848"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19260368"
+        "$ref": "https://mef.rero.ch/api/idref/035120924"
       }
     ],
     "responsibilityStatement": [
@@ -53045,11 +53045,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28199685"
+        "$ref": "https://mef.rero.ch/api/idref/031364004"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5719914"
+        "$ref": "https://mef.rero.ch/api/idref/026753960"
       }
     ],
     "responsibilityStatement": [
@@ -53277,7 +53277,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3180589"
+        "$ref": "https://mef.rero.ch/api/idref/080902952"
       }
     ],
     "responsibilityStatement": [
@@ -53423,11 +53423,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22575077"
+        "$ref": "https://mef.rero.ch/api/idref/117844942"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24018102"
+        "$ref": "https://mef.rero.ch/api/gnd/18954581X"
       }
     ]
   },
@@ -53454,7 +53454,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30460160"
+        "$ref": "https://mef.rero.ch/api/idref/097638870"
       }
     ],
     "responsibilityStatement": [
@@ -53559,7 +53559,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16473306"
+        "$ref": "https://mef.rero.ch/api/idref/035155051"
       }
     ],
     "responsibilityStatement": [
@@ -53656,7 +53656,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -53763,11 +53763,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5248103"
+        "$ref": "https://mef.rero.ch/api/gnd/1035259249"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5745272"
+        "$ref": "https://mef.rero.ch/api/idref/083987703"
       }
     ],
     "responsibilityStatement": [
@@ -54054,7 +54054,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3118501"
+        "$ref": "https://mef.rero.ch/api/idref/035054786"
       }
     ],
     "responsibilityStatement": [
@@ -54278,7 +54278,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17374505"
+        "$ref": "https://mef.rero.ch/api/idref/02680316X"
       }
     ],
     "responsibilityStatement": [
@@ -54370,7 +54370,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2393234"
+        "$ref": "https://mef.rero.ch/api/idref/234193093"
       }
     ],
     "responsibilityStatement": [
@@ -54487,7 +54487,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3242651"
+        "$ref": "https://mef.rero.ch/api/rero/A003457065"
       }
     ],
     "responsibilityStatement": [
@@ -54588,11 +54588,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17982798"
+        "$ref": "https://mef.rero.ch/api/gnd/1068661348"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8283529"
+        "$ref": "https://mef.rero.ch/api/idref/13364071X"
       }
     ],
     "responsibilityStatement": [
@@ -54860,7 +54860,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29831056"
+        "$ref": "https://mef.rero.ch/api/idref/07102350X"
       }
     ],
     "responsibilityStatement": [
@@ -54956,7 +54956,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12611742"
+        "$ref": "https://mef.rero.ch/api/idref/028431391"
       }
     ],
     "responsibilityStatement": [
@@ -55071,7 +55071,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4915093"
+        "$ref": "https://mef.rero.ch/api/idref/02691784X"
       }
     ],
     "responsibilityStatement": [
@@ -55156,7 +55156,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24909563"
+        "$ref": "https://mef.rero.ch/api/rero/A019031126"
       }
     ],
     "responsibilityStatement": [
@@ -55287,7 +55287,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4984803"
+        "$ref": "https://mef.rero.ch/api/rero/A011540407"
       }
     ],
     "responsibilityStatement": [
@@ -55364,7 +55364,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8260059"
+        "$ref": "https://mef.rero.ch/api/idref/026916150"
       }
     ],
     "responsibilityStatement": [
@@ -55471,7 +55471,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21403925"
+        "$ref": "https://mef.rero.ch/api/idref/028352270"
       }
     ],
     "responsibilityStatement": [
@@ -55585,7 +55585,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20741585"
+        "$ref": "https://mef.rero.ch/api/rero/A011557605"
       }
     ],
     "responsibilityStatement": [
@@ -55734,7 +55734,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23929800"
+        "$ref": "https://mef.rero.ch/api/idref/028404971"
       },
       {
         "type": "organisation",
@@ -55770,7 +55770,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7618349"
+        "$ref": "https://mef.rero.ch/api/idref/026874849"
       }
     ],
     "responsibilityStatement": [
@@ -55874,15 +55874,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7136595"
+        "$ref": "https://mef.rero.ch/api/rero/A017202043"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21412106"
+        "$ref": "https://mef.rero.ch/api/rero/A017202047"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23530137"
+        "$ref": "https://mef.rero.ch/api/rero/A017202048"
       }
     ],
     "responsibilityStatement": [
@@ -56062,11 +56062,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6134094"
+        "$ref": "https://mef.rero.ch/api/idref/158883551"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26630614"
+        "$ref": "https://mef.rero.ch/api/idref/150208316"
       }
     ],
     "responsibilityStatement": [
@@ -56246,7 +56246,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13701268"
+        "$ref": "https://mef.rero.ch/api/rero/A003138002"
       }
     ]
   },
@@ -56351,11 +56351,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18619193"
+        "$ref": "https://mef.rero.ch/api/idref/077491033"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29440941"
+        "$ref": "https://mef.rero.ch/api/gnd/140859608"
       }
     ]
   },
@@ -56378,7 +56378,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20241211"
+        "$ref": "https://mef.rero.ch/api/rero/A005512445"
       }
     ],
     "responsibilityStatement": [
@@ -56656,7 +56656,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15518978"
+        "$ref": "https://mef.rero.ch/api/gnd/129265047"
       }
     ],
     "responsibilityStatement": [
@@ -56740,7 +56740,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5826068"
+        "$ref": "https://mef.rero.ch/api/idref/060732415"
       }
     ],
     "responsibilityStatement": [
@@ -56960,7 +56960,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31642141"
+        "$ref": "https://mef.rero.ch/api/idref/073380547"
       }
     ],
     "responsibilityStatement": [
@@ -57036,7 +57036,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28683002"
+        "$ref": "https://mef.rero.ch/api/idref/122064542"
       }
     ],
     "responsibilityStatement": [
@@ -57141,7 +57141,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5120588"
+        "$ref": "https://mef.rero.ch/api/gnd/1061410447"
       }
     ],
     "responsibilityStatement": [
@@ -57253,7 +57253,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2372286"
+        "$ref": "https://mef.rero.ch/api/rero/A011545887"
       }
     ],
     "responsibilityStatement": [
@@ -57321,11 +57321,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31408333"
+        "$ref": "https://mef.rero.ch/api/rero/A018894674"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20984519"
+        "$ref": "https://mef.rero.ch/api/idref/148268501"
       }
     ],
     "responsibilityStatement": [
@@ -57430,7 +57430,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6427474"
+        "$ref": "https://mef.rero.ch/api/idref/027160505"
       }
     ],
     "responsibilityStatement": [
@@ -57518,7 +57518,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31653880"
+        "$ref": "https://mef.rero.ch/api/idref/035216999"
       }
     ],
     "responsibilityStatement": [
@@ -57581,11 +57581,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25672509"
+        "$ref": "https://mef.rero.ch/api/idref/069554099"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11239860"
+        "$ref": "https://mef.rero.ch/api/idref/171166620"
       }
     ],
     "responsibilityStatement": [
@@ -57687,7 +57687,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28760711"
+        "$ref": "https://mef.rero.ch/api/idref/056907125"
       }
     ],
     "responsibilityStatement": [
@@ -57788,11 +57788,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24284536"
+        "$ref": "https://mef.rero.ch/api/idref/057405441"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4463584"
+        "$ref": "https://mef.rero.ch/api/idref/029296218"
       }
     ],
     "responsibilityStatement": [
@@ -57982,15 +57982,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20331365"
+        "$ref": "https://mef.rero.ch/api/idref/185589510"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15783841"
+        "$ref": "https://mef.rero.ch/api/idref/031600379"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17218090"
+        "$ref": "https://mef.rero.ch/api/idref/031766277"
       }
     ]
   },
@@ -58103,7 +58103,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29570915"
+        "$ref": "https://mef.rero.ch/api/gnd/1048018679"
       }
     ],
     "responsibilityStatement": [
@@ -58201,7 +58201,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25724100"
+        "$ref": "https://mef.rero.ch/api/idref/080780806"
       }
     ],
     "responsibilityStatement": [
@@ -58296,7 +58296,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1058326"
+        "$ref": "https://mef.rero.ch/api/idref/057400075"
       }
     ],
     "responsibilityStatement": [
@@ -58400,7 +58400,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21387979"
+        "$ref": "https://mef.rero.ch/api/gnd/115638989"
       }
     ],
     "responsibilityStatement": [
@@ -58595,19 +58595,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26236179"
+        "$ref": "https://mef.rero.ch/api/idref/029240808"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2626228"
+        "$ref": "https://mef.rero.ch/api/idref/028802705"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3762453"
+        "$ref": "https://mef.rero.ch/api/idref/033095027"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11865122"
+        "$ref": "https://mef.rero.ch/api/idref/027212491"
       }
     ]
   },
@@ -58751,11 +58751,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22447538"
+        "$ref": "https://mef.rero.ch/api/idref/117436569"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10894823"
+        "$ref": "https://mef.rero.ch/api/idref/050531212"
       }
     ],
     "responsibilityStatement": [
@@ -58944,7 +58944,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30875049"
+        "$ref": "https://mef.rero.ch/api/idref/026932792"
       }
     ],
     "responsibilityStatement": [
@@ -59049,7 +59049,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28042841"
+        "$ref": "https://mef.rero.ch/api/idref/028944410"
       }
     ],
     "responsibilityStatement": [
@@ -59145,11 +59145,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/779913"
+        "$ref": "https://mef.rero.ch/api/idref/225323869"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17655712"
+        "$ref": "https://mef.rero.ch/api/idref/149195931"
       }
     ],
     "responsibilityStatement": [
@@ -59264,7 +59264,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27588225"
+        "$ref": "https://mef.rero.ch/api/idref/150645228"
       }
     ],
     "responsibilityStatement": [
@@ -59449,7 +59449,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11399983"
+        "$ref": "https://mef.rero.ch/api/idref/061719692"
       }
     ]
   },
@@ -59472,7 +59472,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25280543"
+        "$ref": "https://mef.rero.ch/api/idref/092807356"
       }
     ],
     "responsibilityStatement": [
@@ -59557,11 +59557,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22126030"
+        "$ref": "https://mef.rero.ch/api/gnd/133497852"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2847882"
+        "$ref": "https://mef.rero.ch/api/idref/193155095"
       },
       {
         "type": "organisation",
@@ -59747,11 +59747,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30787573"
+        "$ref": "https://mef.rero.ch/api/idref/028751809"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23946104"
+        "$ref": "https://mef.rero.ch/api/idref/026869047"
       }
     ],
     "responsibilityStatement": [
@@ -59850,7 +59850,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20645024"
+        "$ref": "https://mef.rero.ch/api/idref/122152603"
       }
     ],
     "responsibilityStatement": [
@@ -59941,11 +59941,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24956499"
+        "$ref": "https://mef.rero.ch/api/idref/053423828"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18386000"
+        "$ref": "https://mef.rero.ch/api/gnd/1076286887"
       }
     ],
     "responsibilityStatement": [
@@ -60046,11 +60046,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15230522"
+        "$ref": "https://mef.rero.ch/api/idref/028496000"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15716895"
+        "$ref": "https://mef.rero.ch/api/idref/069282714"
       }
     ],
     "responsibilityStatement": [
@@ -60227,7 +60227,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22142919"
+        "$ref": "https://mef.rero.ch/api/idref/034721223"
       }
     ],
     "responsibilityStatement": [
@@ -60338,7 +60338,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20902973"
+        "$ref": "https://mef.rero.ch/api/idref/026814595"
       }
     ],
     "responsibilityStatement": [
@@ -60425,7 +60425,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/101901"
+        "$ref": "https://mef.rero.ch/api/idref/111022703"
       }
     ],
     "responsibilityStatement": [
@@ -60598,7 +60598,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3024523"
+        "$ref": "https://mef.rero.ch/api/rero/A005972232"
       }
     ]
   },
@@ -60837,7 +60837,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28518723"
+        "$ref": "https://mef.rero.ch/api/idref/133408485"
       }
     ],
     "responsibilityStatement": [
@@ -60946,7 +60946,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31603599"
+        "$ref": "https://mef.rero.ch/api/idref/026896273"
       }
     ],
     "responsibilityStatement": [
@@ -61038,7 +61038,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13847042"
+        "$ref": "https://mef.rero.ch/api/idref/050628364"
       }
     ],
     "responsibilityStatement": [
@@ -61134,15 +61134,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16216227"
+        "$ref": "https://mef.rero.ch/api/gnd/118178997"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27185485"
+        "$ref": "https://mef.rero.ch/api/idref/137071809"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10777115"
+        "$ref": "https://mef.rero.ch/api/idref/088958272"
       }
     ],
     "responsibilityStatement": [
@@ -61249,7 +61249,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28525145"
+        "$ref": "https://mef.rero.ch/api/idref/026760606"
       }
     ],
     "responsibilityStatement": [
@@ -61358,7 +61358,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20701137"
+        "$ref": "https://mef.rero.ch/api/gnd/118586114"
       }
     ],
     "responsibilityStatement": [
@@ -61692,7 +61692,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13346674"
+        "$ref": "https://mef.rero.ch/api/rero/A011575301"
       }
     ],
     "responsibilityStatement": [
@@ -61760,15 +61760,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/959748"
+        "$ref": "https://mef.rero.ch/api/idref/026984334"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29255871"
+        "$ref": "https://mef.rero.ch/api/idref/059372184"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25501186"
+        "$ref": "https://mef.rero.ch/api/idref/085491616"
       }
     ],
     "responsibilityStatement": [
@@ -61862,7 +61862,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21602490"
+        "$ref": "https://mef.rero.ch/api/idref/10094244X"
       }
     ],
     "responsibilityStatement": [
@@ -61950,15 +61950,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7133277"
+        "$ref": "https://mef.rero.ch/api/gnd/1034066048"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31659599"
+        "$ref": "https://mef.rero.ch/api/idref/088069575"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23771194"
+        "$ref": "https://mef.rero.ch/api/idref/059921269"
       }
     ],
     "responsibilityStatement": [
@@ -62082,7 +62082,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26305572"
+        "$ref": "https://mef.rero.ch/api/idref/057529892"
       }
     ],
     "responsibilityStatement": [
@@ -62177,7 +62177,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26062885"
+        "$ref": "https://mef.rero.ch/api/gnd/126515786"
       }
     ],
     "responsibilityStatement": [
@@ -62273,11 +62273,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25935991"
+        "$ref": "https://mef.rero.ch/api/idref/078075750"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30455125"
+        "$ref": "https://mef.rero.ch/api/gnd/1131826531"
       }
     ],
     "responsibilityStatement": [
@@ -62377,7 +62377,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19593476"
+        "$ref": "https://mef.rero.ch/api/idref/079481698"
       }
     ],
     "responsibilityStatement": [
@@ -62475,7 +62475,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3817448"
+        "$ref": "https://mef.rero.ch/api/rero/A003616088"
       }
     ],
     "responsibilityStatement": [
@@ -62583,7 +62583,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2025477"
+        "$ref": "https://mef.rero.ch/api/rero/A019007091"
       }
     ],
     "responsibilityStatement": [
@@ -62715,7 +62715,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/820888"
+        "$ref": "https://mef.rero.ch/api/idref/027976874"
       }
     ],
     "responsibilityStatement": [
@@ -62806,11 +62806,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9390964"
+        "$ref": "https://mef.rero.ch/api/rero/A003793801"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8398862"
+        "$ref": "https://mef.rero.ch/api/gnd/112213102X"
       }
     ],
     "responsibilityStatement": [
@@ -62900,7 +62900,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29767023"
+        "$ref": "https://mef.rero.ch/api/rero/A012380849"
       }
     ],
     "responsibilityStatement": [
@@ -62968,7 +62968,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22989638"
+        "$ref": "https://mef.rero.ch/api/rero/A011528276"
       }
     ],
     "responsibilityStatement": [
@@ -63129,11 +63129,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4836140"
+        "$ref": "https://mef.rero.ch/api/idref/119566621"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24833296"
+        "$ref": "https://mef.rero.ch/api/idref/027608956"
       }
     ]
   },
@@ -63156,7 +63156,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3513635"
+        "$ref": "https://mef.rero.ch/api/idref/092363830"
       }
     ],
     "responsibilityStatement": [
@@ -63253,7 +63253,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30244903"
+        "$ref": "https://mef.rero.ch/api/idref/177611464"
       }
     ],
     "responsibilityStatement": [
@@ -63350,7 +63350,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19519811"
+        "$ref": "https://mef.rero.ch/api/idref/026757540"
       }
     ],
     "responsibilityStatement": [
@@ -63581,11 +63581,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23285959"
+        "$ref": "https://mef.rero.ch/api/idref/085817627"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11386775"
+        "$ref": "https://mef.rero.ch/api/idref/069761124"
       },
       {
         "type": "organisation",
@@ -63748,7 +63748,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9893652"
+        "$ref": "https://mef.rero.ch/api/idref/192879421"
       }
     ],
     "responsibilityStatement": [
@@ -63852,11 +63852,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5249741"
+        "$ref": "https://mef.rero.ch/api/idref/085829145"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31800514"
+        "$ref": "https://mef.rero.ch/api/idref/035224096"
       }
     ],
     "responsibilityStatement": [
@@ -64087,7 +64087,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31979054"
+        "$ref": "https://mef.rero.ch/api/rero/A000132617"
       }
     ]
   },
@@ -64197,7 +64197,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24216860"
+        "$ref": "https://mef.rero.ch/api/idref/028496558"
       }
     ]
   },
@@ -64229,7 +64229,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14469120"
+        "$ref": "https://mef.rero.ch/api/rero/A000195745"
       }
     ],
     "title": [
@@ -64516,7 +64516,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2742222"
+        "$ref": "https://mef.rero.ch/api/gnd/121695271"
       }
     ],
     "responsibilityStatement": [
@@ -64619,11 +64619,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11313900"
+        "$ref": "https://mef.rero.ch/api/idref/026679108"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9689623"
+        "$ref": "https://mef.rero.ch/api/rero/A002926924"
       }
     ],
     "responsibilityStatement": [
@@ -64717,7 +64717,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7615714"
+        "$ref": "https://mef.rero.ch/api/idref/027078159"
       }
     ],
     "responsibilityStatement": [
@@ -64820,7 +64820,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13271172"
+        "$ref": "https://mef.rero.ch/api/idref/035093595"
       }
     ],
     "responsibilityStatement": [
@@ -65094,7 +65094,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11187822"
+        "$ref": "https://mef.rero.ch/api/idref/079963374"
       }
     ],
     "responsibilityStatement": [
@@ -65213,11 +65213,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20869592"
+        "$ref": "https://mef.rero.ch/api/idref/027320723"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30024019"
+        "$ref": "https://mef.rero.ch/api/rero/A003373879"
       }
     ],
     "responsibilityStatement": [
@@ -65407,11 +65407,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6626266"
+        "$ref": "https://mef.rero.ch/api/gnd/13291624X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5473631"
+        "$ref": "https://mef.rero.ch/api/gnd/1139053418"
       }
     ],
     "responsibilityStatement": [
@@ -65549,19 +65549,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30582365"
+        "$ref": "https://mef.rero.ch/api/gnd/13364636X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1151937"
+        "$ref": "https://mef.rero.ch/api/gnd/121486974"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19134710"
+        "$ref": "https://mef.rero.ch/api/rero/A003297073"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27783873"
+        "$ref": "https://mef.rero.ch/api/idref/029399939"
       }
     ],
     "responsibilityStatement": [
@@ -65807,7 +65807,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30898651"
+        "$ref": "https://mef.rero.ch/api/idref/175262292"
       }
     ],
     "responsibilityStatement": [
@@ -65870,7 +65870,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12378917"
+        "$ref": "https://mef.rero.ch/api/rero/A012325194"
       }
     ],
     "responsibilityStatement": [
@@ -65937,7 +65937,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17248926"
+        "$ref": "https://mef.rero.ch/api/idref/031926428"
       }
     ],
     "responsibilityStatement": [
@@ -66038,7 +66038,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8528252"
+        "$ref": "https://mef.rero.ch/api/idref/026965607"
       }
     ],
     "responsibilityStatement": [
@@ -66146,11 +66146,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30497397"
+        "$ref": "https://mef.rero.ch/api/idref/027128660"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31345702"
+        "$ref": "https://mef.rero.ch/api/idref/123595738"
       }
     ],
     "responsibilityStatement": [
@@ -66251,7 +66251,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3261279"
+        "$ref": "https://mef.rero.ch/api/idref/033893438"
       }
     ],
     "responsibilityStatement": [
@@ -66349,7 +66349,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29173440"
+        "$ref": "https://mef.rero.ch/api/idref/059348143"
       }
     ],
     "responsibilityStatement": [
@@ -66446,11 +66446,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7280863"
+        "$ref": "https://mef.rero.ch/api/idref/056746512"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21846081"
+        "$ref": "https://mef.rero.ch/api/idref/234848111"
       },
       {
         "type": "organisation",
@@ -66564,7 +66564,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4915093"
+        "$ref": "https://mef.rero.ch/api/idref/02691784X"
       }
     ],
     "responsibilityStatement": [
@@ -66659,11 +66659,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14915021"
+        "$ref": "https://mef.rero.ch/api/idref/23529182X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29305296"
+        "$ref": "https://mef.rero.ch/api/idref/235279471"
       }
     ],
     "responsibilityStatement": [
@@ -66759,11 +66759,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6830386"
+        "$ref": "https://mef.rero.ch/api/idref/056828691"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9922386"
+        "$ref": "https://mef.rero.ch/api/idref/086144715"
       }
     ],
     "responsibilityStatement": [
@@ -66864,11 +66864,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14921508"
+        "$ref": "https://mef.rero.ch/api/idref/027195104"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18511464"
+        "$ref": "https://mef.rero.ch/api/rero/A003556034"
       }
     ],
     "responsibilityStatement": [
@@ -66972,7 +66972,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21800490"
+        "$ref": "https://mef.rero.ch/api/idref/03176214X"
       }
     ],
     "responsibilityStatement": [
@@ -67073,11 +67073,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/200104"
+        "$ref": "https://mef.rero.ch/api/rero/A000015097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16809808"
+        "$ref": "https://mef.rero.ch/api/gnd/134702980"
       }
     ],
     "responsibilityStatement": [
@@ -67176,7 +67176,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30162412"
+        "$ref": "https://mef.rero.ch/api/idref/031627102"
       }
     ],
     "responsibilityStatement": [
@@ -67267,7 +67267,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31890774"
+        "$ref": "https://mef.rero.ch/api/rero/A011545889"
       }
     ],
     "responsibilityStatement": [
@@ -67406,7 +67406,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28115944"
+        "$ref": "https://mef.rero.ch/api/idref/119443406"
       }
     ],
     "responsibilityStatement": [
@@ -67558,15 +67558,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31190358"
+        "$ref": "https://mef.rero.ch/api/idref/029977479"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26231520"
+        "$ref": "https://mef.rero.ch/api/idref/026742152"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18691080"
+        "$ref": "https://mef.rero.ch/api/idref/035087935"
       }
     ],
     "responsibilityStatement": [
@@ -67845,7 +67845,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15349619"
+        "$ref": "https://mef.rero.ch/api/idref/203887131"
       }
     ]
   },
@@ -67868,7 +67868,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29400815"
+        "$ref": "https://mef.rero.ch/api/idref/18609809X"
       }
     ],
     "responsibilityStatement": [
@@ -67975,7 +67975,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27609753"
+        "$ref": "https://mef.rero.ch/api/idref/086143263"
       }
     ],
     "responsibilityStatement": [
@@ -68240,11 +68240,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6473845"
+        "$ref": "https://mef.rero.ch/api/idref/07013085X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18948492"
+        "$ref": "https://mef.rero.ch/api/idref/088441555"
       }
     ]
   },
@@ -68353,11 +68353,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24265629"
+        "$ref": "https://mef.rero.ch/api/idref/02911344X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17075312"
+        "$ref": "https://mef.rero.ch/api/idref/028845870"
       },
       {
         "type": "organisation",
@@ -68384,7 +68384,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29256923"
+        "$ref": "https://mef.rero.ch/api/idref/027203166"
       }
     ],
     "responsibilityStatement": [
@@ -68489,11 +68489,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28612702"
+        "$ref": "https://mef.rero.ch/api/idref/02694507X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32301452"
+        "$ref": "https://mef.rero.ch/api/idref/057629498"
       }
     ],
     "responsibilityStatement": [
@@ -68617,7 +68617,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30500459"
+        "$ref": "https://mef.rero.ch/api/idref/078047285"
       }
     ],
     "responsibilityStatement": [
@@ -68703,7 +68703,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27549470"
+        "$ref": "https://mef.rero.ch/api/idref/032132212"
       }
     ],
     "responsibilityStatement": [
@@ -69155,7 +69155,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23866320"
+        "$ref": "https://mef.rero.ch/api/idref/130672726"
       }
     ],
     "responsibilityStatement": [
@@ -69260,7 +69260,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30979610"
+        "$ref": "https://mef.rero.ch/api/idref/028602587"
       }
     ],
     "responsibilityStatement": [
@@ -69356,7 +69356,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7768978"
+        "$ref": "https://mef.rero.ch/api/idref/031745903"
       }
     ],
     "responsibilityStatement": [
@@ -69458,15 +69458,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8942311"
+        "$ref": "https://mef.rero.ch/api/idref/057531692"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7326727"
+        "$ref": "https://mef.rero.ch/api/idref/034571795"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30114647"
+        "$ref": "https://mef.rero.ch/api/idref/128006471"
       }
     ],
     "responsibilityStatement": [
@@ -69561,7 +69561,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6751363"
+        "$ref": "https://mef.rero.ch/api/rero/A027508095"
       }
     ],
     "responsibilityStatement": [
@@ -69658,7 +69658,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27823746"
+        "$ref": "https://mef.rero.ch/api/rero/A000134328"
       }
     ],
     "title": [
@@ -69836,11 +69836,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30538695"
+        "$ref": "https://mef.rero.ch/api/idref/227824490"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20342800"
+        "$ref": "https://mef.rero.ch/api/idref/229507255"
       }
     ],
     "responsibilityStatement": [
@@ -69947,7 +69947,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20320509"
+        "$ref": "https://mef.rero.ch/api/idref/027043339"
       }
     ],
     "responsibilityStatement": [
@@ -70035,7 +70035,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21199321"
+        "$ref": "https://mef.rero.ch/api/idref/165588241"
       }
     ],
     "responsibilityStatement": [
@@ -70098,7 +70098,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2627224"
+        "$ref": "https://mef.rero.ch/api/idref/084008768"
       }
     ],
     "responsibilityStatement": [
@@ -70214,7 +70214,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28363367"
+        "$ref": "https://mef.rero.ch/api/rero/A011545830"
       }
     ],
     "responsibilityStatement": [
@@ -70379,7 +70379,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26838446"
+        "$ref": "https://mef.rero.ch/api/gnd/132240289"
       }
     ]
   },
@@ -70411,7 +70411,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28222766"
+        "$ref": "https://mef.rero.ch/api/idref/080001858"
       }
     ],
     "responsibilityStatement": [
@@ -70598,11 +70598,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11786664"
+        "$ref": "https://mef.rero.ch/api/rero/A003714361"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14335112"
+        "$ref": "https://mef.rero.ch/api/idref/199829586"
       }
     ],
     "responsibilityStatement": [
@@ -70715,7 +70715,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13838637"
+        "$ref": "https://mef.rero.ch/api/rero/A013076004"
       }
     ],
     "responsibilityStatement": [
@@ -70801,7 +70801,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1465091"
+        "$ref": "https://mef.rero.ch/api/idref/185099092"
       }
     ],
     "responsibilityStatement": [
@@ -70884,7 +70884,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8337413"
+        "$ref": "https://mef.rero.ch/api/idref/237263513"
       }
     ],
     "responsibilityStatement": [
@@ -70986,7 +70986,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9426528"
+        "$ref": "https://mef.rero.ch/api/gnd/1176575325"
       }
     ],
     "responsibilityStatement": [
@@ -71203,7 +71203,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2088564"
+        "$ref": "https://mef.rero.ch/api/idref/095778454"
       }
     ],
     "responsibilityStatement": [
@@ -71359,7 +71359,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21873195"
+        "$ref": "https://mef.rero.ch/api/idref/029560292"
       }
     ]
   },
@@ -71471,7 +71471,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14751299"
+        "$ref": "https://mef.rero.ch/api/idref/033623929"
       }
     ]
   },
@@ -71494,7 +71494,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20587925"
+        "$ref": "https://mef.rero.ch/api/rero/A014188271"
       }
     ],
     "responsibilityStatement": [
@@ -71593,7 +71593,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12525221"
+        "$ref": "https://mef.rero.ch/api/rero/A011508202"
       }
     ],
     "responsibilityStatement": [
@@ -71665,15 +71665,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14706445"
+        "$ref": "https://mef.rero.ch/api/idref/111661315"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2151255"
+        "$ref": "https://mef.rero.ch/api/idref/150083068"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8998390"
+        "$ref": "https://mef.rero.ch/api/idref/194090493"
       }
     ],
     "responsibilityStatement": [
@@ -71783,7 +71783,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15645908"
+        "$ref": "https://mef.rero.ch/api/gnd/1025285646"
       }
     ],
     "responsibilityStatement": [
@@ -72300,7 +72300,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31396701"
+        "$ref": "https://mef.rero.ch/api/idref/028752538"
       }
     ],
     "responsibilityStatement": [
@@ -72382,11 +72382,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23161861"
+        "$ref": "https://mef.rero.ch/api/gnd/133733793"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23264863"
+        "$ref": "https://mef.rero.ch/api/rero/A003988452"
       }
     ],
     "responsibilityStatement": [
@@ -72570,11 +72570,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29759119"
+        "$ref": "https://mef.rero.ch/api/idref/075450844"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3420224"
+        "$ref": "https://mef.rero.ch/api/idref/026784556"
       }
     ],
     "responsibilityStatement": [
@@ -72675,7 +72675,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8182128"
+        "$ref": "https://mef.rero.ch/api/gnd/133091449"
       }
     ],
     "responsibilityStatement": [
@@ -72875,7 +72875,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30657828"
+        "$ref": "https://mef.rero.ch/api/idref/029763665"
       }
     ],
     "responsibilityStatement": [
@@ -72972,7 +72972,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9668365"
+        "$ref": "https://mef.rero.ch/api/idref/034666087"
       }
     ],
     "responsibilityStatement": [
@@ -73067,7 +73067,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25985376"
+        "$ref": "https://mef.rero.ch/api/idref/115720502"
       }
     ],
     "responsibilityStatement": [
@@ -73177,7 +73177,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10164131"
+        "$ref": "https://mef.rero.ch/api/rero/A012371231"
       }
     ],
     "responsibilityStatement": [
@@ -73335,7 +73335,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12443783"
+        "$ref": "https://mef.rero.ch/api/idref/030415225"
       }
     ],
     "responsibilityStatement": [
@@ -73407,19 +73407,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28838600"
+        "$ref": "https://mef.rero.ch/api/idref/028266358"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29501059"
+        "$ref": "https://mef.rero.ch/api/idref/070427518"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25198022"
+        "$ref": "https://mef.rero.ch/api/idref/030261163"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14794016"
+        "$ref": "https://mef.rero.ch/api/idref/061128163"
       }
     ],
     "responsibilityStatement": [
@@ -73593,7 +73593,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12460776"
+        "$ref": "https://mef.rero.ch/api/idref/030544033"
       }
     ],
     "responsibilityStatement": [
@@ -73683,7 +73683,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17297173"
+        "$ref": "https://mef.rero.ch/api/idref/074120956"
       }
     ],
     "responsibilityStatement": [
@@ -73755,7 +73755,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -73866,7 +73866,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29256923"
+        "$ref": "https://mef.rero.ch/api/idref/027203166"
       }
     ],
     "responsibilityStatement": [
@@ -73962,7 +73962,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24666564"
+        "$ref": "https://mef.rero.ch/api/idref/080076548"
       }
     ],
     "responsibilityStatement": [
@@ -74068,11 +74068,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4502687"
+        "$ref": "https://mef.rero.ch/api/idref/085795089"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9768739"
+        "$ref": "https://mef.rero.ch/api/gnd/104562692"
       }
     ],
     "responsibilityStatement": [
@@ -74261,11 +74261,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21173456"
+        "$ref": "https://mef.rero.ch/api/idref/067694055"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27050499"
+        "$ref": "https://mef.rero.ch/api/idref/074153684"
       }
     ]
   },
@@ -74369,11 +74369,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9401802"
+        "$ref": "https://mef.rero.ch/api/idref/026951096"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25239946"
+        "$ref": "https://mef.rero.ch/api/idref/026735253"
       }
     ],
     "responsibilityStatement": [
@@ -74479,7 +74479,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23030367"
+        "$ref": "https://mef.rero.ch/api/idref/027128016"
       }
     ],
     "responsibilityStatement": [
@@ -74585,11 +74585,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15028043"
+        "$ref": "https://mef.rero.ch/api/idref/147186412"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15115883"
+        "$ref": "https://mef.rero.ch/api/idref/053432053"
       }
     ],
     "responsibilityStatement": [
@@ -74694,11 +74694,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/472828"
+        "$ref": "https://mef.rero.ch/api/rero/A013360195"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22566758"
+        "$ref": "https://mef.rero.ch/api/idref/152505636"
       }
     ],
     "responsibilityStatement": [
@@ -74893,11 +74893,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31628214"
+        "$ref": "https://mef.rero.ch/api/idref/02694734X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5043117"
+        "$ref": "https://mef.rero.ch/api/idref/057048215"
       }
     ],
     "responsibilityStatement": [
@@ -75130,7 +75130,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9960657"
+        "$ref": "https://mef.rero.ch/api/idref/090440412"
       }
     ],
     "responsibilityStatement": [
@@ -75308,15 +75308,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13935854"
+        "$ref": "https://mef.rero.ch/api/idref/027053857"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21813682"
+        "$ref": "https://mef.rero.ch/api/idref/034236031"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25229456"
+        "$ref": "https://mef.rero.ch/api/idref/100940498"
       }
     ],
     "responsibilityStatement": [
@@ -75422,7 +75422,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16390577"
+        "$ref": "https://mef.rero.ch/api/rero/A011539270"
       }
     ],
     "responsibilityStatement": [
@@ -75674,7 +75674,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7764650"
+        "$ref": "https://mef.rero.ch/api/idref/223543497"
       }
     ],
     "responsibilityStatement": [
@@ -75837,11 +75837,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21804095"
+        "$ref": "https://mef.rero.ch/api/idref/028264878"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1396206"
+        "$ref": "https://mef.rero.ch/api/idref/028415264"
       }
     ],
     "responsibilityStatement": [
@@ -75960,7 +75960,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20086098"
+        "$ref": "https://mef.rero.ch/api/idref/026809079"
       }
     ],
     "responsibilityStatement": [
@@ -76054,7 +76054,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29263197"
+        "$ref": "https://mef.rero.ch/api/rero/A003997130"
       }
     ],
     "responsibilityStatement": [
@@ -76214,7 +76214,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4545173"
+        "$ref": "https://mef.rero.ch/api/idref/148269958"
       }
     ],
     "titlesProper": [
@@ -76244,7 +76244,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8891461"
+        "$ref": "https://mef.rero.ch/api/idref/035715928"
       }
     ],
     "responsibilityStatement": [
@@ -76349,7 +76349,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/161042"
+        "$ref": "https://mef.rero.ch/api/idref/033491577"
       },
       {
         "type": "person",
@@ -76490,7 +76490,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20981097"
+        "$ref": "https://mef.rero.ch/api/gnd/172800757"
       }
     ],
     "responsibilityStatement": [
@@ -76606,7 +76606,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14296927"
+        "$ref": "https://mef.rero.ch/api/idref/131005960"
       }
     ],
     "responsibilityStatement": [
@@ -76840,11 +76840,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32322670"
+        "$ref": "https://mef.rero.ch/api/idref/02675441X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9920900"
+        "$ref": "https://mef.rero.ch/api/rero/A003042303"
       }
     ],
     "responsibilityStatement": [
@@ -77036,15 +77036,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10321672"
+        "$ref": "https://mef.rero.ch/api/idref/032444621"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25499567"
+        "$ref": "https://mef.rero.ch/api/idref/028028856"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/962192"
+        "$ref": "https://mef.rero.ch/api/idref/032583702"
       }
     ],
     "responsibilityStatement": [
@@ -77237,7 +77237,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9102195"
+        "$ref": "https://mef.rero.ch/api/idref/112345476"
       }
     ],
     "responsibilityStatement": [
@@ -77375,7 +77375,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9581721"
+        "$ref": "https://mef.rero.ch/api/idref/026788861"
       }
     ],
     "responsibilityStatement": [
@@ -77474,11 +77474,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13511108"
+        "$ref": "https://mef.rero.ch/api/idref/164504540"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9082557"
+        "$ref": "https://mef.rero.ch/api/idref/164504567"
       }
     ],
     "responsibilityStatement": [
@@ -77599,7 +77599,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29798364"
+        "$ref": "https://mef.rero.ch/api/idref/026665875"
       }
     ],
     "responsibilityStatement": [
@@ -77791,7 +77791,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9254654"
+        "$ref": "https://mef.rero.ch/api/idref/067252540"
       }
     ],
     "responsibilityStatement": [
@@ -77895,7 +77895,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7868442"
+        "$ref": "https://mef.rero.ch/api/idref/033265151"
       }
     ],
     "responsibilityStatement": [
@@ -78005,7 +78005,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8997160"
+        "$ref": "https://mef.rero.ch/api/rero/A005598805"
       }
     ],
     "responsibilityStatement": [
@@ -78101,11 +78101,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12865045"
+        "$ref": "https://mef.rero.ch/api/idref/057372896"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28113326"
+        "$ref": "https://mef.rero.ch/api/idref/136094597"
       }
     ],
     "responsibilityStatement": [
@@ -78260,11 +78260,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13111780"
+        "$ref": "https://mef.rero.ch/api/idref/084291419"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24434886"
+        "$ref": "https://mef.rero.ch/api/idref/027771202"
       },
       {
         "type": "organisation",
@@ -78295,7 +78295,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32255415"
+        "$ref": "https://mef.rero.ch/api/idref/074180304"
       }
     ],
     "responsibilityStatement": [
@@ -78396,7 +78396,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13096711"
+        "$ref": "https://mef.rero.ch/api/idref/033088721"
       }
     ],
     "responsibilityStatement": [
@@ -78469,7 +78469,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31555579"
+        "$ref": "https://mef.rero.ch/api/rero/A014161336"
       }
     ],
     "responsibilityStatement": [
@@ -78646,7 +78646,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15576188"
+        "$ref": "https://mef.rero.ch/api/idref/026726327"
       }
     ],
     "responsibilityStatement": [
@@ -78737,11 +78737,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22617413"
+        "$ref": "https://mef.rero.ch/api/idref/028510054"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12768174"
+        "$ref": "https://mef.rero.ch/api/rero/A003527890"
       }
     ],
     "responsibilityStatement": [
@@ -78838,7 +78838,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16715428"
+        "$ref": "https://mef.rero.ch/api/rero/A011525154"
       }
     ],
     "responsibilityStatement": [
@@ -78915,7 +78915,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6312810"
+        "$ref": "https://mef.rero.ch/api/idref/032026374"
       }
     ],
     "responsibilityStatement": [
@@ -79010,11 +79010,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31077167"
+        "$ref": "https://mef.rero.ch/api/rero/A003490634"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/480691"
+        "$ref": "https://mef.rero.ch/api/idref/078122538"
       }
     ],
     "responsibilityStatement": [
@@ -79121,7 +79121,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/735841"
+        "$ref": "https://mef.rero.ch/api/rero/A017007938"
       }
     ],
     "responsibilityStatement": [
@@ -79423,7 +79423,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17449302"
+        "$ref": "https://mef.rero.ch/api/rero/A011551431"
       }
     ],
     "responsibilityStatement": [
@@ -79575,7 +79575,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2626600"
+        "$ref": "https://mef.rero.ch/api/idref/077805011"
       }
     ],
     "responsibilityStatement": [
@@ -79651,7 +79651,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24346679"
+        "$ref": "https://mef.rero.ch/api/idref/057557845"
       }
     ],
     "responsibilityStatement": [
@@ -79741,7 +79741,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22199234"
+        "$ref": "https://mef.rero.ch/api/rero/A008747341"
       }
     ],
     "responsibilityStatement": [
@@ -79839,11 +79839,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27828448"
+        "$ref": "https://mef.rero.ch/api/rero/A003058658"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28840960"
+        "$ref": "https://mef.rero.ch/api/idref/073740896"
       }
     ],
     "responsibilityStatement": [
@@ -79944,7 +79944,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19435614"
+        "$ref": "https://mef.rero.ch/api/idref/032441770"
       }
     ],
     "responsibilityStatement": [
@@ -80109,11 +80109,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24664365"
+        "$ref": "https://mef.rero.ch/api/idref/060312149"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14635225"
+        "$ref": "https://mef.rero.ch/api/idref/033405786"
       }
     ]
   },
@@ -80144,11 +80144,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26893749"
+        "$ref": "https://mef.rero.ch/api/idref/078796210"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23948742"
+        "$ref": "https://mef.rero.ch/api/idref/026933659"
       }
     ],
     "responsibilityStatement": [
@@ -80267,15 +80267,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29884806"
+        "$ref": "https://mef.rero.ch/api/idref/027329453"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8837636"
+        "$ref": "https://mef.rero.ch/api/idref/143311867"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31771082"
+        "$ref": "https://mef.rero.ch/api/gnd/14290757X"
       }
     ],
     "responsibilityStatement": [
@@ -80467,7 +80467,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31011014"
+        "$ref": "https://mef.rero.ch/api/idref/027032299"
       }
     ]
   },
@@ -80494,7 +80494,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22673473"
+        "$ref": "https://mef.rero.ch/api/idref/027000346"
       }
     ],
     "responsibilityStatement": [
@@ -80590,7 +80590,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24062925"
+        "$ref": "https://mef.rero.ch/api/rero/A000180000"
       }
     ],
     "responsibilityStatement": [
@@ -80728,7 +80728,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14964194"
+        "$ref": "https://mef.rero.ch/api/gnd/104272508X"
       }
     ],
     "responsibilityStatement": [
@@ -80823,7 +80823,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19881525"
+        "$ref": "https://mef.rero.ch/api/idref/110341406"
       }
     ],
     "responsibilityStatement": [
@@ -80890,15 +80890,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4131533"
+        "$ref": "https://mef.rero.ch/api/gnd/136668615"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18726847"
+        "$ref": "https://mef.rero.ch/api/rero/A003290633"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/476023"
+        "$ref": "https://mef.rero.ch/api/gnd/1053813430"
       }
     ],
     "responsibilityStatement": [
@@ -81006,7 +81006,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12891850"
+        "$ref": "https://mef.rero.ch/api/idref/200194062"
       }
     ],
     "responsibilityStatement": [
@@ -81123,7 +81123,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21898049"
+        "$ref": "https://mef.rero.ch/api/idref/08202412X"
       }
     ],
     "responsibilityStatement": [
@@ -81222,7 +81222,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32451687"
+        "$ref": "https://mef.rero.ch/api/idref/134447522"
       }
     ],
     "responsibilityStatement": [
@@ -81314,7 +81314,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9663467"
+        "$ref": "https://mef.rero.ch/api/idref/030266246"
       }
     ],
     "responsibilityStatement": [
@@ -81386,7 +81386,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18386000"
+        "$ref": "https://mef.rero.ch/api/gnd/1076286887"
       }
     ],
     "responsibilityStatement": [
@@ -81482,11 +81482,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23161861"
+        "$ref": "https://mef.rero.ch/api/gnd/133733793"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23264863"
+        "$ref": "https://mef.rero.ch/api/rero/A003988452"
       }
     ],
     "responsibilityStatement": [
@@ -81668,7 +81668,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26151146"
+        "$ref": "https://mef.rero.ch/api/idref/028841646"
       }
     ]
   },
@@ -81771,11 +81771,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12261117"
+        "$ref": "https://mef.rero.ch/api/gnd/1022443860"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23034032"
+        "$ref": "https://mef.rero.ch/api/gnd/108684849"
       }
     ]
   },
@@ -81798,15 +81798,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21797665"
+        "$ref": "https://mef.rero.ch/api/rero/A003922852"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18851446"
+        "$ref": "https://mef.rero.ch/api/idref/095134123"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16291687"
+        "$ref": "https://mef.rero.ch/api/idref/163253277"
       }
     ],
     "responsibilityStatement": [
@@ -81924,7 +81924,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16803241"
+        "$ref": "https://mef.rero.ch/api/idref/027101770"
       }
     ],
     "responsibilityStatement": [
@@ -82029,7 +82029,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25901353"
+        "$ref": "https://mef.rero.ch/api/idref/08523348X"
       },
       {
         "type": "organisation",
@@ -82133,7 +82133,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11458642"
+        "$ref": "https://mef.rero.ch/api/rero/A019238775"
       }
     ],
     "responsibilityStatement": [
@@ -82249,7 +82249,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30320612"
+        "$ref": "https://mef.rero.ch/api/idref/050302175"
       }
     ],
     "responsibilityStatement": [
@@ -82446,11 +82446,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25008916"
+        "$ref": "https://mef.rero.ch/api/idref/119025469"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18454858"
+        "$ref": "https://mef.rero.ch/api/gnd/1062086759"
       }
     ]
   },
@@ -82482,7 +82482,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20279177"
+        "$ref": "https://mef.rero.ch/api/idref/057290830"
       }
     ],
     "responsibilityStatement": [
@@ -82587,11 +82587,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2052531"
+        "$ref": "https://mef.rero.ch/api/gnd/1049810163"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17375508"
+        "$ref": "https://mef.rero.ch/api/idref/032800983"
       }
     ],
     "responsibilityStatement": [
@@ -82692,7 +82692,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7191747"
+        "$ref": "https://mef.rero.ch/api/idref/027190099"
       }
     ],
     "responsibilityStatement": [
@@ -82789,7 +82789,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18441853"
+        "$ref": "https://mef.rero.ch/api/idref/055278302"
       }
     ],
     "responsibilityStatement": [
@@ -82976,11 +82976,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3679059"
+        "$ref": "https://mef.rero.ch/api/idref/027280896"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15800031"
+        "$ref": "https://mef.rero.ch/api/idref/026723417"
       }
     ],
     "responsibilityStatement": [
@@ -83304,7 +83304,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22246907"
+        "$ref": "https://mef.rero.ch/api/rero/A000079766"
       }
     ],
     "responsibilityStatement": [
@@ -83395,7 +83395,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17508693"
+        "$ref": "https://mef.rero.ch/api/idref/028622928"
       }
     ],
     "responsibilityStatement": [
@@ -83541,11 +83541,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2708422"
+        "$ref": "https://mef.rero.ch/api/idref/067686400"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19013036"
+        "$ref": "https://mef.rero.ch/api/idref/223528722"
       }
     ],
     "titlesProper": [
@@ -83571,11 +83571,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16069119"
+        "$ref": "https://mef.rero.ch/api/idref/111101883"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18766067"
+        "$ref": "https://mef.rero.ch/api/rero/A006473229"
       }
     ],
     "responsibilityStatement": [
@@ -83850,11 +83850,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4098420"
+        "$ref": "https://mef.rero.ch/api/idref/032213247"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26816440"
+        "$ref": "https://mef.rero.ch/api/idref/031505910"
       }
     ]
   },
@@ -83882,7 +83882,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18234230"
+        "$ref": "https://mef.rero.ch/api/idref/134364392"
       }
     ],
     "responsibilityStatement": [
@@ -83977,11 +83977,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20619098"
+        "$ref": "https://mef.rero.ch/api/idref/027188671"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26199204"
+        "$ref": "https://mef.rero.ch/api/idref/166374563"
       }
     ],
     "responsibilityStatement": [
@@ -84222,7 +84222,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24680799"
+        "$ref": "https://mef.rero.ch/api/rero/A016432321"
       }
     ],
     "responsibilityStatement": [
@@ -84349,7 +84349,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12480727"
+        "$ref": "https://mef.rero.ch/api/idref/148257054"
       }
     ],
     "responsibilityStatement": [
@@ -84459,7 +84459,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10394470"
+        "$ref": "https://mef.rero.ch/api/idref/030470676"
       }
     ],
     "responsibilityStatement": [
@@ -84658,11 +84658,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15719504"
+        "$ref": "https://mef.rero.ch/api/idref/161698158"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/795605"
+        "$ref": "https://mef.rero.ch/api/idref/230063365"
       }
     ]
   },
@@ -84774,7 +84774,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4997512"
+        "$ref": "https://mef.rero.ch/api/idref/129246301"
       }
     ],
     "responsibilityStatement": [
@@ -84871,7 +84871,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10170369"
+        "$ref": "https://mef.rero.ch/api/rero/A003019993"
       }
     ],
     "responsibilityStatement": [
@@ -84961,7 +84961,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22784686"
+        "$ref": "https://mef.rero.ch/api/idref/163893314"
       }
     ],
     "responsibilityStatement": [
@@ -85070,7 +85070,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11542777"
+        "$ref": "https://mef.rero.ch/api/idref/027053636"
       }
     ],
     "responsibilityStatement": [
@@ -85256,11 +85256,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4070303"
+        "$ref": "https://mef.rero.ch/api/idref/164852115"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1052802"
+        "$ref": "https://mef.rero.ch/api/idref/189217650"
       }
     ],
     "responsibilityStatement": [
@@ -85364,11 +85364,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29713780"
+        "$ref": "https://mef.rero.ch/api/idref/031400825"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7534743"
+        "$ref": "https://mef.rero.ch/api/idref/031400833"
       }
     ],
     "responsibilityStatement": [
@@ -85553,7 +85553,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9511504"
+        "$ref": "https://mef.rero.ch/api/idref/026879921"
       }
     ],
     "responsibilityStatement": [
@@ -85650,7 +85650,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11871735"
+        "$ref": "https://mef.rero.ch/api/idref/03533682X"
       }
     ],
     "responsibilityStatement": [
@@ -85810,7 +85810,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -85916,7 +85916,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29256923"
+        "$ref": "https://mef.rero.ch/api/idref/027203166"
       }
     ],
     "responsibilityStatement": [
@@ -86017,7 +86017,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30995100"
+        "$ref": "https://mef.rero.ch/api/idref/028413148"
       }
     ],
     "responsibilityStatement": [
@@ -86121,11 +86121,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20640793"
+        "$ref": "https://mef.rero.ch/api/idref/151469113"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11949282"
+        "$ref": "https://mef.rero.ch/api/idref/029996465"
       }
     ],
     "responsibilityStatement": [
@@ -86225,7 +86225,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11388621"
+        "$ref": "https://mef.rero.ch/api/rero/A003063602"
       }
     ],
     "responsibilityStatement": [
@@ -86500,11 +86500,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20828403"
+        "$ref": "https://mef.rero.ch/api/idref/030720494"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13479369"
+        "$ref": "https://mef.rero.ch/api/idref/031238351"
       }
     ]
   },
@@ -86527,7 +86527,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31071482"
+        "$ref": "https://mef.rero.ch/api/idref/027102645"
       }
     ],
     "responsibilityStatement": [
@@ -86628,11 +86628,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7940199"
+        "$ref": "https://mef.rero.ch/api/idref/031771416"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1642899"
+        "$ref": "https://mef.rero.ch/api/idref/031771440"
       }
     ],
     "responsibilityStatement": [
@@ -86755,11 +86755,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24336347"
+        "$ref": "https://mef.rero.ch/api/idref/034211675"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3436256"
+        "$ref": "https://mef.rero.ch/api/idref/03421173X"
       }
     ],
     "responsibilityStatement": [
@@ -86948,11 +86948,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17066261"
+        "$ref": "https://mef.rero.ch/api/idref/086089935"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10153182"
+        "$ref": "https://mef.rero.ch/api/rero/A003015814"
       }
     ]
   },
@@ -86988,7 +86988,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5905550"
+        "$ref": "https://mef.rero.ch/api/idref/027343685"
       }
     ],
     "responsibilityStatement": [
@@ -87080,7 +87080,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11875052"
+        "$ref": "https://mef.rero.ch/api/idref/027440737"
       }
     ],
     "responsibilityStatement": [
@@ -87177,11 +87177,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13117437"
+        "$ref": "https://mef.rero.ch/api/rero/A003034438"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32787952"
+        "$ref": "https://mef.rero.ch/api/idref/029024625"
       }
     ],
     "responsibilityStatement": [
@@ -87295,7 +87295,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24333358"
+        "$ref": "https://mef.rero.ch/api/idref/13370744X"
       }
     ],
     "responsibilityStatement": [
@@ -87765,7 +87765,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30160608"
+        "$ref": "https://mef.rero.ch/api/idref/069120048"
       }
     ],
     "responsibilityStatement": [
@@ -87858,7 +87858,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31796389"
+        "$ref": "https://mef.rero.ch/api/rero/A016698997"
       }
     ],
     "responsibilityStatement": [
@@ -87959,11 +87959,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7371810"
+        "$ref": "https://mef.rero.ch/api/idref/050671731"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31190358"
+        "$ref": "https://mef.rero.ch/api/idref/029977479"
       }
     ],
     "responsibilityStatement": [
@@ -88058,11 +88058,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28102982"
+        "$ref": "https://mef.rero.ch/api/gnd/120965771"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24339406"
+        "$ref": "https://mef.rero.ch/api/idref/080115942"
       }
     ],
     "responsibilityStatement": [
@@ -88164,11 +88164,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16555025"
+        "$ref": "https://mef.rero.ch/api/idref/029173256"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31600215"
+        "$ref": "https://mef.rero.ch/api/idref/116357282"
       }
     ],
     "responsibilityStatement": [
@@ -88302,7 +88302,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8915565"
+        "$ref": "https://mef.rero.ch/api/idref/117974323"
       }
     ],
     "responsibilityStatement": [
@@ -88620,7 +88620,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2268546"
+        "$ref": "https://mef.rero.ch/api/idref/194575969"
       }
     ]
   },
@@ -88643,7 +88643,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15806874"
+        "$ref": "https://mef.rero.ch/api/gnd/106106384"
       }
     ],
     "responsibilityStatement": [
@@ -88726,7 +88726,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15240000"
+        "$ref": "https://mef.rero.ch/api/idref/069182892"
       }
     ],
     "responsibilityStatement": [
@@ -88828,11 +88828,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21961154"
+        "$ref": "https://mef.rero.ch/api/idref/028270339"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17441752"
+        "$ref": "https://mef.rero.ch/api/idref/035138211"
       }
     ],
     "responsibilityStatement": [
@@ -88918,7 +88918,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17870213"
+        "$ref": "https://mef.rero.ch/api/gnd/136116698"
       }
     ],
     "responsibilityStatement": [
@@ -89041,11 +89041,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17247785"
+        "$ref": "https://mef.rero.ch/api/rero/A018893082"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18766067"
+        "$ref": "https://mef.rero.ch/api/rero/A006473229"
       }
     ],
     "responsibilityStatement": [
@@ -89374,7 +89374,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5606803"
+        "$ref": "https://mef.rero.ch/api/idref/03498867X"
       }
     ]
   },
@@ -89503,7 +89503,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10590390"
+        "$ref": "https://mef.rero.ch/api/idref/086136151"
       }
     ],
     "responsibilityStatement": [
@@ -89604,7 +89604,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17058855"
+        "$ref": "https://mef.rero.ch/api/idref/082016461"
       }
     ],
     "responsibilityStatement": [
@@ -89716,7 +89716,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4504461"
+        "$ref": "https://mef.rero.ch/api/idref/050220489"
       }
     ],
     "responsibilityStatement": [
@@ -89813,7 +89813,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7322397"
+        "$ref": "https://mef.rero.ch/api/idref/028090527"
       }
     ],
     "responsibilityStatement": [
@@ -89936,7 +89936,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16812316"
+        "$ref": "https://mef.rero.ch/api/idref/02691770X"
       }
     ],
     "responsibilityStatement": [
@@ -90023,7 +90023,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18787770"
+        "$ref": "https://mef.rero.ch/api/idref/194447421"
       }
     ],
     "responsibilityStatement": [
@@ -90086,7 +90086,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29263197"
+        "$ref": "https://mef.rero.ch/api/rero/A003997130"
       }
     ],
     "responsibilityStatement": [
@@ -90176,11 +90176,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17195524"
+        "$ref": "https://mef.rero.ch/api/idref/027172112"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16263757"
+        "$ref": "https://mef.rero.ch/api/idref/026897717"
       }
     ],
     "responsibilityStatement": [
@@ -90271,7 +90271,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31137187"
+        "$ref": "https://mef.rero.ch/api/gnd/128987987"
       }
     ],
     "responsibilityStatement": [
@@ -90465,7 +90465,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9836645"
+        "$ref": "https://mef.rero.ch/api/idref/146704304"
       }
     ],
     "responsibilityStatement": [
@@ -90563,7 +90563,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32471889"
+        "$ref": "https://mef.rero.ch/api/idref/028367502"
       }
     ],
     "responsibilityStatement": [
@@ -90635,7 +90635,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12653726"
+        "$ref": "https://mef.rero.ch/api/idref/028778103"
       }
     ],
     "responsibilityStatement": [
@@ -90812,11 +90812,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18151477"
+        "$ref": "https://mef.rero.ch/api/idref/028281497"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23346581"
+        "$ref": "https://mef.rero.ch/api/idref/034083464"
       }
     ],
     "responsibilityStatement": [
@@ -90911,7 +90911,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5570242"
+        "$ref": "https://mef.rero.ch/api/idref/033417741"
       }
     ],
     "responsibilityStatement": [
@@ -91028,11 +91028,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25234968"
+        "$ref": "https://mef.rero.ch/api/idref/029119987"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20660584"
+        "$ref": "https://mef.rero.ch/api/idref/055669484"
       }
     ],
     "responsibilityStatement": [
@@ -91228,7 +91228,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16545010"
+        "$ref": "https://mef.rero.ch/api/idref/077007220"
       }
     ]
   },
@@ -91344,7 +91344,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13680212"
+        "$ref": "https://mef.rero.ch/api/idref/030576873"
       }
     ]
   },
@@ -91371,11 +91371,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16977684"
+        "$ref": "https://mef.rero.ch/api/rero/A005961404"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/928047"
+        "$ref": "https://mef.rero.ch/api/rero/A005961406"
       }
     ],
     "responsibilityStatement": [
@@ -91495,7 +91495,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15248199"
+        "$ref": "https://mef.rero.ch/api/idref/057585482"
       }
     ],
     "responsibilityStatement": [
@@ -91604,11 +91604,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3107542"
+        "$ref": "https://mef.rero.ch/api/idref/027021882"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24631763"
+        "$ref": "https://mef.rero.ch/api/idref/061134910"
       },
       {
         "type": "organisation",
@@ -91718,7 +91718,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25167053"
+        "$ref": "https://mef.rero.ch/api/rero/A025550294"
       }
     ],
     "responsibilityStatement": [
@@ -91845,11 +91845,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32293779"
+        "$ref": "https://mef.rero.ch/api/idref/182635112"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3803097"
+        "$ref": "https://mef.rero.ch/api/gnd/1068191279"
       }
     ],
     "responsibilityStatement": [
@@ -91939,7 +91939,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/341222"
+        "$ref": "https://mef.rero.ch/api/idref/029222818"
       }
     ],
     "responsibilityStatement": [
@@ -92123,7 +92123,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29184863"
+        "$ref": "https://mef.rero.ch/api/idref/034305769"
       }
     ]
   },
@@ -92146,7 +92146,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10604455"
+        "$ref": "https://mef.rero.ch/api/idref/113867638"
       }
     ],
     "responsibilityStatement": [
@@ -92238,7 +92238,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24873739"
+        "$ref": "https://mef.rero.ch/api/rero/A018880915"
       }
     ],
     "responsibilityStatement": [
@@ -92324,7 +92324,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10566821"
+        "$ref": "https://mef.rero.ch/api/idref/027897346"
       }
     ],
     "responsibilityStatement": [
@@ -92391,11 +92391,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11596071"
+        "$ref": "https://mef.rero.ch/api/idref/053476999"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20947193"
+        "$ref": "https://mef.rero.ch/api/idref/108547000"
       }
     ],
     "responsibilityStatement": [
@@ -92507,7 +92507,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15444695"
+        "$ref": "https://mef.rero.ch/api/idref/131203460"
       }
     ],
     "responsibilityStatement": [
@@ -92660,7 +92660,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1969822"
+        "$ref": "https://mef.rero.ch/api/idref/028438876"
       }
     ],
     "responsibilityStatement": [
@@ -92845,7 +92845,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25315139"
+        "$ref": "https://mef.rero.ch/api/gnd/10904357X"
       }
     ],
     "responsibilityStatement": [
@@ -93014,7 +93014,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11313170"
+        "$ref": "https://mef.rero.ch/api/idref/182311643"
       }
     ]
   },
@@ -93037,7 +93037,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23196473"
+        "$ref": "https://mef.rero.ch/api/idref/028500849"
       }
     ],
     "responsibilityStatement": [
@@ -93209,11 +93209,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8353347"
+        "$ref": "https://mef.rero.ch/api/idref/026847760"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13562266"
+        "$ref": "https://mef.rero.ch/api/idref/032533349"
       }
     ]
   },
@@ -93241,7 +93241,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2325279"
+        "$ref": "https://mef.rero.ch/api/idref/034667180"
       }
     ],
     "responsibilityStatement": [
@@ -93410,7 +93410,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26573752"
+        "$ref": "https://mef.rero.ch/api/gnd/142191590"
       }
     ],
     "responsibilityStatement": [
@@ -93510,7 +93510,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7322480"
+        "$ref": "https://mef.rero.ch/api/idref/030705479"
       }
     ],
     "responsibilityStatement": [
@@ -93605,7 +93605,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3971814"
+        "$ref": "https://mef.rero.ch/api/idref/028315545"
       }
     ],
     "responsibilityStatement": [
@@ -93727,7 +93727,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13934411"
+        "$ref": "https://mef.rero.ch/api/rero/A011575926"
       }
     ],
     "responsibilityStatement": [
@@ -93794,11 +93794,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10407007"
+        "$ref": "https://mef.rero.ch/api/rero/A003963044"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31811065"
+        "$ref": "https://mef.rero.ch/api/idref/077220617"
       }
     ],
     "responsibilityStatement": [
@@ -93905,7 +93905,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15069521"
+        "$ref": "https://mef.rero.ch/api/gnd/130376361"
       }
     ],
     "responsibilityStatement": [
@@ -94000,7 +94000,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29524057"
+        "$ref": "https://mef.rero.ch/api/idref/028439929"
       }
     ],
     "responsibilityStatement": [
@@ -94092,7 +94092,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23805367"
+        "$ref": "https://mef.rero.ch/api/idref/03346894X"
       }
     ],
     "responsibilityStatement": [
@@ -94202,7 +94202,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22193500"
+        "$ref": "https://mef.rero.ch/api/idref/129712043"
       }
     ],
     "responsibilityStatement": [
@@ -94294,7 +94294,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23028141"
+        "$ref": "https://mef.rero.ch/api/idref/124411177"
       }
     ],
     "responsibilityStatement": [
@@ -94532,11 +94532,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11549548"
+        "$ref": "https://mef.rero.ch/api/idref/131232576"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15168002"
+        "$ref": "https://mef.rero.ch/api/rero/A018578472"
       }
     ],
     "responsibilityStatement": [
@@ -94641,11 +94641,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27782975"
+        "$ref": "https://mef.rero.ch/api/idref/03098064X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18109905"
+        "$ref": "https://mef.rero.ch/api/idref/026934574"
       }
     ],
     "responsibilityStatement": [
@@ -94927,7 +94927,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22778702"
+        "$ref": "https://mef.rero.ch/api/idref/050421204"
       }
     ],
     "responsibilityStatement": [
@@ -95029,11 +95029,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30831886"
+        "$ref": "https://mef.rero.ch/api/idref/143219359"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6591250"
+        "$ref": "https://mef.rero.ch/api/idref/028751698"
       }
     ],
     "responsibilityStatement": [
@@ -95242,7 +95242,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31328316"
+        "$ref": "https://mef.rero.ch/api/gnd/1068536632"
       }
     ],
     "responsibilityStatement": [
@@ -95353,7 +95353,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22246907"
+        "$ref": "https://mef.rero.ch/api/rero/A000079766"
       }
     ],
     "responsibilityStatement": [
@@ -95565,7 +95565,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24217606"
+        "$ref": "https://mef.rero.ch/api/idref/057392978"
       }
     ]
   },
@@ -95592,11 +95592,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31959013"
+        "$ref": "https://mef.rero.ch/api/rero/A005860858"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24346390"
+        "$ref": "https://mef.rero.ch/api/rero/A005860861"
       }
     ],
     "responsibilityStatement": [
@@ -95715,19 +95715,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9615976"
+        "$ref": "https://mef.rero.ch/api/idref/028732235"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5561505"
+        "$ref": "https://mef.rero.ch/api/idref/028767888"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30941269"
+        "$ref": "https://mef.rero.ch/api/idref/055765610"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/473778"
+        "$ref": "https://mef.rero.ch/api/rero/A005913488"
       }
     ],
     "responsibilityStatement": [
@@ -95837,7 +95837,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9434399"
+        "$ref": "https://mef.rero.ch/api/rero/A003867252"
       }
     ],
     "responsibilityStatement": [
@@ -95941,7 +95941,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22193500"
+        "$ref": "https://mef.rero.ch/api/idref/129712043"
       }
     ],
     "responsibilityStatement": [
@@ -96032,11 +96032,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25658162"
+        "$ref": "https://mef.rero.ch/api/idref/026894920"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32377722"
+        "$ref": "https://mef.rero.ch/api/idref/033459924"
       }
     ],
     "responsibilityStatement": [
@@ -96126,7 +96126,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19874981"
+        "$ref": "https://mef.rero.ch/api/idref/055130372"
       }
     ],
     "responsibilityStatement": [
@@ -96231,7 +96231,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20325971"
+        "$ref": "https://mef.rero.ch/api/idref/087452022"
       }
     ],
     "responsibilityStatement": [
@@ -96325,7 +96325,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11186067"
+        "$ref": "https://mef.rero.ch/api/rero/A000109522"
       }
     ],
     "responsibilityStatement": [
@@ -96522,7 +96522,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1518452"
+        "$ref": "https://mef.rero.ch/api/idref/111091667"
       }
     ],
     "responsibilityStatement": [
@@ -96620,7 +96620,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28745796"
+        "$ref": "https://mef.rero.ch/api/rero/A019009457"
       }
     ],
     "responsibilityStatement": [
@@ -96719,7 +96719,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18365066"
+        "$ref": "https://mef.rero.ch/api/idref/111364388"
       }
     ],
     "responsibilityStatement": [
@@ -96827,11 +96827,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7285289"
+        "$ref": "https://mef.rero.ch/api/idref/027004236"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3398680"
+        "$ref": "https://mef.rero.ch/api/idref/227597559"
       }
     ],
     "responsibilityStatement": [
@@ -97079,11 +97079,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10859065"
+        "$ref": "https://mef.rero.ch/api/idref/029383099"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12692543"
+        "$ref": "https://mef.rero.ch/api/idref/031201547"
       }
     ]
   },
@@ -97223,7 +97223,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/58074"
+        "$ref": "https://mef.rero.ch/api/idref/050713760"
       }
     ],
     "responsibilityStatement": [
@@ -97319,7 +97319,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26316445"
+        "$ref": "https://mef.rero.ch/api/idref/027074617"
       }
     ],
     "responsibilityStatement": [
@@ -97497,11 +97497,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10408491"
+        "$ref": "https://mef.rero.ch/api/idref/029164370"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16802356"
+        "$ref": "https://mef.rero.ch/api/idref/030353548"
       }
     ],
     "responsibilityStatement": [
@@ -97610,7 +97610,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13105956"
+        "$ref": "https://mef.rero.ch/api/idref/112170579"
       }
     ],
     "responsibilityStatement": [
@@ -97713,11 +97713,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25510785"
+        "$ref": "https://mef.rero.ch/api/idref/163808325"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1728019"
+        "$ref": "https://mef.rero.ch/api/idref/220077304"
       }
     ],
     "responsibilityStatement": [
@@ -97896,11 +97896,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22463536"
+        "$ref": "https://mef.rero.ch/api/idref/029957281"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6267848"
+        "$ref": "https://mef.rero.ch/api/gnd/129816736"
       }
     ]
   },
@@ -97927,7 +97927,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31903199"
+        "$ref": "https://mef.rero.ch/api/idref/028274822"
       },
       {
         "type": "person",
@@ -98032,7 +98032,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25174798"
+        "$ref": "https://mef.rero.ch/api/idref/050138421"
       }
     ],
     "responsibilityStatement": [
@@ -98125,7 +98125,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16724922"
+        "$ref": "https://mef.rero.ch/api/idref/084521902"
       }
     ],
     "responsibilityStatement": [
@@ -98192,7 +98192,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14548244"
+        "$ref": "https://mef.rero.ch/api/idref/02832627X"
       }
     ],
     "responsibilityStatement": [
@@ -98470,7 +98470,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9243250"
+        "$ref": "https://mef.rero.ch/api/idref/143818740"
       }
     ],
     "responsibilityStatement": [
@@ -98579,7 +98579,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29045128"
+        "$ref": "https://mef.rero.ch/api/idref/23426960X"
       }
     ],
     "responsibilityStatement": [
@@ -98729,7 +98729,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7170030"
+        "$ref": "https://mef.rero.ch/api/rero/A018882619"
       }
     ],
     "responsibilityStatement": [
@@ -98826,7 +98826,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6463572"
+        "$ref": "https://mef.rero.ch/api/idref/079495362"
       }
     ],
     "responsibilityStatement": [
@@ -98946,15 +98946,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18268161"
+        "$ref": "https://mef.rero.ch/api/gnd/142376221"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/551765"
+        "$ref": "https://mef.rero.ch/api/rero/A003791274"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3481827"
+        "$ref": "https://mef.rero.ch/api/idref/152232389"
       }
     ],
     "responsibilityStatement": [
@@ -99051,7 +99051,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22919129"
+        "$ref": "https://mef.rero.ch/api/idref/035034734"
       }
     ],
     "responsibilityStatement": [
@@ -99145,11 +99145,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27692780"
+        "$ref": "https://mef.rero.ch/api/idref/029194202"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16474037"
+        "$ref": "https://mef.rero.ch/api/idref/140885935"
       }
     ],
     "responsibilityStatement": [
@@ -99454,11 +99454,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24993600"
+        "$ref": "https://mef.rero.ch/api/idref/031103219"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3308618"
+        "$ref": "https://mef.rero.ch/api/idref/055281729"
       }
     ],
     "responsibilityStatement": [
@@ -99559,7 +99559,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25324399"
+        "$ref": "https://mef.rero.ch/api/idref/080712509"
       }
     ],
     "responsibilityStatement": [
@@ -99744,7 +99744,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11292135"
+        "$ref": "https://mef.rero.ch/api/rero/A009042477"
       }
     ]
   },
@@ -99962,7 +99962,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1130815"
+        "$ref": "https://mef.rero.ch/api/idref/123045460"
       }
     ],
     "responsibilityStatement": [
@@ -100121,7 +100121,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13195354"
+        "$ref": "https://mef.rero.ch/api/idref/085988154"
       }
     ],
     "responsibilityStatement": [
@@ -100276,7 +100276,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26301348"
+        "$ref": "https://mef.rero.ch/api/idref/050502336"
       }
     ],
     "responsibilityStatement": [
@@ -100382,19 +100382,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22422411"
+        "$ref": "https://mef.rero.ch/api/idref/026859297"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14832183"
+        "$ref": "https://mef.rero.ch/api/idref/137598041"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15920210"
+        "$ref": "https://mef.rero.ch/api/idref/026687860"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5414964"
+        "$ref": "https://mef.rero.ch/api/idref/032601786"
       },
       {
         "type": "organisation",
@@ -100510,7 +100510,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31977967"
+        "$ref": "https://mef.rero.ch/api/rero/A002963621"
       }
     ],
     "responsibilityStatement": [
@@ -100851,7 +100851,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2912826"
+        "$ref": "https://mef.rero.ch/api/gnd/17304767X"
       }
     ]
   },
@@ -100882,11 +100882,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10685918"
+        "$ref": "https://mef.rero.ch/api/rero/A000006566"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14180534"
+        "$ref": "https://mef.rero.ch/api/idref/055286569"
       }
     ],
     "responsibilityStatement": [
@@ -101003,7 +101003,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -101105,11 +101105,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19055572"
+        "$ref": "https://mef.rero.ch/api/idref/128422424"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22193500"
+        "$ref": "https://mef.rero.ch/api/idref/129712043"
       }
     ],
     "responsibilityStatement": [
@@ -101200,7 +101200,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4282398"
+        "$ref": "https://mef.rero.ch/api/rero/A003763401"
       }
     ],
     "responsibilityStatement": [
@@ -101304,7 +101304,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20802544"
+        "$ref": "https://mef.rero.ch/api/idref/031586058"
       },
       {
         "type": "organisation",
@@ -101416,7 +101416,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28821051"
+        "$ref": "https://mef.rero.ch/api/idref/034607129"
       }
     ],
     "responsibilityStatement": [
@@ -101479,7 +101479,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25959786"
+        "$ref": "https://mef.rero.ch/api/gnd/1064757464"
       }
     ],
     "responsibilityStatement": [
@@ -101551,7 +101551,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15363126"
+        "$ref": "https://mef.rero.ch/api/rero/A003427027"
       }
     ],
     "responsibilityStatement": [
@@ -101662,7 +101662,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24864552"
+        "$ref": "https://mef.rero.ch/api/idref/033747830"
       }
     ],
     "responsibilityStatement": [
@@ -101758,11 +101758,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28938703"
+        "$ref": "https://mef.rero.ch/api/rero/A012320585"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30230409"
+        "$ref": "https://mef.rero.ch/api/idref/186317972"
       }
     ],
     "responsibilityStatement": [
@@ -101863,7 +101863,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14833947"
+        "$ref": "https://mef.rero.ch/api/idref/031583849"
       }
     ],
     "responsibilityStatement": [
@@ -101974,7 +101974,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22309425"
+        "$ref": "https://mef.rero.ch/api/idref/031999050"
       }
     ],
     "responsibilityStatement": [
@@ -102069,11 +102069,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9158615"
+        "$ref": "https://mef.rero.ch/api/idref/189771402"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14835365"
+        "$ref": "https://mef.rero.ch/api/rero/A003095361"
       }
     ],
     "responsibilityStatement": [
@@ -102158,15 +102158,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18041858"
+        "$ref": "https://mef.rero.ch/api/idref/026870290"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24628597"
+        "$ref": "https://mef.rero.ch/api/idref/057487359"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20619664"
+        "$ref": "https://mef.rero.ch/api/gnd/108934578"
       }
     ],
     "responsibilityStatement": [
@@ -102284,11 +102284,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1221761"
+        "$ref": "https://mef.rero.ch/api/idref/079448860"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25490541"
+        "$ref": "https://mef.rero.ch/api/idref/080269699"
       }
     ],
     "responsibilityStatement": [
@@ -102461,11 +102461,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1401026"
+        "$ref": "https://mef.rero.ch/api/idref/026749327"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2277657"
+        "$ref": "https://mef.rero.ch/api/gnd/1069121673"
       }
     ],
     "responsibilityStatement": [
@@ -102564,7 +102564,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4919632"
+        "$ref": "https://mef.rero.ch/api/idref/027037061"
       }
     ],
     "responsibilityStatement": [
@@ -102660,7 +102660,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26615932"
+        "$ref": "https://mef.rero.ch/api/rero/A011505168"
       }
     ],
     "responsibilityStatement": [
@@ -102732,7 +102732,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2772740"
+        "$ref": "https://mef.rero.ch/api/idref/031075126"
       }
     ],
     "responsibilityStatement": [
@@ -102913,15 +102913,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14664973"
+        "$ref": "https://mef.rero.ch/api/idref/03340674X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31513577"
+        "$ref": "https://mef.rero.ch/api/rero/A003699379"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/164657"
+        "$ref": "https://mef.rero.ch/api/idref/06873929X"
       }
     ],
     "responsibilityStatement": [
@@ -103021,7 +103021,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11179792"
+        "$ref": "https://mef.rero.ch/api/idref/029680212"
       }
     ],
     "responsibilityStatement": [
@@ -103282,7 +103282,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4423781"
+        "$ref": "https://mef.rero.ch/api/gnd/1082261416"
       }
     ],
     "responsibilityStatement": [
@@ -103380,7 +103380,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25080471"
+        "$ref": "https://mef.rero.ch/api/rero/A011505153"
       }
     ],
     "responsibilityStatement": [
@@ -103517,7 +103517,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18274678"
+        "$ref": "https://mef.rero.ch/api/idref/031679447"
       }
     ]
   },
@@ -103548,11 +103548,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9169448"
+        "$ref": "https://mef.rero.ch/api/rero/A003466944"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28304685"
+        "$ref": "https://mef.rero.ch/api/rero/A003466946"
       }
     ],
     "responsibilityStatement": [
@@ -103663,7 +103663,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/669910"
+        "$ref": "https://mef.rero.ch/api/idref/032104561"
       }
     ],
     "responsibilityStatement": [
@@ -103763,15 +103763,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1718638"
+        "$ref": "https://mef.rero.ch/api/rero/A014303108"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2543614"
+        "$ref": "https://mef.rero.ch/api/rero/A014316011"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17386715"
+        "$ref": "https://mef.rero.ch/api/rero/A027314111"
       },
       {
         "type": "organisation",
@@ -103909,7 +103909,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6706249"
+        "$ref": "https://mef.rero.ch/api/idref/071047557"
       }
     ],
     "responsibilityStatement": [
@@ -104025,7 +104025,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14673858"
+        "$ref": "https://mef.rero.ch/api/rero/A012350832"
       }
     ],
     "responsibilityStatement": [
@@ -104113,7 +104113,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10223275"
+        "$ref": "https://mef.rero.ch/api/idref/030636272"
       }
     ],
     "responsibilityStatement": [
@@ -104207,7 +104207,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7453346"
+        "$ref": "https://mef.rero.ch/api/rero/A011517473"
       }
     ],
     "responsibilityStatement": [
@@ -104353,7 +104353,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5471125"
+        "$ref": "https://mef.rero.ch/api/idref/080514294"
       }
     ],
     "responsibilityStatement": [
@@ -104444,7 +104444,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21144172"
+        "$ref": "https://mef.rero.ch/api/idref/029683203"
       }
     ],
     "responsibilityStatement": [
@@ -104581,7 +104581,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24191804"
+        "$ref": "https://mef.rero.ch/api/gnd/127067620"
       }
     ]
   },
@@ -104688,7 +104688,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15159117"
+        "$ref": "https://mef.rero.ch/api/idref/139416781"
       }
     ],
     "responsibilityStatement": [
@@ -105068,7 +105068,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13391274"
+        "$ref": "https://mef.rero.ch/api/idref/154448478"
       }
     ],
     "responsibilityStatement": [
@@ -105266,7 +105266,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19023251"
+        "$ref": "https://mef.rero.ch/api/gnd/1135749892"
       }
     ]
   },
@@ -105293,7 +105293,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29256923"
+        "$ref": "https://mef.rero.ch/api/idref/027203166"
       }
     ],
     "responsibilityStatement": [
@@ -105656,11 +105656,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28934039"
+        "$ref": "https://mef.rero.ch/api/idref/026745151"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18766062"
+        "$ref": "https://mef.rero.ch/api/idref/034460608"
       }
     ],
     "responsibilityStatement": [
@@ -105758,7 +105758,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27151325"
+        "$ref": "https://mef.rero.ch/api/idref/026966107"
       }
     ],
     "responsibilityStatement": [
@@ -105918,7 +105918,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9581721"
+        "$ref": "https://mef.rero.ch/api/idref/026788861"
       }
     ],
     "responsibilityStatement": [
@@ -106015,7 +106015,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10975952"
+        "$ref": "https://mef.rero.ch/api/idref/050318683"
       }
     ],
     "responsibilityStatement": [
@@ -106111,7 +106111,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2648864"
+        "$ref": "https://mef.rero.ch/api/idref/078626420"
       }
     ],
     "responsibilityStatement": [
@@ -106207,7 +106207,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19547434"
+        "$ref": "https://mef.rero.ch/api/idref/158759877"
       }
     ],
     "responsibilityStatement": [
@@ -106327,11 +106327,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12747607"
+        "$ref": "https://mef.rero.ch/api/idref/027018466"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28614391"
+        "$ref": "https://mef.rero.ch/api/idref/032189192"
       }
     ],
     "responsibilityStatement": [
@@ -106428,7 +106428,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18529328"
+        "$ref": "https://mef.rero.ch/api/idref/081313322"
       }
     ],
     "responsibilityStatement": [
@@ -106570,7 +106570,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24767325"
+        "$ref": "https://mef.rero.ch/api/rero/A006074709"
       }
     ]
   },
@@ -106602,11 +106602,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1697132"
+        "$ref": "https://mef.rero.ch/api/gnd/120061015"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23040869"
+        "$ref": "https://mef.rero.ch/api/idref/031824641"
       }
     ],
     "responsibilityStatement": [
@@ -106691,7 +106691,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6230668"
+        "$ref": "https://mef.rero.ch/api/rero/A003538045"
       }
     ],
     "responsibilityStatement": [
@@ -106793,7 +106793,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9331718"
+        "$ref": "https://mef.rero.ch/api/idref/028445430"
       }
     ],
     "responsibilityStatement": [
@@ -106896,7 +106896,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6640901"
+        "$ref": "https://mef.rero.ch/api/idref/030322774"
       }
     ],
     "responsibilityStatement": [
@@ -107002,11 +107002,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22742557"
+        "$ref": "https://mef.rero.ch/api/idref/197467644"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31942474"
+        "$ref": "https://mef.rero.ch/api/idref/188607919"
       }
     ],
     "responsibilityStatement": [
@@ -107125,11 +107125,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16634757"
+        "$ref": "https://mef.rero.ch/api/idref/027116875"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/821455"
+        "$ref": "https://mef.rero.ch/api/idref/030430402"
       }
     ],
     "responsibilityStatement": [
@@ -107215,7 +107215,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27631408"
+        "$ref": "https://mef.rero.ch/api/rero/A011557603"
       }
     ],
     "responsibilityStatement": [
@@ -107357,11 +107357,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31761136"
+        "$ref": "https://mef.rero.ch/api/idref/034708138"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12285074"
+        "$ref": "https://mef.rero.ch/api/idref/144600749"
       }
     ],
     "responsibilityStatement": [
@@ -107468,7 +107468,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4713239"
+        "$ref": "https://mef.rero.ch/api/rero/A019037016"
       }
     ],
     "responsibilityStatement": [
@@ -107624,7 +107624,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2045048"
+        "$ref": "https://mef.rero.ch/api/idref/20050441X"
       }
     ],
     "responsibilityStatement": [
@@ -107687,7 +107687,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6234413"
+        "$ref": "https://mef.rero.ch/api/idref/028464249"
       }
     ],
     "responsibilityStatement": [
@@ -107891,7 +107891,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8355448"
+        "$ref": "https://mef.rero.ch/api/idref/031659381"
       }
     ],
     "responsibilityStatement": [
@@ -108196,7 +108196,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25130699"
+        "$ref": "https://mef.rero.ch/api/rero/A005818603"
       }
     ]
   },
@@ -108224,7 +108224,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27405118"
+        "$ref": "https://mef.rero.ch/api/idref/131252682"
       }
     ],
     "responsibilityStatement": [
@@ -108320,7 +108320,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5878137"
+        "$ref": "https://mef.rero.ch/api/idref/125178999"
       }
     ],
     "responsibilityStatement": [
@@ -108415,7 +108415,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22246907"
+        "$ref": "https://mef.rero.ch/api/rero/A000079766"
       }
     ],
     "responsibilityStatement": [
@@ -108510,7 +108510,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5307451"
+        "$ref": "https://mef.rero.ch/api/idref/028817257"
       }
     ],
     "responsibilityStatement": [
@@ -108857,11 +108857,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27865698"
+        "$ref": "https://mef.rero.ch/api/rero/A003510209"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12486993"
+        "$ref": "https://mef.rero.ch/api/idref/110754441"
       }
     ]
   },
@@ -108884,7 +108884,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28555664"
+        "$ref": "https://mef.rero.ch/api/gnd/1013539591"
       }
     ],
     "responsibilityStatement": [
@@ -108998,7 +108998,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21142279"
+        "$ref": "https://mef.rero.ch/api/rero/A025133458"
       }
     ],
     "responsibilityStatement": [
@@ -109096,7 +109096,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23399760"
+        "$ref": "https://mef.rero.ch/api/rero/A003418300"
       }
     ],
     "responsibilityStatement": [
@@ -109191,7 +109191,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16372833"
+        "$ref": "https://mef.rero.ch/api/idref/03475833X"
       }
     ],
     "responsibilityStatement": [
@@ -109384,7 +109384,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18023117"
+        "$ref": "https://mef.rero.ch/api/idref/031568637"
       }
     ]
   },
@@ -109407,7 +109407,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29905981"
+        "$ref": "https://mef.rero.ch/api/idref/067006817"
       }
     ],
     "responsibilityStatement": [
@@ -109488,7 +109488,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29458375"
+        "$ref": "https://mef.rero.ch/api/idref/145815285"
       }
     ],
     "responsibilityStatement": [
@@ -109670,11 +109670,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9650862"
+        "$ref": "https://mef.rero.ch/api/idref/164099832"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2906718"
+        "$ref": "https://mef.rero.ch/api/idref/164099859"
       }
     ]
   },
@@ -109697,7 +109697,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14251320"
+        "$ref": "https://mef.rero.ch/api/idref/148093507"
       }
     ],
     "responsibilityStatement": [
@@ -109770,11 +109770,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9536199"
+        "$ref": "https://mef.rero.ch/api/gnd/118092332"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5864485"
+        "$ref": "https://mef.rero.ch/api/gnd/103824997X"
       }
     ],
     "responsibilityStatement": [
@@ -109922,7 +109922,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14168019"
+        "$ref": "https://mef.rero.ch/api/idref/028804430"
       }
     ]
   },
@@ -110031,11 +110031,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17457792"
+        "$ref": "https://mef.rero.ch/api/idref/074755978"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9165323"
+        "$ref": "https://mef.rero.ch/api/rero/A003683610"
       }
     ],
     "titlesProper": [
@@ -110142,15 +110142,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13928698"
+        "$ref": "https://mef.rero.ch/api/rero/A003036266"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13107435"
+        "$ref": "https://mef.rero.ch/api/gnd/115356630"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10254130"
+        "$ref": "https://mef.rero.ch/api/gnd/129208922"
       }
     ],
     "responsibilityStatement": [
@@ -110266,7 +110266,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3591678"
+        "$ref": "https://mef.rero.ch/api/rero/A003916863"
       }
     ],
     "responsibilityStatement": [
@@ -110372,11 +110372,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2939005"
+        "$ref": "https://mef.rero.ch/api/idref/140043349"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/855130"
+        "$ref": "https://mef.rero.ch/api/gnd/108947735X"
       }
     ],
     "responsibilityStatement": [
@@ -110476,19 +110476,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27287548"
+        "$ref": "https://mef.rero.ch/api/idref/182383288"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21379574"
+        "$ref": "https://mef.rero.ch/api/idref/193293838"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5399318"
+        "$ref": "https://mef.rero.ch/api/idref/028804686"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32732073"
+        "$ref": "https://mef.rero.ch/api/idref/182433684"
       }
     ],
     "responsibilityStatement": [
@@ -110595,7 +110595,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14303478"
+        "$ref": "https://mef.rero.ch/api/idref/074347802"
       }
     ],
     "title": [
@@ -110656,15 +110656,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15577856"
+        "$ref": "https://mef.rero.ch/api/idref/026812924"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10907118"
+        "$ref": "https://mef.rero.ch/api/idref/029314100"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1944241"
+        "$ref": "https://mef.rero.ch/api/idref/182639096"
       }
     ],
     "responsibilityStatement": [
@@ -110779,11 +110779,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11731076"
+        "$ref": "https://mef.rero.ch/api/idref/069217815"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11680046"
+        "$ref": "https://mef.rero.ch/api/rero/A003851306"
       }
     ],
     "responsibilityStatement": [
@@ -110883,7 +110883,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26845028"
+        "$ref": "https://mef.rero.ch/api/idref/077083210"
       }
     ],
     "responsibilityStatement": [
@@ -111005,11 +111005,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20155421"
+        "$ref": "https://mef.rero.ch/api/idref/03103490X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16538830"
+        "$ref": "https://mef.rero.ch/api/idref/118561774"
       }
     ],
     "responsibilityStatement": [
@@ -111450,11 +111450,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23429117"
+        "$ref": "https://mef.rero.ch/api/rero/A003925829"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12704632"
+        "$ref": "https://mef.rero.ch/api/idref/135988489"
       },
       {
         "type": "organisation",
@@ -111485,7 +111485,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11845815"
+        "$ref": "https://mef.rero.ch/api/rero/A019068593"
       }
     ],
     "responsibilityStatement": [
@@ -111673,7 +111673,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12200087"
+        "$ref": "https://mef.rero.ch/api/idref/026806347"
       }
     ],
     "responsibilityStatement": [
@@ -111773,11 +111773,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3691857"
+        "$ref": "https://mef.rero.ch/api/gnd/136608906"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6545581"
+        "$ref": "https://mef.rero.ch/api/idref/057566860"
       }
     ],
     "responsibilityStatement": [
@@ -111873,7 +111873,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28937683"
+        "$ref": "https://mef.rero.ch/api/idref/028288548"
       }
     ],
     "responsibilityStatement": [
@@ -111958,11 +111958,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11972582"
+        "$ref": "https://mef.rero.ch/api/idref/03029486X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29639312"
+        "$ref": "https://mef.rero.ch/api/idref/031680372"
       }
     ],
     "responsibilityStatement": [
@@ -112142,7 +112142,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/242271"
+        "$ref": "https://mef.rero.ch/api/rero/A011546573"
       }
     ],
     "responsibilityStatement": [
@@ -112290,7 +112290,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7806334"
+        "$ref": "https://mef.rero.ch/api/idref/029768748"
       }
     ]
   },
@@ -112322,7 +112322,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12282760"
+        "$ref": "https://mef.rero.ch/api/idref/057366160"
       }
     ],
     "responsibilityStatement": [
@@ -112432,7 +112432,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13929743"
+        "$ref": "https://mef.rero.ch/api/idref/150155883"
       }
     ],
     "responsibilityStatement": [
@@ -112558,7 +112558,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3598709"
+        "$ref": "https://mef.rero.ch/api/idref/078068339"
       }
     ],
     "responsibilityStatement": [
@@ -112653,7 +112653,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19440068"
+        "$ref": "https://mef.rero.ch/api/rero/A017202058"
       }
     ],
     "responsibilityStatement": [
@@ -112757,11 +112757,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10649423"
+        "$ref": "https://mef.rero.ch/api/idref/050645870"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/587950"
+        "$ref": "https://mef.rero.ch/api/idref/085264938"
       }
     ],
     "responsibilityStatement": [
@@ -112866,11 +112866,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4904941"
+        "$ref": "https://mef.rero.ch/api/idref/05056059X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28795640"
+        "$ref": "https://mef.rero.ch/api/idref/05259680X"
       }
     ],
     "responsibilityStatement": [
@@ -113142,7 +113142,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5800211"
+        "$ref": "https://mef.rero.ch/api/idref/030267021"
       }
     ]
   },
@@ -113165,7 +113165,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1712213"
+        "$ref": "https://mef.rero.ch/api/rero/A011534742"
       }
     ],
     "responsibilityStatement": [
@@ -113232,7 +113232,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4086073"
+        "$ref": "https://mef.rero.ch/api/gnd/1196216878"
       }
     ],
     "responsibilityStatement": [
@@ -113444,7 +113444,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30213843"
+        "$ref": "https://mef.rero.ch/api/idref/031301134"
       }
     ],
     "responsibilityStatement": [
@@ -113543,11 +113543,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9374508"
+        "$ref": "https://mef.rero.ch/api/idref/031134386"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14039014"
+        "$ref": "https://mef.rero.ch/api/idref/031216463"
       }
     ],
     "responsibilityStatement": [
@@ -113833,7 +113833,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/811971"
+        "$ref": "https://mef.rero.ch/api/idref/057530130"
       },
       {
         "type": "organisation",
@@ -113937,11 +113937,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4451595"
+        "$ref": "https://mef.rero.ch/api/gnd/1082525111"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16467364"
+        "$ref": "https://mef.rero.ch/api/idref/02684060X"
       }
     ],
     "responsibilityStatement": [
@@ -114041,7 +114041,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3427898"
+        "$ref": "https://mef.rero.ch/api/idref/057796424"
       }
     ],
     "responsibilityStatement": [
@@ -114148,7 +114148,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13847592"
+        "$ref": "https://mef.rero.ch/api/idref/06930453X"
       }
     ],
     "responsibilityStatement": [
@@ -114318,11 +114318,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21967618"
+        "$ref": "https://mef.rero.ch/api/idref/026951738"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10638973"
+        "$ref": "https://mef.rero.ch/api/idref/131458507"
       }
     ]
   },
@@ -114349,7 +114349,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27700727"
+        "$ref": "https://mef.rero.ch/api/idref/126236321"
       }
     ],
     "responsibilityStatement": [
@@ -114488,7 +114488,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11538436"
+        "$ref": "https://mef.rero.ch/api/idref/029116023"
       }
     ],
     "responsibilityStatement": [
@@ -114712,7 +114712,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17710964"
+        "$ref": "https://mef.rero.ch/api/idref/034072306"
       }
     ],
     "responsibilityStatement": [
@@ -114795,7 +114795,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15187877"
+        "$ref": "https://mef.rero.ch/api/idref/083943048"
       }
     ],
     "responsibilityStatement": [
@@ -114893,7 +114893,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12291401"
+        "$ref": "https://mef.rero.ch/api/gnd/118763539"
       }
     ],
     "responsibilityStatement": [
@@ -114990,7 +114990,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30289806"
+        "$ref": "https://mef.rero.ch/api/rero/A018886916"
       }
     ],
     "responsibilityStatement": [
@@ -115275,7 +115275,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10068367"
+        "$ref": "https://mef.rero.ch/api/idref/122905385"
       }
     ]
   },
@@ -115312,7 +115312,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20392687"
+        "$ref": "https://mef.rero.ch/api/idref/056827938"
       }
     ],
     "responsibilityStatement": [
@@ -115443,7 +115443,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8590340"
+        "$ref": "https://mef.rero.ch/api/idref/028939794"
       }
     ],
     "responsibilityStatement": [
@@ -115623,7 +115623,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32631734"
+        "$ref": "https://mef.rero.ch/api/idref/140222820"
       }
     ]
   },
@@ -115650,7 +115650,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19475801"
+        "$ref": "https://mef.rero.ch/api/idref/109257359"
       }
     ],
     "responsibilityStatement": [
@@ -115843,7 +115843,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3364227"
+        "$ref": "https://mef.rero.ch/api/idref/120576600"
       }
     ]
   },
@@ -115866,7 +115866,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31230431"
+        "$ref": "https://mef.rero.ch/api/idref/060824069"
       }
     ],
     "responsibilityStatement": [
@@ -115963,7 +115963,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6678109"
+        "$ref": "https://mef.rero.ch/api/idref/027067661"
       }
     ],
     "responsibilityStatement": [
@@ -116026,7 +116026,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15372423"
+        "$ref": "https://mef.rero.ch/api/rero/A011526653"
       }
     ],
     "responsibilityStatement": [
@@ -116089,7 +116089,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2489058"
+        "$ref": "https://mef.rero.ch/api/idref/072752580"
       }
     ],
     "responsibilityStatement": [
@@ -116166,7 +116166,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24334272"
+        "$ref": "https://mef.rero.ch/api/idref/026892286"
       }
     ],
     "responsibilityStatement": [
@@ -116253,15 +116253,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/388371"
+        "$ref": "https://mef.rero.ch/api/idref/130598771"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8108939"
+        "$ref": "https://mef.rero.ch/api/idref/027023931"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21852255"
+        "$ref": "https://mef.rero.ch/api/idref/030949084"
       }
     ],
     "responsibilityStatement": [
@@ -116356,11 +116356,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6728220"
+        "$ref": "https://mef.rero.ch/api/idref/085598046"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7665730"
+        "$ref": "https://mef.rero.ch/api/idref/169804887"
       }
     ],
     "responsibilityStatement": [
@@ -116820,7 +116820,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3171822"
+        "$ref": "https://mef.rero.ch/api/gnd/135690226"
       }
     ]
   },
@@ -116843,7 +116843,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14994299"
+        "$ref": "https://mef.rero.ch/api/gnd/103218947"
       }
     ],
     "responsibilityStatement": [
@@ -116915,7 +116915,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32498486"
+        "$ref": "https://mef.rero.ch/api/rero/A027242837"
       }
     ],
     "responsibilityStatement": [
@@ -117072,11 +117072,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8182422"
+        "$ref": "https://mef.rero.ch/api/idref/030599296"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9590402"
+        "$ref": "https://mef.rero.ch/api/rero/A003532579"
       }
     ]
   },
@@ -117099,7 +117099,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21406140"
+        "$ref": "https://mef.rero.ch/api/rero/A003675622"
       }
     ],
     "responsibilityStatement": [
@@ -117171,7 +117171,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20808644"
+        "$ref": "https://mef.rero.ch/api/rero/A018889759"
       }
     ],
     "responsibilityStatement": [
@@ -117500,7 +117500,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29174298"
+        "$ref": "https://mef.rero.ch/api/idref/082018855"
       }
     ],
     "responsibilityStatement": [
@@ -117591,7 +117591,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4273345"
+        "$ref": "https://mef.rero.ch/api/idref/147509939"
       }
     ],
     "responsibilityStatement": [
@@ -117755,7 +117755,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17198704"
+        "$ref": "https://mef.rero.ch/api/idref/08794359X"
       }
     ]
   },
@@ -117998,7 +117998,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16841776"
+        "$ref": "https://mef.rero.ch/api/idref/074626965"
       }
     ],
     "responsibilityStatement": [
@@ -118194,11 +118194,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11951299"
+        "$ref": "https://mef.rero.ch/api/idref/028315111"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9659949"
+        "$ref": "https://mef.rero.ch/api/idref/026852209"
       }
     ],
     "responsibilityStatement": [
@@ -118288,11 +118288,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7280990"
+        "$ref": "https://mef.rero.ch/api/rero/A003744601"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24058816"
+        "$ref": "https://mef.rero.ch/api/idref/030306353"
       }
     ],
     "responsibilityStatement": [
@@ -118384,7 +118384,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17484009"
+        "$ref": "https://mef.rero.ch/api/idref/033963584"
       }
     ],
     "responsibilityStatement": [
@@ -118479,7 +118479,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/817132"
+        "$ref": "https://mef.rero.ch/api/rero/A011575917"
       }
     ],
     "responsibilityStatement": [
@@ -118542,7 +118542,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25043129"
+        "$ref": "https://mef.rero.ch/api/rero/A003579776"
       }
     ],
     "responsibilityStatement": [

--- a/data/documents_small.json
+++ b/data/documents_small.json
@@ -23,7 +23,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30500459"
+        "$ref": "https://mef.rero.ch/api/idref/078047285"
       }
     ],
     "responsibilityStatement": [
@@ -105,7 +105,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10604455"
+        "$ref": "https://mef.rero.ch/api/idref/113867638"
       }
     ],
     "responsibilityStatement": [
@@ -198,7 +198,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25742875"
+        "$ref": "https://mef.rero.ch/api/idref/035713801"
       }
     ],
     "responsibilityStatement": [
@@ -290,15 +290,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/631548"
+        "$ref": "https://mef.rero.ch/api/idref/10924785X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20130329"
+        "$ref": "https://mef.rero.ch/api/idref/185544207"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17110543"
+        "$ref": "https://mef.rero.ch/api/idref/185544266"
       }
     ],
     "responsibilityStatement": [
@@ -409,7 +409,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25167053"
+        "$ref": "https://mef.rero.ch/api/rero/A025550294"
       }
     ],
     "responsibilityStatement": [
@@ -527,15 +527,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15577856"
+        "$ref": "https://mef.rero.ch/api/idref/026812924"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10907118"
+        "$ref": "https://mef.rero.ch/api/idref/029314100"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1944241"
+        "$ref": "https://mef.rero.ch/api/idref/182639096"
       }
     ],
     "responsibilityStatement": [
@@ -822,7 +822,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8673342"
+        "$ref": "https://mef.rero.ch/api/idref/085939323"
       }
     ],
     "responsibilityStatement": [
@@ -926,15 +926,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9135703"
+        "$ref": "https://mef.rero.ch/api/idref/070192979"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30682398"
+        "$ref": "https://mef.rero.ch/api/idref/05737841X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4686906"
+        "$ref": "https://mef.rero.ch/api/idref/052496767"
       }
     ],
     "responsibilityStatement": [
@@ -1033,7 +1033,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1465091"
+        "$ref": "https://mef.rero.ch/api/idref/185099092"
       }
     ],
     "responsibilityStatement": [
@@ -1198,11 +1198,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17457792"
+        "$ref": "https://mef.rero.ch/api/idref/074755978"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9165323"
+        "$ref": "https://mef.rero.ch/api/rero/A003683610"
       }
     ],
     "titlesProper": [
@@ -1308,7 +1308,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6720083"
+        "$ref": "https://mef.rero.ch/api/idref/027009211"
       }
     ],
     "responsibilityStatement": [
@@ -1492,11 +1492,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13111780"
+        "$ref": "https://mef.rero.ch/api/idref/084291419"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24434886"
+        "$ref": "https://mef.rero.ch/api/idref/027771202"
       },
       {
         "type": "organisation",
@@ -1527,7 +1527,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26845028"
+        "$ref": "https://mef.rero.ch/api/idref/077083210"
       }
     ],
     "responsibilityStatement": [
@@ -1649,11 +1649,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1221761"
+        "$ref": "https://mef.rero.ch/api/idref/079448860"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25490541"
+        "$ref": "https://mef.rero.ch/api/idref/080269699"
       }
     ],
     "responsibilityStatement": [
@@ -1749,7 +1749,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14251320"
+        "$ref": "https://mef.rero.ch/api/idref/148093507"
       }
     ],
     "responsibilityStatement": [
@@ -1817,7 +1817,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29901633"
+        "$ref": "https://mef.rero.ch/api/rero/A018871003"
       }
     ],
     "responsibilityStatement": [
@@ -1970,7 +1970,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5120588"
+        "$ref": "https://mef.rero.ch/api/gnd/1061410447"
       }
     ],
     "responsibilityStatement": [
@@ -2164,11 +2164,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18619193"
+        "$ref": "https://mef.rero.ch/api/idref/077491033"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29440941"
+        "$ref": "https://mef.rero.ch/api/gnd/140859608"
       }
     ]
   },
@@ -2191,7 +2191,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6890001"
+        "$ref": "https://mef.rero.ch/api/rero/A017188049"
       }
     ],
     "title": [
@@ -2367,7 +2367,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7576847"
+        "$ref": "https://mef.rero.ch/api/gnd/121098664"
       }
     ],
     "responsibilityStatement": [
@@ -2527,7 +2527,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26838446"
+        "$ref": "https://mef.rero.ch/api/gnd/132240289"
       }
     ]
   },
@@ -2766,11 +2766,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30538695"
+        "$ref": "https://mef.rero.ch/api/idref/227824490"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20342800"
+        "$ref": "https://mef.rero.ch/api/idref/229507255"
       }
     ],
     "responsibilityStatement": [
@@ -2873,7 +2873,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29400815"
+        "$ref": "https://mef.rero.ch/api/idref/18609809X"
       }
     ],
     "responsibilityStatement": [
@@ -2979,7 +2979,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9329449"
+        "$ref": "https://mef.rero.ch/api/rero/A006010680"
       }
     ],
     "responsibilityStatement": [
@@ -3077,7 +3077,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10590390"
+        "$ref": "https://mef.rero.ch/api/idref/086136151"
       }
     ],
     "responsibilityStatement": [
@@ -3179,7 +3179,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21602490"
+        "$ref": "https://mef.rero.ch/api/idref/10094244X"
       }
     ],
     "responsibilityStatement": [
@@ -3272,11 +3272,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32293779"
+        "$ref": "https://mef.rero.ch/api/idref/182635112"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3803097"
+        "$ref": "https://mef.rero.ch/api/gnd/1068191279"
       }
     ],
     "responsibilityStatement": [
@@ -3371,7 +3371,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14469120"
+        "$ref": "https://mef.rero.ch/api/rero/A000195745"
       }
     ],
     "title": [
@@ -3482,7 +3482,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12119853"
+        "$ref": "https://mef.rero.ch/api/gnd/133458466"
       }
     ],
     "responsibilityStatement": [
@@ -3692,7 +3692,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3024523"
+        "$ref": "https://mef.rero.ch/api/rero/A005972232"
       }
     ]
   },
@@ -3719,15 +3719,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16216227"
+        "$ref": "https://mef.rero.ch/api/gnd/118178997"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27185485"
+        "$ref": "https://mef.rero.ch/api/idref/137071809"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10777115"
+        "$ref": "https://mef.rero.ch/api/idref/088958272"
       }
     ],
     "responsibilityStatement": [
@@ -3842,11 +3842,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3107542"
+        "$ref": "https://mef.rero.ch/api/idref/027021882"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24631763"
+        "$ref": "https://mef.rero.ch/api/idref/061134910"
       },
       {
         "type": "organisation",
@@ -4076,11 +4076,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20035619"
+        "$ref": "https://mef.rero.ch/api/gnd/112060234"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28759548"
+        "$ref": "https://mef.rero.ch/api/gnd/1061808637"
       }
     ],
     "responsibilityStatement": [
@@ -4389,7 +4389,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28000744"
+        "$ref": "https://mef.rero.ch/api/rero/A003361480"
       }
     ],
     "responsibilityStatement": [
@@ -4638,11 +4638,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6626266"
+        "$ref": "https://mef.rero.ch/api/gnd/13291624X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5473631"
+        "$ref": "https://mef.rero.ch/api/gnd/1139053418"
       }
     ],
     "responsibilityStatement": [
@@ -4915,7 +4915,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13701268"
+        "$ref": "https://mef.rero.ch/api/rero/A003138002"
       }
     ]
   },
@@ -4947,11 +4947,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31371883"
+        "$ref": "https://mef.rero.ch/api/idref/095969314"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15397284"
+        "$ref": "https://mef.rero.ch/api/idref/095969357"
       }
     ],
     "responsibilityStatement": [
@@ -5066,7 +5066,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30074520"
+        "$ref": "https://mef.rero.ch/api/rero/A011766479"
       }
     ],
     "responsibilityStatement": [
@@ -5176,11 +5176,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/200104"
+        "$ref": "https://mef.rero.ch/api/rero/A000015097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3836257"
+        "$ref": "https://mef.rero.ch/api/idref/066924502"
       }
     ],
     "responsibilityStatement": [
@@ -5496,11 +5496,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28934039"
+        "$ref": "https://mef.rero.ch/api/idref/026745151"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18766062"
+        "$ref": "https://mef.rero.ch/api/idref/034460608"
       }
     ],
     "responsibilityStatement": [
@@ -5698,11 +5698,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8353347"
+        "$ref": "https://mef.rero.ch/api/idref/026847760"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13562266"
+        "$ref": "https://mef.rero.ch/api/idref/032533349"
       }
     ]
   },
@@ -5780,7 +5780,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14168019"
+        "$ref": "https://mef.rero.ch/api/idref/028804430"
       }
     ]
   },
@@ -5803,7 +5803,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23028141"
+        "$ref": "https://mef.rero.ch/api/idref/124411177"
       }
     ],
     "responsibilityStatement": [
@@ -5940,11 +5940,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29764724"
+        "$ref": "https://mef.rero.ch/api/idref/030260868"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18802674"
+        "$ref": "https://mef.rero.ch/api/idref/078617960"
       },
       {
         "type": "organisation",
@@ -6139,7 +6139,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3873270"
+        "$ref": "https://mef.rero.ch/api/idref/087110350"
       }
     ],
     "responsibilityStatement": [
@@ -6222,7 +6222,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32619267"
+        "$ref": "https://mef.rero.ch/api/idref/082279942"
       }
     ],
     "responsibilityStatement": [
@@ -6484,7 +6484,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23805367"
+        "$ref": "https://mef.rero.ch/api/idref/03346894X"
       }
     ],
     "responsibilityStatement": [
@@ -6677,27 +6677,27 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6148908"
+        "$ref": "https://mef.rero.ch/api/idref/030690609"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5060367"
+        "$ref": "https://mef.rero.ch/api/idref/064815846"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1542120"
+        "$ref": "https://mef.rero.ch/api/idref/032316992"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20110162"
+        "$ref": "https://mef.rero.ch/api/idref/030835801"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12526643"
+        "$ref": "https://mef.rero.ch/api/idref/064816125"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10730881"
+        "$ref": "https://mef.rero.ch/api/idref/145599671"
       }
     ],
     "title": [
@@ -6789,7 +6789,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13197904"
+        "$ref": "https://mef.rero.ch/api/idref/035707119"
       }
     ],
     "responsibilityStatement": [
@@ -6977,7 +6977,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4850824"
+        "$ref": "https://mef.rero.ch/api/idref/027066185"
       }
     ],
     "responsibilityStatement": [
@@ -7073,7 +7073,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12028740"
+        "$ref": "https://mef.rero.ch/api/idref/029093147"
       }
     ],
     "responsibilityStatement": [
@@ -7165,11 +7165,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24636784"
+        "$ref": "https://mef.rero.ch/api/idref/073311855"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5485677"
+        "$ref": "https://mef.rero.ch/api/idref/031601375"
       }
     ],
     "responsibilityStatement": [
@@ -7317,11 +7317,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8182422"
+        "$ref": "https://mef.rero.ch/api/idref/030599296"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9590402"
+        "$ref": "https://mef.rero.ch/api/rero/A003532579"
       }
     ]
   },
@@ -7348,7 +7348,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21387979"
+        "$ref": "https://mef.rero.ch/api/gnd/115638989"
       }
     ],
     "responsibilityStatement": [
@@ -7568,7 +7568,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26062885"
+        "$ref": "https://mef.rero.ch/api/gnd/126515786"
       }
     ],
     "responsibilityStatement": [
@@ -7732,11 +7732,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24247228"
+        "$ref": "https://mef.rero.ch/api/idref/030031966"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25050160"
+        "$ref": "https://mef.rero.ch/api/idref/03003194X"
       }
     ]
   },
@@ -7763,11 +7763,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26835132"
+        "$ref": "https://mef.rero.ch/api/idref/02714769X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14959294"
+        "$ref": "https://mef.rero.ch/api/idref/056965737"
       }
     ],
     "responsibilityStatement": [
@@ -7969,11 +7969,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13268138"
+        "$ref": "https://mef.rero.ch/api/idref/02827850X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14100346"
+        "$ref": "https://mef.rero.ch/api/idref/029743508"
       }
     ],
     "responsibilityStatement": [
@@ -8156,7 +8156,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27815869"
+        "$ref": "https://mef.rero.ch/api/gnd/143183907"
       }
     ],
     "responsibilityStatement": [
@@ -8270,11 +8270,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30507342"
+        "$ref": "https://mef.rero.ch/api/idref/027076164"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17197823"
+        "$ref": "https://mef.rero.ch/api/idref/026753618"
       }
     ],
     "responsibilityStatement": [
@@ -8574,11 +8574,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29110121"
+        "$ref": "https://mef.rero.ch/api/idref/026662019"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23697096"
+        "$ref": "https://mef.rero.ch/api/idref/02873789X"
       }
     ],
     "responsibilityStatement": [
@@ -8702,7 +8702,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32255415"
+        "$ref": "https://mef.rero.ch/api/idref/074180304"
       }
     ],
     "responsibilityStatement": [
@@ -8811,15 +8811,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/200104"
+        "$ref": "https://mef.rero.ch/api/rero/A000015097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9984525"
+        "$ref": "https://mef.rero.ch/api/idref/083581049"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11716737"
+        "$ref": "https://mef.rero.ch/api/idref/076443930"
       }
     ],
     "responsibilityStatement": [
@@ -8918,11 +8918,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27828448"
+        "$ref": "https://mef.rero.ch/api/rero/A003058658"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28840960"
+        "$ref": "https://mef.rero.ch/api/idref/073740896"
       }
     ],
     "responsibilityStatement": [
@@ -9023,11 +9023,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31077167"
+        "$ref": "https://mef.rero.ch/api/rero/A003490634"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/480691"
+        "$ref": "https://mef.rero.ch/api/idref/078122538"
       }
     ],
     "responsibilityStatement": [
@@ -9248,7 +9248,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17870213"
+        "$ref": "https://mef.rero.ch/api/gnd/136116698"
       }
     ],
     "responsibilityStatement": [
@@ -9371,11 +9371,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31761136"
+        "$ref": "https://mef.rero.ch/api/idref/034708138"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12285074"
+        "$ref": "https://mef.rero.ch/api/idref/144600749"
       }
     ],
     "responsibilityStatement": [
@@ -9491,7 +9491,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3591678"
+        "$ref": "https://mef.rero.ch/api/rero/A003916863"
       }
     ],
     "responsibilityStatement": [
@@ -9588,7 +9588,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19440068"
+        "$ref": "https://mef.rero.ch/api/rero/A017202058"
       }
     ],
     "responsibilityStatement": [
@@ -9867,11 +9867,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22864010"
+        "$ref": "https://mef.rero.ch/api/idref/050805916"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26769359"
+        "$ref": "https://mef.rero.ch/api/rero/A006052444"
       }
     ]
   },
@@ -9894,7 +9894,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6234413"
+        "$ref": "https://mef.rero.ch/api/idref/028464249"
       }
     ],
     "responsibilityStatement": [
@@ -10005,7 +10005,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31555579"
+        "$ref": "https://mef.rero.ch/api/rero/A014161336"
       }
     ],
     "responsibilityStatement": [
@@ -10110,7 +10110,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2325279"
+        "$ref": "https://mef.rero.ch/api/idref/034667180"
       }
     ],
     "responsibilityStatement": [
@@ -10305,11 +10305,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14915021"
+        "$ref": "https://mef.rero.ch/api/idref/23529182X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29305296"
+        "$ref": "https://mef.rero.ch/api/idref/235279471"
       }
     ],
     "responsibilityStatement": [
@@ -10405,7 +10405,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5307451"
+        "$ref": "https://mef.rero.ch/api/idref/028817257"
       }
     ],
     "responsibilityStatement": [
@@ -10506,7 +10506,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15444695"
+        "$ref": "https://mef.rero.ch/api/idref/131203460"
       }
     ],
     "responsibilityStatement": [
@@ -10659,19 +10659,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22422411"
+        "$ref": "https://mef.rero.ch/api/idref/026859297"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14832183"
+        "$ref": "https://mef.rero.ch/api/idref/137598041"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15920210"
+        "$ref": "https://mef.rero.ch/api/idref/026687860"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5414964"
+        "$ref": "https://mef.rero.ch/api/idref/032601786"
       },
       {
         "type": "organisation",
@@ -10876,19 +10876,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24668082"
+        "$ref": "https://mef.rero.ch/api/idref/186402163"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6133255"
+        "$ref": "https://mef.rero.ch/api/idref/186402376"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1902151"
+        "$ref": "https://mef.rero.ch/api/idref/186402627"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31294294"
+        "$ref": "https://mef.rero.ch/api/idref/18640266X"
       }
     ]
   },
@@ -10985,7 +10985,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18274678"
+        "$ref": "https://mef.rero.ch/api/idref/031679447"
       }
     ]
   },
@@ -11008,7 +11008,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19133348"
+        "$ref": "https://mef.rero.ch/api/gnd/170091317"
       }
     ],
     "responsibilityStatement": [
@@ -11106,7 +11106,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8585427"
+        "$ref": "https://mef.rero.ch/api/rero/A005913787"
       }
     ],
     "responsibilityStatement": [
@@ -11285,11 +11285,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5850347"
+        "$ref": "https://mef.rero.ch/api/idref/149657986"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7701656"
+        "$ref": "https://mef.rero.ch/api/idref/052477878"
       }
     ],
     "responsibilityStatement": [
@@ -11534,11 +11534,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5354433"
+        "$ref": "https://mef.rero.ch/api/idref/027120449"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9850282"
+        "$ref": "https://mef.rero.ch/api/rero/A003811654"
       }
     ],
     "responsibilityStatement": [
@@ -11713,7 +11713,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23102539"
+        "$ref": "https://mef.rero.ch/api/idref/074504878"
       }
     ],
     "responsibilityStatement": [
@@ -11893,11 +11893,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24265629"
+        "$ref": "https://mef.rero.ch/api/idref/02911344X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17075312"
+        "$ref": "https://mef.rero.ch/api/idref/028845870"
       },
       {
         "type": "organisation",
@@ -11924,11 +11924,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31230431"
+        "$ref": "https://mef.rero.ch/api/idref/060824069"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1233948"
+        "$ref": "https://mef.rero.ch/api/rero/A012506149"
       }
     ],
     "responsibilityStatement": [
@@ -12026,7 +12026,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9164371"
+        "$ref": "https://mef.rero.ch/api/idref/032014201"
       }
     ],
     "responsibilityStatement": [
@@ -12119,7 +12119,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26928987"
+        "$ref": "https://mef.rero.ch/api/idref/084565241"
       }
     ],
     "responsibilityStatement": [
@@ -12228,7 +12228,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17290163"
+        "$ref": "https://mef.rero.ch/api/idref/050305255"
       }
     ],
     "responsibilityStatement": [
@@ -12374,7 +12374,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11292135"
+        "$ref": "https://mef.rero.ch/api/rero/A009042477"
       }
     ]
   },
@@ -12397,7 +12397,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25959786"
+        "$ref": "https://mef.rero.ch/api/gnd/1064757464"
       }
     ],
     "responsibilityStatement": [
@@ -12465,7 +12465,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18441774"
+        "$ref": "https://mef.rero.ch/api/rero/A022902314"
       }
     ],
     "responsibilityStatement": [
@@ -12576,11 +12576,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7280863"
+        "$ref": "https://mef.rero.ch/api/idref/056746512"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21846081"
+        "$ref": "https://mef.rero.ch/api/idref/234848111"
       },
       {
         "type": "organisation",
@@ -12820,11 +12820,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10859065"
+        "$ref": "https://mef.rero.ch/api/idref/029383099"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12692543"
+        "$ref": "https://mef.rero.ch/api/idref/031201547"
       }
     ]
   },
@@ -12987,11 +12987,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23285959"
+        "$ref": "https://mef.rero.ch/api/idref/085817627"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11386775"
+        "$ref": "https://mef.rero.ch/api/idref/069761124"
       },
       {
         "type": "organisation",
@@ -13086,7 +13086,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/402894"
+        "$ref": "https://mef.rero.ch/api/idref/056792948"
       }
     ],
     "responsibilityStatement": [
@@ -13158,7 +13158,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1571410"
+        "$ref": "https://mef.rero.ch/api/idref/026932997"
       }
     ],
     "responsibilityStatement": [
@@ -13395,19 +13395,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9510951"
+        "$ref": "https://mef.rero.ch/api/idref/050345095"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23200839"
+        "$ref": "https://mef.rero.ch/api/idref/05765025X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29875011"
+        "$ref": "https://mef.rero.ch/api/idref/057223688"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9021159"
+        "$ref": "https://mef.rero.ch/api/idref/032768214"
       }
     ]
   },
@@ -13638,11 +13638,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3691857"
+        "$ref": "https://mef.rero.ch/api/gnd/136608906"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6545581"
+        "$ref": "https://mef.rero.ch/api/idref/057566860"
       }
     ],
     "responsibilityStatement": [
@@ -13744,7 +13744,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27823746"
+        "$ref": "https://mef.rero.ch/api/rero/A000134328"
       }
     ],
     "title": [
@@ -13847,11 +13847,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11786664"
+        "$ref": "https://mef.rero.ch/api/rero/A003714361"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14335112"
+        "$ref": "https://mef.rero.ch/api/idref/199829586"
       }
     ],
     "responsibilityStatement": [
@@ -14039,7 +14039,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9177045"
+        "$ref": "https://mef.rero.ch/api/idref/055677401"
       }
     ],
     "responsibilityStatement": [
@@ -14250,11 +14250,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7199900"
+        "$ref": "https://mef.rero.ch/api/gnd/1146234244"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8482624"
+        "$ref": "https://mef.rero.ch/api/rero/A013065996"
       }
     ]
   },
@@ -14378,19 +14378,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1571427"
+        "$ref": "https://mef.rero.ch/api/idref/027152596"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14635837"
+        "$ref": "https://mef.rero.ch/api/idref/033183139"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12663017"
+        "$ref": "https://mef.rero.ch/api/idref/026773252"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18613808"
+        "$ref": "https://mef.rero.ch/api/idref/032410182"
       }
     ],
     "responsibilityStatement": [
@@ -14522,7 +14522,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5905550"
+        "$ref": "https://mef.rero.ch/api/idref/027343685"
       }
     ],
     "responsibilityStatement": [
@@ -14614,7 +14614,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23399760"
+        "$ref": "https://mef.rero.ch/api/rero/A003418300"
       }
     ],
     "responsibilityStatement": [
@@ -14709,7 +14709,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27716367"
+        "$ref": "https://mef.rero.ch/api/idref/028339819"
       }
     ],
     "responsibilityStatement": [
@@ -14900,19 +14900,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26236179"
+        "$ref": "https://mef.rero.ch/api/idref/029240808"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2626228"
+        "$ref": "https://mef.rero.ch/api/idref/028802705"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3762453"
+        "$ref": "https://mef.rero.ch/api/idref/033095027"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11865122"
+        "$ref": "https://mef.rero.ch/api/idref/027212491"
       }
     ]
   },
@@ -15009,7 +15009,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24191804"
+        "$ref": "https://mef.rero.ch/api/gnd/127067620"
       }
     ]
   },
@@ -15042,19 +15042,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29764724"
+        "$ref": "https://mef.rero.ch/api/idref/030260868"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/309046"
+        "$ref": "https://mef.rero.ch/api/idref/172774004"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25478396"
+        "$ref": "https://mef.rero.ch/api/gnd/124095739"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11109101"
+        "$ref": "https://mef.rero.ch/api/gnd/1160612242"
       }
     ],
     "responsibilityStatement": [
@@ -15181,7 +15181,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18350613"
+        "$ref": "https://mef.rero.ch/api/gnd/119295873"
       }
     ],
     "responsibilityStatement": [
@@ -15280,7 +15280,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26573752"
+        "$ref": "https://mef.rero.ch/api/gnd/142191590"
       }
     ],
     "responsibilityStatement": [
@@ -15385,15 +15385,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14706445"
+        "$ref": "https://mef.rero.ch/api/idref/111661315"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2151255"
+        "$ref": "https://mef.rero.ch/api/idref/150083068"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8998390"
+        "$ref": "https://mef.rero.ch/api/idref/194090493"
       }
     ],
     "responsibilityStatement": [
@@ -15507,15 +15507,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10321672"
+        "$ref": "https://mef.rero.ch/api/idref/032444621"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25499567"
+        "$ref": "https://mef.rero.ch/api/idref/028028856"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/962192"
+        "$ref": "https://mef.rero.ch/api/idref/032583702"
       }
     ],
     "responsibilityStatement": [
@@ -15625,7 +15625,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21142279"
+        "$ref": "https://mef.rero.ch/api/rero/A025133458"
       }
     ],
     "responsibilityStatement": [
@@ -15723,7 +15723,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7192053"
+        "$ref": "https://mef.rero.ch/api/idref/198276958"
       }
     ],
     "responsibilityStatement": [
@@ -15844,7 +15844,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6350070"
+        "$ref": "https://mef.rero.ch/api/idref/033053413"
       }
     ],
     "responsibilityStatement": [
@@ -16062,7 +16062,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26713975"
+        "$ref": "https://mef.rero.ch/api/idref/050769561"
       }
     ],
     "responsibilityStatement": [
@@ -16157,7 +16157,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22673473"
+        "$ref": "https://mef.rero.ch/api/idref/027000346"
       }
     ],
     "responsibilityStatement": [
@@ -16248,7 +16248,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17703741"
+        "$ref": "https://mef.rero.ch/api/rero/A003084243"
       }
     ],
     "responsibilityStatement": [
@@ -16429,11 +16429,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23429117"
+        "$ref": "https://mef.rero.ch/api/rero/A003925829"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12704632"
+        "$ref": "https://mef.rero.ch/api/idref/135988489"
       },
       {
         "type": "organisation",
@@ -16469,7 +16469,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5471125"
+        "$ref": "https://mef.rero.ch/api/idref/080514294"
       }
     ],
     "responsibilityStatement": [
@@ -16560,11 +16560,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/4338546"
+        "$ref": "https://mef.rero.ch/api/idref/02665234X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20171404"
+        "$ref": "https://mef.rero.ch/api/idref/074540394"
       }
     ],
     "responsibilityStatement": [
@@ -16743,7 +16743,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12367183"
+        "$ref": "https://mef.rero.ch/api/gnd/172825229"
       }
     ]
   },
@@ -16770,7 +16770,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22202235"
+        "$ref": "https://mef.rero.ch/api/gnd/112610579"
       }
     ],
     "responsibilityStatement": [
@@ -16942,7 +16942,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21800490"
+        "$ref": "https://mef.rero.ch/api/idref/03176214X"
       }
     ],
     "responsibilityStatement": [
@@ -17039,11 +17039,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11227694"
+        "$ref": "https://mef.rero.ch/api/idref/028278992"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27041068"
+        "$ref": "https://mef.rero.ch/api/idref/050510479"
       }
     ],
     "responsibilityStatement": [
@@ -17259,11 +17259,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32322670"
+        "$ref": "https://mef.rero.ch/api/idref/02675441X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9920900"
+        "$ref": "https://mef.rero.ch/api/rero/A003042303"
       }
     ],
     "responsibilityStatement": [
@@ -17350,15 +17350,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18041858"
+        "$ref": "https://mef.rero.ch/api/idref/026870290"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24628597"
+        "$ref": "https://mef.rero.ch/api/idref/057487359"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20619664"
+        "$ref": "https://mef.rero.ch/api/gnd/108934578"
       }
     ],
     "responsibilityStatement": [
@@ -17471,7 +17471,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29174298"
+        "$ref": "https://mef.rero.ch/api/idref/082018855"
       }
     ],
     "responsibilityStatement": [
@@ -17570,11 +17570,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27718318"
+        "$ref": "https://mef.rero.ch/api/idref/033603901"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17284712"
+        "$ref": "https://mef.rero.ch/api/idref/033589194"
       }
     ],
     "responsibilityStatement": [
@@ -17765,7 +17765,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13937415"
+        "$ref": "https://mef.rero.ch/api/idref/070532753"
       }
     ],
     "responsibilityStatement": [
@@ -17857,11 +17857,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30412250"
+        "$ref": "https://mef.rero.ch/api/idref/028188012"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21721474"
+        "$ref": "https://mef.rero.ch/api/idref/094513627"
       }
     ],
     "responsibilityStatement": [
@@ -18007,7 +18007,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24062925"
+        "$ref": "https://mef.rero.ch/api/rero/A000180000"
       }
     ],
     "responsibilityStatement": [
@@ -18228,11 +18228,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/19633872"
+        "$ref": "https://mef.rero.ch/api/idref/134232240"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27099987"
+        "$ref": "https://mef.rero.ch/api/rero/A006071570"
       }
     ],
     "responsibilityStatement": [
@@ -18501,7 +18501,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12611742"
+        "$ref": "https://mef.rero.ch/api/idref/028431391"
       }
     ],
     "responsibilityStatement": [
@@ -18616,11 +18616,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27547259"
+        "$ref": "https://mef.rero.ch/api/idref/028592484"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29010527"
+        "$ref": "https://mef.rero.ch/api/idref/028275055"
       }
     ],
     "responsibilityStatement": [
@@ -18734,7 +18734,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17539757"
+        "$ref": "https://mef.rero.ch/api/idref/032450877"
       }
     ],
     "responsibilityStatement": [
@@ -18832,7 +18832,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13346674"
+        "$ref": "https://mef.rero.ch/api/rero/A011575301"
       }
     ],
     "responsibilityStatement": [
@@ -18904,7 +18904,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24493020"
+        "$ref": "https://mef.rero.ch/api/idref/086955748"
       }
     ],
     "responsibilityStatement": [
@@ -19005,7 +19005,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2393234"
+        "$ref": "https://mef.rero.ch/api/idref/234193093"
       }
     ],
     "responsibilityStatement": [
@@ -19127,7 +19127,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21761301"
+        "$ref": "https://mef.rero.ch/api/idref/028965892"
       }
     ],
     "responsibilityStatement": [
@@ -19295,11 +19295,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11313900"
+        "$ref": "https://mef.rero.ch/api/idref/026679108"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9689623"
+        "$ref": "https://mef.rero.ch/api/rero/A002926924"
       }
     ],
     "responsibilityStatement": [
@@ -19467,7 +19467,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26498598"
+        "$ref": "https://mef.rero.ch/api/idref/026725428"
       }
     ]
   },
@@ -19490,7 +19490,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15806874"
+        "$ref": "https://mef.rero.ch/api/gnd/106106384"
       }
     ],
     "responsibilityStatement": [
@@ -19577,27 +19577,27 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18512274"
+        "$ref": "https://mef.rero.ch/api/idref/028320549"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3118365"
+        "$ref": "https://mef.rero.ch/api/idref/079000169"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1292121"
+        "$ref": "https://mef.rero.ch/api/idref/07950535X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5984493"
+        "$ref": "https://mef.rero.ch/api/gnd/134882644"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/26407135"
+        "$ref": "https://mef.rero.ch/api/idref/060995254"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30898769"
+        "$ref": "https://mef.rero.ch/api/idref/079505341"
       },
       {
         "type": "organisation",
@@ -19701,11 +19701,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11972582"
+        "$ref": "https://mef.rero.ch/api/idref/03029486X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29639312"
+        "$ref": "https://mef.rero.ch/api/idref/031680372"
       }
     ],
     "responsibilityStatement": [
@@ -19805,11 +19805,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8943799"
+        "$ref": "https://mef.rero.ch/api/gnd/142191760"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6791017"
+        "$ref": "https://mef.rero.ch/api/gnd/13181477X"
       }
     ],
     "responsibilityStatement": [
@@ -19909,7 +19909,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/16473306"
+        "$ref": "https://mef.rero.ch/api/idref/035155051"
       }
     ],
     "responsibilityStatement": [
@@ -20079,7 +20079,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5606803"
+        "$ref": "https://mef.rero.ch/api/idref/03498867X"
       }
     ]
   },
@@ -20111,7 +20111,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1874070"
+        "$ref": "https://mef.rero.ch/api/idref/035573473"
       }
     ],
     "responsibilityStatement": [
@@ -20310,7 +20310,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1772825"
+        "$ref": "https://mef.rero.ch/api/idref/030688361"
       }
     ],
     "responsibilityStatement": [
@@ -20578,7 +20578,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20645024"
+        "$ref": "https://mef.rero.ch/api/idref/122152603"
       }
     ],
     "responsibilityStatement": [
@@ -20843,7 +20843,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13540681"
+        "$ref": "https://mef.rero.ch/api/gnd/113845081"
       }
     ]
   },
@@ -20953,15 +20953,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5822994"
+        "$ref": "https://mef.rero.ch/api/idref/07146073X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23197448"
+        "$ref": "https://mef.rero.ch/api/idref/085977268"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/7790609"
+        "$ref": "https://mef.rero.ch/api/idref/031604005"
       }
     ],
     "responsibilityStatement": [
@@ -21093,7 +21093,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12809924"
+        "$ref": "https://mef.rero.ch/api/gnd/123889324"
       }
     ],
     "responsibilityStatement": [
@@ -21199,7 +21199,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21898049"
+        "$ref": "https://mef.rero.ch/api/idref/08202412X"
       }
     ],
     "responsibilityStatement": [
@@ -21316,7 +21316,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24333358"
+        "$ref": "https://mef.rero.ch/api/idref/13370744X"
       }
     ],
     "responsibilityStatement": [
@@ -21512,7 +21512,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/22778702"
+        "$ref": "https://mef.rero.ch/api/idref/050421204"
       }
     ],
     "responsibilityStatement": [
@@ -21614,15 +21614,15 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31246254"
+        "$ref": "https://mef.rero.ch/api/rero/A006039544"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14336991"
+        "$ref": "https://mef.rero.ch/api/rero/A006039548"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3856475"
+        "$ref": "https://mef.rero.ch/api/rero/A006039549"
       }
     ],
     "responsibilityStatement": [
@@ -21727,11 +21727,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8312379"
+        "$ref": "https://mef.rero.ch/api/idref/03020027X"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11724433"
+        "$ref": "https://mef.rero.ch/api/idref/031386725"
       }
     ],
     "title": [
@@ -21853,7 +21853,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3971814"
+        "$ref": "https://mef.rero.ch/api/idref/028315545"
       }
     ],
     "responsibilityStatement": [
@@ -21979,11 +21979,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10915154"
+        "$ref": "https://mef.rero.ch/api/gnd/1103504657"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29170088"
+        "$ref": "https://mef.rero.ch/api/idref/030724392"
       }
     ],
     "responsibilityStatement": [
@@ -22123,7 +22123,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31328316"
+        "$ref": "https://mef.rero.ch/api/gnd/1068536632"
       }
     ],
     "responsibilityStatement": [
@@ -22230,7 +22230,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/735841"
+        "$ref": "https://mef.rero.ch/api/rero/A017007938"
       }
     ],
     "responsibilityStatement": [
@@ -22322,11 +22322,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30497397"
+        "$ref": "https://mef.rero.ch/api/idref/027128660"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31345702"
+        "$ref": "https://mef.rero.ch/api/idref/123595738"
       }
     ],
     "responsibilityStatement": [
@@ -22432,7 +22432,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31796389"
+        "$ref": "https://mef.rero.ch/api/rero/A016698997"
       }
     ],
     "responsibilityStatement": [
@@ -22533,7 +22533,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/58074"
+        "$ref": "https://mef.rero.ch/api/idref/050713760"
       }
     ],
     "responsibilityStatement": [
@@ -22629,7 +22629,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/27549470"
+        "$ref": "https://mef.rero.ch/api/idref/032132212"
       }
     ],
     "responsibilityStatement": [
@@ -22736,11 +22736,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8526211"
+        "$ref": "https://mef.rero.ch/api/idref/115098364"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5316522"
+        "$ref": "https://mef.rero.ch/api/idref/20183152X"
       }
     ],
     "responsibilityStatement": [
@@ -22828,11 +22828,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/17484009"
+        "$ref": "https://mef.rero.ch/api/idref/033963584"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6950722"
+        "$ref": "https://mef.rero.ch/api/idref/050835750"
       }
     ],
     "responsibilityStatement": [
@@ -23124,7 +23124,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11951550"
+        "$ref": "https://mef.rero.ch/api/idref/064814165"
       },
       {
         "type": "organisation",
@@ -23223,7 +23223,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3513635"
+        "$ref": "https://mef.rero.ch/api/idref/092363830"
       }
     ],
     "responsibilityStatement": [
@@ -23311,11 +23311,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/21967618"
+        "$ref": "https://mef.rero.ch/api/idref/026951738"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8212775"
+        "$ref": "https://mef.rero.ch/api/idref/035573139"
       }
     ],
     "responsibilityStatement": [
@@ -23412,7 +23412,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31977967"
+        "$ref": "https://mef.rero.ch/api/rero/A002963621"
       }
     ],
     "responsibilityStatement": [
@@ -23494,7 +23494,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3966999"
+        "$ref": "https://mef.rero.ch/api/gnd/1064704794"
       }
     ],
     "responsibilityStatement": [
@@ -23593,7 +23593,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1546069"
+        "$ref": "https://mef.rero.ch/api/idref/179898582"
       }
     ],
     "responsibilityStatement": [
@@ -23707,19 +23707,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28838600"
+        "$ref": "https://mef.rero.ch/api/idref/028266358"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29501059"
+        "$ref": "https://mef.rero.ch/api/idref/070427518"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25198022"
+        "$ref": "https://mef.rero.ch/api/idref/030261163"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/14794016"
+        "$ref": "https://mef.rero.ch/api/idref/061128163"
       }
     ],
     "responsibilityStatement": [
@@ -23943,11 +23943,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/13306768"
+        "$ref": "https://mef.rero.ch/api/gnd/122742850"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15283722"
+        "$ref": "https://mef.rero.ch/api/gnd/134341031"
       }
     ]
   },
@@ -23970,7 +23970,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/18365066"
+        "$ref": "https://mef.rero.ch/api/idref/111364388"
       }
     ],
     "responsibilityStatement": [
@@ -24078,11 +24078,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29252602"
+        "$ref": "https://mef.rero.ch/api/idref/158715241"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/10166642"
+        "$ref": "https://mef.rero.ch/api/idref/234931639"
       }
     ],
     "responsibilityStatement": [
@@ -24191,11 +24191,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3520733"
+        "$ref": "https://mef.rero.ch/api/idref/026817756"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/23537395"
+        "$ref": "https://mef.rero.ch/api/idref/02976615X"
       }
     ],
     "responsibilityStatement": [
@@ -24373,19 +24373,19 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/9615976"
+        "$ref": "https://mef.rero.ch/api/idref/028732235"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/5561505"
+        "$ref": "https://mef.rero.ch/api/idref/028767888"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/30941269"
+        "$ref": "https://mef.rero.ch/api/idref/055765610"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/473778"
+        "$ref": "https://mef.rero.ch/api/rero/A005913488"
       }
     ],
     "responsibilityStatement": [
@@ -24709,11 +24709,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15085825"
+        "$ref": "https://mef.rero.ch/api/idref/026727587"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/2376090"
+        "$ref": "https://mef.rero.ch/api/idref/027062260"
       }
     ],
     "responsibilityStatement": [
@@ -24807,7 +24807,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/24493810"
+        "$ref": "https://mef.rero.ch/api/idref/029404053"
       }
     ],
     "responsibilityStatement": [
@@ -24988,7 +24988,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/32631734"
+        "$ref": "https://mef.rero.ch/api/idref/140222820"
       }
     ]
   },
@@ -25109,7 +25109,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/28222766"
+        "$ref": "https://mef.rero.ch/api/idref/080001858"
       }
     ],
     "responsibilityStatement": [
@@ -25351,7 +25351,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/12191031"
+        "$ref": "https://mef.rero.ch/api/idref/152390774"
       }
     ],
     "titlesProper": [
@@ -25544,11 +25544,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25608518"
+        "$ref": "https://mef.rero.ch/api/idref/026803097"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/1545640"
+        "$ref": "https://mef.rero.ch/api/idref/059643307"
       }
     ]
   },
@@ -25652,7 +25652,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20424489"
+        "$ref": "https://mef.rero.ch/api/idref/033591067"
       },
       {
         "type": "organisation",
@@ -25762,11 +25762,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/29527355"
+        "$ref": "https://mef.rero.ch/api/idref/078197104"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/8298484"
+        "$ref": "https://mef.rero.ch/api/idref/174111819"
       }
     ]
   },
@@ -25881,7 +25881,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/11187822"
+        "$ref": "https://mef.rero.ch/api/idref/079963374"
       }
     ],
     "responsibilityStatement": [
@@ -26005,11 +26005,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/3679059"
+        "$ref": "https://mef.rero.ch/api/idref/027280896"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15800031"
+        "$ref": "https://mef.rero.ch/api/idref/026723417"
       }
     ],
     "responsibilityStatement": [
@@ -26134,7 +26134,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/15518978"
+        "$ref": "https://mef.rero.ch/api/gnd/129265047"
       }
     ],
     "responsibilityStatement": [
@@ -26291,7 +26291,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25248040"
+        "$ref": "https://mef.rero.ch/api/idref/10378747X"
       },
       {
         "type": "organisation",
@@ -26326,7 +26326,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/6706249"
+        "$ref": "https://mef.rero.ch/api/idref/071047557"
       }
     ],
     "responsibilityStatement": [
@@ -26446,11 +26446,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31804051"
+        "$ref": "https://mef.rero.ch/api/idref/151179786"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/31941775"
+        "$ref": "https://mef.rero.ch/api/gnd/12023615X"
       }
     ],
     "responsibilityStatement": [

--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
@@ -346,9 +346,9 @@
                 }
               },
               "$ref": {
-                "title": "MEF person reference",
+                "title": "person reference",
                 "type": "string",
-                "pattern": "^https://mef.rero.ch/api/mef/.*?$",
+                "pattern": "^https://mef.rero.ch/api/bnf|gnd|idref|rero/.*?$",
                 "form": {
                   "wrappers": [
                     "ref"

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -350,9 +350,9 @@
                 }
               },
               "$ref": {
-                "title": "MEF person reference",
+                "title": "person reference",
                 "type": "string",
-                "pattern": "^https://mef.rero.ch/api/mef/.*?$",
+                "pattern": "^https://mef.rero.ch/api/bnf|gnd|idref|rero/.*?$",
                 "form": {
                   "wrappers": [
                     "ref"

--- a/rero_ils/modules/documents/listener.py
+++ b/rero_ils/modules/documents/listener.py
@@ -79,10 +79,9 @@ def enrich_document_data(sender, json=None, record=None, index=None,
         # MEF person ES index update
         authors = []
         for author in json.get('authors', []):
-            pid = author.get('pid', None)
+            pid = author.get('pid')
             if pid:
-                # Check presence in DB
-                person = Person.get_record_by_mef_pid(pid)
+                person = Person.get_record_by_pid(pid)
                 if person:
                     author = person.dumps_for_document()
             authors.append(author)

--- a/rero_ils/modules/documents/serializers.py
+++ b/rero_ils/modules/documents/serializers.py
@@ -61,13 +61,14 @@ class DocumentJSONSerializer(JSONSerializer):
             rec['ui_title_variants'] = variant_titles
         if request and request.args.get('resolve') == '1':
             rec = record.replace_refs()
-            authors = rec.get('authors', [])
-            for idx, author in enumerate(authors):
-                pid_value = author.get('pid')
-                if pid_value:
-                    person = Person.get_record_by_mef_pid(pid_value)
+            authors = []
+            for author in rec.get('authors', []):
+                pers_pid = author.get('pid')
+                if pers_pid:
+                    person = Person.get_record_by_pid(pers_pid)
                     if person:
-                        authors[idx] = person.dumps_for_document()
+                        authors.append(person.dumps_for_document())
+            rec['authors'] = authors
         data = super(JSONSerializer, self).preprocess_record(
             pid=pid, record=rec, links_factory=links_factory, kwargs=kwargs)
 

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -309,7 +309,6 @@ class Notification(IlsRecord):
                 try:
                     pid = payload['pid']
                     notification = Notification.get_record_by_pid(pid)
-                    print('----process_notifications----:', notification)
                     Dispatcher().dispatch_notification(notification, verbose)
                     message.ack()
                     count['send'] += 1

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1247,7 +1247,7 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/pers1"
+        "$ref": "https://mef.rero.ch/api/rero/A017671081"
       }
     ],
     "title": [

--- a/tests/data/documents.json
+++ b/tests/data/documents.json
@@ -27,11 +27,11 @@
     "authors": [
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/20109313"
+        "$ref": "https://mef.rero.ch/api/idref/20109313"
       },
       {
         "type": "person",
-        "$ref": "https://mef.rero.ch/api/mef/25552024"
+        "$ref": "https://mef.rero.ch/api/gnd/25552024"
       }
     ],
     "title": "Le due tensioni : appunti per una ideologia della letteratura",

--- a/tests/fixtures/metadata.py
+++ b/tests/fixtures/metadata.py
@@ -177,8 +177,14 @@ def person_data_tmp(data):
 def person_response_data(person_data):
     """Load mef person response data."""
     json_data = {
-        'id': person_data['pid'],
-        'metadata': person_data
+        'hits': {
+            'hits': [
+                {
+                    'id': person_data['pid'],
+                    'metadata': person_data
+                }
+            ]
+        }
     }
     return json_data
 

--- a/tests/ui/documents/test_documents_mapping.py
+++ b/tests/ui/documents/test_documents_mapping.py
@@ -17,6 +17,8 @@
 
 """Document mapping tests."""
 
+from copy import deepcopy
+
 from elasticsearch_dsl.query import MultiMatch
 from utils import get_mapping
 
@@ -29,8 +31,9 @@ def test_document_es_mapping(es, db, org_martigny,
     search = DocumentsSearch()
     mapping = get_mapping(search.Meta.index)
     assert mapping
+    data = deepcopy(document_data_ref)
     Document.create(
-        document_data_ref,
+        data,
         dbcommit=True,
         reindex=True,
         delete_pid=True


### PR DESCRIPTION
* Links documents to the source authority file, such as GND or IdRef,
  through the MEF server, instead of the MEF clusterized record. This
  is needed to provide a stable link to the authority.

My PR depends on the following `rero-ils`'s PR(s):

* rero/rero-ils-ui#269

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
