### PR TITLE
translations: add translations API

### DIFF
--- a/rero_ils/modules/items/views.py
+++ b/rero_ils/modules/items/views.py
@@ -122,7 +122,7 @@ def patron_request(viewcode, item_pid=None, pickup_location_pid=None):
 
 @blueprint.app_template_filter()
 def item_availability_text(item):
-    """Returns text to disaply for item."""
+    """Returns text to display for item."""
     if item.available:
         return str(_(item.status))
     else:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ setup(
             'rero-ils = rero_ils.modules.ext:REROILSAPP'
         ],
         'invenio_base.api_apps': [
-            'rero-ils = rero_ils.modules.ext:REROILSAPP'
+            'rero-ils = rero_ils.modules.ext:REROILSAPP',
+            'invenio_i18n = invenio_i18n:InvenioI18N'
         ],
         'invenio_base.blueprints': [
             'rero_ils = rero_ils.views:blueprint',

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -183,7 +183,7 @@ def test_item_holding_document_availability(
     assert item_availablity_status(
         client, item_lib_martigny.pid, librarian_martigny_no_email.user)
     assert item_lib_martigny.available
-    assert item_availability_text(item_lib_martigny) == 'on_shelf'
+    assert item_availability_text(item_lib_martigny) == 'on shelf'
     assert holding_lib_martigny.available
     assert holding_availablity_status(
         client, holding_lib_martigny.pid, librarian_martigny_no_email.user)

--- a/tests/api/test_documents_rest.py
+++ b/tests/api/test_documents_rest.py
@@ -26,8 +26,7 @@ from utils import VerifyRecordPermissionPatch, get_json, postdata
 
 from rero_ils.modules.documents.utils import clean_text
 from rero_ils.modules.documents.views import can_request, \
-    item_library_pickup_locations, item_status_text, number_of_requests, \
-    patron_request_rank, requested_this_item
+    item_library_pickup_locations
 
 
 def test_documents_permissions(client, document, json_header):
@@ -326,16 +325,11 @@ def test_document_can_request_view(client, item_lib_fully,
     """Test can request on document view."""
     login_user_via_session(client, patron_martigny_no_email.user)
 
-    assert not patron_request_rank(item_lib_fully)
-
     with mock.patch(
         'rero_ils.modules.documents.views.current_user',
         patron_martigny_no_email.user
     ):
         assert can_request(item_lib_fully)
-        assert not requested_this_item(item_lib_fully)
-        assert number_of_requests(item_lib_fully) == 1
-        assert number_of_requests(item_lib_martigny) == 0
         assert not can_request(item_lib_sion)
 
     with mock.patch(
@@ -343,14 +337,6 @@ def test_document_can_request_view(client, item_lib_fully,
         patron2_martigny_no_email.user
     ):
         assert not can_request(item_lib_fully)
-        assert requested_this_item(item_lib_fully)
-        assert patron_request_rank(item_lib_fully)
-
-    status = item_status_text(item_lib_fully, format='medium', locale='en')
-    assert status == 'not available (requested)'
-
-    status = item_status_text(item_lib_martigny, format='medium', locale='en')
-    assert status == 'available'
 
     picks = item_library_pickup_locations(item_lib_fully)
     assert len(picks) == 3

--- a/tests/api/test_items_rest_views.py
+++ b/tests/api/test_items_rest_views.py
@@ -26,7 +26,6 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from utils import get_json, postdata
 
-from rero_ils.modules.documents.views import item_status_text
 from rero_ils.modules.errors import InvalidRecordID
 from rero_ils.modules.items.api import Item
 from rero_ils.modules.items.models import ItemStatus
@@ -248,9 +247,6 @@ def test_automatic_checkin(client, librarian_martigny_no_email, lib_martigny,
     item = Item.get_record_by_pid(item_lib_martigny.pid)
     assert item.status == ItemStatus.IN_TRANSIT
 
-    text = item_status_text(item, format='medium', locale='en')
-    assert text == 'not available (requested) (in_transit)'
-
     record, actions = item.automatic_checkin()
     assert 'receive' in actions
 
@@ -293,16 +289,6 @@ def test_item_different_actions(client, librarian_martigny_no_email,
     loan_pid = data.get('action_applied')[LoanAction.CHECKOUT].get('pid')
 
     record = Item.get_record_by_pid(item_lib_martigny.pid)
-
-    class current_i18n:
-        class locale:
-            language = 'en'
-    with mock.patch(
-        'rero_ils.modules.items.api.circulation.current_i18n',
-        current_i18n
-    ):
-        text = item_status_text(record, format='medium', locale='en')
-        assert 'due until' in text
 
     res, _ = postdata(
         client,

--- a/tests/api/test_translations.py
+++ b/tests/api/test_translations.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test translations API."""
+
+
+from flask import url_for
+from utils import get_json
+
+
+def test_translations(client, app):
+    """Test translations API."""
+    res = client.get(
+        url_for(
+            'api_blueprint.translations',
+            ln='doesnotexists'
+        )
+    )
+    assert res.status_code == 404
+
+    for ln in app.extensions.get('invenio-i18n').get_languages():
+        res = client.get(
+            url_for(
+                'api_blueprint.translations',
+                ln=ln[0]
+            )
+        )
+        assert res.status_code == 200
+        assert len(get_json(res)) > 0

--- a/tests/ui/documents/test_documents_filter.py
+++ b/tests/ui/documents/test_documents_filter.py
@@ -20,7 +20,7 @@
 
 from rero_ils.modules.documents.api import Document
 from rero_ils.modules.documents.views import authors_format, \
-    identifiedby_format, language_format, publishers_format, series_format
+    identifiedby_format, language_format, series_format
 
 
 def test_authors_format(db, document_data):
@@ -28,15 +28,6 @@ def test_authors_format(db, document_data):
     result = 'Vincent, Sophie'
     doc = Document.create(document_data, delete_pid=True)
     assert result == authors_format(doc.pid, 'en', 'global')
-
-
-def test_publishers_format():
-    """Test publishers format."""
-    result = 'Foo; place1; place2: Foo; Bar'
-    assert result == publishers_format([
-        {'name': ['Foo']},
-        {'place': ['place1', 'place2'], 'name': ['Foo', 'Bar']}
-    ])
 
 
 def test_series_format():


### PR DESCRIPTION
* Adds a new HTTP endpoint to expose the python po based translations
in JSON in order to use theses translations in single app application
instead of duplicates the translations in several projects.
* Fixes spelling in comment.
* Exposes `invenio-i18n` to the uwsgi API.
* Fixes tests with the `invenio-i18n` enabled for the API.
* Removes useless template filters and their tests.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Related to https://tree.taiga.io/project/rero21-reroils/task/1456?kanban-status=1224894

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui: https://github.com/rero/rero-ils-ui/pull/271

## How to test?

- Start the server and try: https://localhost:5000/api/translations/<ln>.json with <ln> is one of en, fr, de, it.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
