### PR TITLE
serials: receive an issue

### DIFF
--- a/data/patterns.json
+++ b/data/patterns.json
@@ -5,7 +5,7 @@
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "first_expected_date": "2020-03-01",
+      "next_expected_date": "2020-03-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -43,7 +43,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1013",
-      "first_expected_date": "2020-01-02",
+      "next_expected_date": "2020-01-02",
       "values": [
         {
           "name": "first_enumeration",
@@ -72,7 +72,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} Edition {{first_chronology.level_1}}",
       "frequency": "rdafr:1013",
-      "first_expected_date": "2020-06-01",
+      "next_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -101,7 +101,7 @@
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1014",
-      "first_expected_date": "2020-03-03",
+      "next_expected_date": "2020-03-03",
       "values": [
         {
           "name": "first_enumeration",
@@ -144,7 +144,7 @@
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} Heft {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "first_expected_date": "2020-09-01",
+      "next_expected_date": "2020-09-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -183,7 +183,7 @@
     "patterns": {
       "template": "ann\u00e9e {{first_chronology.level_1}} no {{first_enumeration.level_1}} {{second_chronology.level_2}} {{second_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "first_expected_date": "2020-03-20",
+      "next_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_chronology",
@@ -235,7 +235,7 @@
     "patterns": {
       "template": "N\u02da {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "first_expected_date": "2020-03-20",
+      "next_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_enumeration",
@@ -271,7 +271,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1007",
-      "first_expected_date": "2020-01-15",
+      "next_expected_date": "2020-01-15",
       "values": [
         {
           "name": "first_enumeration",
@@ -311,7 +311,7 @@
     "patterns": {
       "template": "Ann\u00e9e {{first_enumeration.level_1}} no {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "first_expected_date": "2020-06-01",
+      "next_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -360,7 +360,7 @@
     "patterns": {
       "template": "Jg {{first_enumeration.level_1}} Nr {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1007",
-      "first_expected_date": "2020-01-05",
+      "next_expected_date": "2020-01-05",
       "values": [
         {
           "name": "first_enumeration",

--- a/rero_ils/modules/ebooks/utils.py
+++ b/rero_ils/modules/ebooks/utils.py
@@ -23,7 +23,7 @@ from invenio_oaiharvester.models import OAIHarvestConfig
 
 from ..documents.api import Document
 from ..holdings.api import Holding, create_holding, \
-    get_standard_holding_pid_by_doc_location_item_type
+    get_holding_pid_by_doc_location_item_type
 from ..organisations.api import Organisation
 
 
@@ -128,7 +128,7 @@ def update_document_holding(record, pid):
             item_type_pid = org.online_circulation_category()
             locations = org.get_online_locations()
             for location_pid in locations:
-                if not get_standard_holding_pid_by_doc_location_item_type(
+                if not get_holding_pid_by_doc_location_item_type(
                     new_record.pid, location_pid, item_type_pid, 'electronic'
                 ):
                     create_holding(

--- a/rero_ils/modules/errors.py
+++ b/rero_ils/modules/errors.py
@@ -40,3 +40,7 @@ class MissingRequiredParameterError(RecordsError):
 
 class RecordValidationError(RecordsError):
     """Exception raised when record is not validated."""
+
+
+class RegularReceiveNotAllowed(Exception):
+    """Holdings of type serials and irregular frequency."""

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -133,7 +133,7 @@
       "propertiesOrder": [
         "template",
         "frequency",
-        "first_expected_date",
+        "next_expected_date",
         "values"
       ],
       "additionalProperties": false,
@@ -244,10 +244,10 @@
             ]
           }
         },
-        "first_expected_date": {
+        "next_expected_date": {
           "type": "string",
           "format": "date",
-          "title": "The expected date for the first issue",
+          "title": "The expected date for the next issue",
           "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
           "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
           "form": {

--- a/rero_ils/modules/holdings/mappings/v6/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/mappings/v6/holdings/holding-v0.0.1.json
@@ -76,7 +76,7 @@
             "frequency": {
               "type": "keyword"
             },
-            "first_expected_date": {
+            "next_expected_date": {
               "type": "date"
             },
             "values": {

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -57,7 +57,9 @@ class ItemsSearch(IlsRecordsSearch):
     @classmethod
     def flush(cls):
         """Flush indexes."""
+        from rero_ils.modules.holdings.api import HoldingsSearch
         current_search.flush_and_refresh(DocumentsSearch.Meta.index)
+        current_search.flush_and_refresh(HoldingsSearch.Meta.index)
         current_search.flush_and_refresh(cls.Meta.index)
 
 
@@ -118,7 +120,7 @@ class ItemsIndexer(IlsRecordsIndexer):
 
     def index(self, record):
         """Index an item."""
-        from ...holdings.api import Holding
+        from ...holdings.api import Holding, HoldingsSearch
         # get the old holding record if exists
         items = ItemsSearch().filter(
             'term', pid=record.get('pid')
@@ -134,6 +136,7 @@ class ItemsIndexer(IlsRecordsIndexer):
         document = Document.get_record_by_pid(document_pid)
         document.reindex()
         current_search.flush_and_refresh(DocumentsSearch.Meta.index)
+        current_search.flush_and_refresh(HoldingsSearch.Meta.index)
 
         # check if old holding can be deleted
         if holding_pid:

--- a/rero_ils/modules/items/api/issue.py
+++ b/rero_ils/modules/items/api/issue.py
@@ -22,4 +22,23 @@ from ...api import IlsRecord
 
 class ItemIssue(IlsRecord):
     """Item issue class."""
-    # TODO: the methods are added in the next PR.
+
+    @property
+    def expected_date(self):
+        """Shortcut for issue expected date."""
+        return self.get('issue', {}).get('expected_date')
+
+    @property
+    def received_date(self):
+        """Shortcut for issue received date."""
+        return self.get('issue', {}).get('received_date')
+
+    @property
+    def display_text(self):
+        """Shortcut for issue display_text."""
+        return self.get('issue', {}).get('display_text')
+
+    @property
+    def issue_status(self):
+        """Shortcut for issue status."""
+        return self.get('issue', {}).get('status')

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -139,7 +139,8 @@
           "default": "received",
           "enum": [
             "received",
-            "claimed"
+            "claimed",
+            "deleted"
           ]
         },
         "display_text": {

--- a/rero_ils/permissions.py
+++ b/rero_ils/permissions.py
@@ -335,3 +335,23 @@ def wiki_edit_ui_permission():
     :return: true if the logged user has the editor role
     """
     return editor_permission.can()
+
+
+def can_receive_regular_issue(holding):
+    """Checks if logged user can receive a regular issue of its organisation.
+
+    user must have librarian or system_librarian role.
+    returns False if a librarian tries to receive anissue of another library.
+    """
+    patron = staffer_is_authenticated()
+    if not patron:
+        return False
+    if patron.organisation_pid == holding.organisation_pid:
+        if patron.is_system_librarian:
+            return True
+        if patron.is_librarian:
+            if patron.library_pid and holding.library_pid and \
+                    holding.library_pid != patron.library_pid:
+                return False
+            return True
+    return False

--- a/tests/api/test_patterns.py
+++ b/tests/api/test_patterns.py
@@ -20,7 +20,9 @@
 
 from __future__ import absolute_import, print_function
 
-import jinja2
+from copy import deepcopy
+from datetime import datetime
+
 import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
@@ -30,215 +32,7 @@ from rero_ils.modules.documents.api import Document
 from rero_ils.modules.errors import RecordValidationError
 from rero_ils.modules.holdings.api import Holding
 from rero_ils.modules.items.api import Item
-
-
-def test_patterns_functions(holding_lib_martigny_w_patterns,
-                            holding_lib_martigny):
-    """Test holdings patterns functions."""
-    # test no prediction for standard holdings record
-    assert not holding_lib_martigny.increment_next_prediction()
-    assert not holding_lib_martigny.next_issue_display_text
-    assert not holding_lib_martigny.prediction_issues_preview(1)
-
-    holding = holding_lib_martigny_w_patterns
-    old_template = holding.get('patterns').get('template')
-    # test invalid syntax for pattern templates
-    template = 'no {{first_chronology.level_1}'
-    holding['patterns']['template'] = template
-    with pytest.raises(jinja2.exceptions.TemplateSyntaxError):
-        assert holding.next_issue_display_text
-
-    template = 'no {{unknown_chronology.level_1}}'
-    holding['patterns']['template'] = template
-    with pytest.raises(jinja2.exceptions.UndefinedError):
-        assert holding.next_issue_display_text
-    holding['patterns']['template'] = old_template
-
-
-def test_patterns_quarterly_one_level(holding_lib_martigny_w_patterns):
-    """Test holdings patterns annual two levels."""
-    holding = holding_lib_martigny_w_patterns
-    # test first issue
-    assert holding.next_issue_display_text == 'no 61 mars 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'no 62 juin 2020'
-    for r in range(11):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'no 73 mars 2023'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'no 85 mars 2026'
-
-
-def test_patterns_yearly_one_level(
-        holding_lib_martigny_w_patterns,
-        pattern_yearly_one_level_data):
-    """Test pattern yearly one level."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = pattern_yearly_one_level_data['patterns']
-
-    # test first issue
-    assert holding.next_issue_display_text == '82 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == '83 2021'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == '108 2046'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == '120 2058'
-
-
-def test_patterns_yearly_one_level_with_label(
-        holding_lib_martigny_w_patterns,
-        pattern_yearly_one_level_with_label_data):
-    """Test pattern yearly one level with label."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = pattern_yearly_one_level_with_label_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == '29 Edition 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == '30 Edition 2021'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == '55 Edition 2046'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == '67 Edition 2058'
-
-
-def test_patterns_yearly_two_times(
-        holding_lib_martigny_w_patterns,
-        pattern_yearly_two_times_data):
-    """Test pattern yearly two times."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = pattern_yearly_two_times_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == 'Jg. 8 Nov. 2019'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Jg. 9 März 2020'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Jg. 21 Nov. 2032'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'Jg. 27 Nov. 2038'
-
-
-def test_patterns_quarterly_two_levels(
-        holding_lib_martigny_w_patterns,
-        pattern_quarterly_two_levels_data):
-    """Test pattern quarterly_two_levels."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = pattern_quarterly_two_levels_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == 'Jg. 20 Heft 1 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Jg. 20 Heft 2 2020'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Jg. 26 Heft 3 2026'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'Jg. 29 Heft 3 2029'
-
-
-def test_patterns_quarterly_two_levels_with_season(
-        holding_lib_martigny_w_patterns,
-        pattern_quarterly_two_levels_with_season_data):
-    """Test pattern quarterly_two_levels_with_season."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = \
-        pattern_quarterly_two_levels_with_season_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == \
-        'année 2019 no 277 printemps 2018'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'année 2019 no 278 été 2018'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == \
-        'année 2025 no 303 automne 2024'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'année 2028 no 315 automne 2027'
-
-
-def test_patterns_half_yearly_one_level(
-        holding_lib_martigny_w_patterns,
-        pattern_half_yearly_one_level_data):
-    """Test pattern half_yearly_one_level."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = \
-        pattern_half_yearly_one_level_data['patterns']
-
-    # test first issue
-    assert holding.next_issue_display_text == 'N˚ 48 printemps 2019'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'N˚ 49 automne 2019'
-    for r in range(13):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'N˚ 62 printemps 2026'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'N˚ 74 printemps 2032'
-
-
-def test_patterns_bimonthly_every_two_months_one_level(
-        holding_lib_martigny_w_patterns,
-        pattern_bimonthly_every_two_months_one_level_data):
-    """Test pattern quarterly_two_levels."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = \
-        pattern_bimonthly_every_two_months_one_level_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == '47 jan./fév. 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == '48 mars/avril 2020'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == '73 mai/juin 2024'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == '85 mai/juin 2026'
-
-
-def test_patterns_half_yearly_two_levels(
-        holding_lib_martigny_w_patterns,
-        pattern_half_yearly_two_levels_data):
-    """Test pattern half_yearly_two_levels."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = \
-        pattern_half_yearly_two_levels_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == 'Année 30 no 84 June 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Année 30 no 85 Dec. 2020'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Année 43 no 110 June 2033'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'Année 49 no 122 June 2039'
-
-
-def test_bimonthly_every_two_months_two_levels(
-        holding_lib_martigny_w_patterns,
-        pattern_bimonthly_every_two_months_two_levels_data):
-    """Test pattern bimonthly_every_two_months_two_levels."""
-    holding = holding_lib_martigny_w_patterns
-    holding['patterns'] = \
-        pattern_bimonthly_every_two_months_two_levels_data['patterns']
-    # test first issue
-    assert holding.next_issue_display_text == 'Jg 51 Nr 1 Jan. 2020'
-    holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Jg 51 Nr 2 März 2020'
-    for r in range(25):
-        holding.increment_next_prediction()
-    assert holding.next_issue_display_text == 'Jg 55 Nr 3 Mai 2024'
-    # test preview
-    issues = holding.prediction_issues_preview(13)
-    assert issues[-1] == 'Jg 57 Nr 3 Mai 2026'
+from rero_ils.modules.utils import get_ref_for_pid, get_schema_for_resource
 
 
 def test_pattern_preview_api(
@@ -246,6 +40,7 @@ def test_pattern_preview_api(
     """Test holdings patterns preview api."""
     login_user_via_session(client, librarian_martigny_no_email.user)
     holding = holding_lib_martigny_w_patterns
+    # holding = Holding.get_record_by_pid(holding.pid)
     # test preview by default 10 issues returned
     res = client.get(
         url_for(
@@ -255,7 +50,7 @@ def test_pattern_preview_api(
     )
     assert res.status_code == 200
     issues = get_json(res).get('issues')
-    assert issues[0] == 'no 61 mars 2020'
+    assert issues[0]['issue'] == 'no 61 mars 2020'
     assert len(issues) == 10
     # test invalid size
     res = client.get(
@@ -267,7 +62,7 @@ def test_pattern_preview_api(
     )
     assert res.status_code == 200
     issues = get_json(res).get('issues')
-    assert issues[0] == 'no 61 mars 2020'
+    assert issues[0]['issue'] == 'no 61 mars 2020'
     assert len(issues) == 10
     # test preview for a given size
     res = client.get(
@@ -279,8 +74,117 @@ def test_pattern_preview_api(
     )
     assert res.status_code == 200
     issues = get_json(res).get('issues')
-    assert issues[12] == 'no 73 mars 2023'
+    assert issues[12]['issue'] == 'no 73 mars 2023'
     assert len(issues) == 13
+
+
+def test_pattern_preview_api(
+        client, holding_lib_martigny_w_patterns, librarian_martigny_no_email):
+    """Test holdings patterns preview api."""
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    holding = holding_lib_martigny_w_patterns
+    # holding = Holding.get_record_by_pid(holding.pid)
+    # test preview by default 10 issues returned
+    res = client.get(
+        url_for(
+            'api_holding.patterns_preview',
+            holding_pid=holding.pid
+        )
+    )
+    assert res.status_code == 200
+    issues = get_json(res).get('issues')
+    assert issues[0]['issue'] == 'no 61 mars 2020'
+    assert len(issues) == 10
+    # test invalid size
+    res = client.get(
+        url_for(
+            'api_holding.patterns_preview',
+            holding_pid=holding.pid,
+            size='no size'
+        )
+    )
+    assert res.status_code == 200
+    issues = get_json(res).get('issues')
+    assert issues[0]['issue'] == 'no 61 mars 2020'
+    assert len(issues) == 10
+    # test preview for a given size
+    res = client.get(
+        url_for(
+            'api_holding.patterns_preview',
+            holding_pid=holding.pid,
+            size=13
+        )
+    )
+    assert res.status_code == 200
+    issues = get_json(res).get('issues')
+    assert issues[12]['issue'] == 'no 73 mars 2023'
+    assert len(issues) == 13
+
+
+def test_receive_regular_issue_api(
+        client, holding_lib_martigny_w_patterns,
+        librarian_fully_no_email, librarian_martigny_no_email,
+        system_librarian_sion_no_email):
+    """Test holdings receive regular issues API."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    issue_display, expected_date = holding._get_next_issue_display_text(
+                        holding.get('patterns'))
+    # not logged users are not authorized
+    res, data = postdata(
+        client,
+        'api_holding.receive_regular_issue',
+        dict(holdings_pid=holding.pid)
+    )
+    assert res.status_code == 401
+
+    # librarian of another library are not authoritzed to receive issues
+    # for another library.
+    login_user_via_session(client, librarian_fully_no_email.user)
+    res, data = postdata(
+        client,
+        'api_holding.receive_regular_issue',
+        dict(holdings_pid=holding.pid)
+    )
+    assert res.status_code == 401
+    # only users of same organisation may receive issues.
+    login_user_via_session(client, system_librarian_sion_no_email.user)
+    res, data = postdata(
+        client,
+        'api_holding.receive_regular_issue',
+        dict(holdings_pid=holding.pid)
+    )
+    assert res.status_code == 401
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    res, data = postdata(
+        client,
+        'api_holding.receive_regular_issue',
+        dict(holdings_pid=holding.pid)
+    )
+    assert res.status_code == 200
+    issue = get_json(res).get('issue')
+    assert issue.get('issue').get('display_text') == issue_display
+    assert issue.get('issue').get('expected_date') == expected_date
+    item = {
+        'issue': {
+            'regular': True,
+            'status': 'received',
+            'expected_date': datetime.now().strftime('%Y-%m-%d'),
+            'received_date': datetime.now().strftime('%Y-%m-%d'),
+            'display_text': 'free_text'
+        }
+    }
+    res, data = postdata(
+        client,
+        'api_holding.receive_regular_issue',
+        {'holdings_pid': holding.pid, 'item': item}
+    )
+    assert res.status_code == 200
+    issue = get_json(res).get('issue')
+    assert issue.get('issue').get('display_text') == 'free_text'
+    assert issue.get('issue').get('expected_date') == \
+        datetime.now().strftime('%Y-%m-%d')
 
 
 def test_create_holdings_with_pattern(
@@ -341,7 +245,7 @@ def test_holding_pattern_preview_api(
     assert res.status_code == 200
 
     issues = get_json(res).get('issues')
-    assert issues[0] == '108 2046'
+    assert issues[0]['issue'] == '82 2020'
     assert len(issues) == 15
 
     # test invalid patterns
@@ -378,14 +282,14 @@ def test_automatic_item_creation_no_serials(
         holding_lib_martigny_w_patterns.get('circulation_category')
 
 
-def test_validate_first_expected_date(
+def test_validate_next_expected_date(
         client, librarian_martigny_no_email,
         journal, loc_public_sion, item_type_internal_sion, document,
         pattern_yearly_two_times_data, json_header,
         holding_lib_sion_w_patterns_data):
     """Test create holding with regular frequency and missing
 
-    the first_expected_date.
+    the next_expected_date.
     """
     login_user_via_session(client, librarian_martigny_no_email.user)
     holding = holding_lib_sion_w_patterns_data
@@ -393,12 +297,89 @@ def test_validate_first_expected_date(
     holding['patterns'] = \
         pattern_yearly_two_times_data['patterns']
     del holding['pid']
-    del holding['patterns']['first_expected_date']
+    del holding['patterns']['next_expected_date']
     # test will fail when the serial holding has no field
-    # first_expected_date for the regular frequency
+    # next_expected_date for the regular frequency
     with pytest.raises(RecordValidationError):
         Holding.create(
             data=holding,
             delete_pid=False,
             dbcommit=True,
             reindex=True)
+
+
+def test_irregular_issue_creation_update_delete_api(
+        client, holding_lib_martigny_w_patterns,
+        librarian_martigny_no_email):
+    """Test create, update and delete of an irregular issue API."""
+    holding = holding_lib_martigny_w_patterns
+    issue_display, expected_date = holding._get_next_issue_display_text(
+                        holding.get('patterns'))
+
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item = {
+        'issue': {
+            'status': 'received',
+            'display_text': 'irregular_issue',
+            'received_date': datetime.now().strftime('%Y-%m-%d'),
+            'expected_date': datetime.now().strftime('%Y-%m-%d'),
+            'regular': False
+        },
+        'status': 'on_shelf',
+        'holding': {'$ref': get_ref_for_pid('hold', holding.pid)},
+        '$schema': get_schema_for_resource(Item),
+        'location': holding.get('location'),
+        'document': holding.get('document'),
+        'item_type': holding.get('circulation_category'),
+        'type': 'issue',
+        'organisation':
+            {'$ref': get_ref_for_pid('org', holding.organisation_pid)}
+    }
+    res, data = postdata(
+        client,
+        'invenio_records_rest.item_list',
+        item
+    )
+    assert res.status_code == 201
+    created_item = Item.get_record_by_pid(data['metadata'].get('pid'))
+    assert created_item.get('barcode').startswith('f-')
+    assert created_item.get('type') == 'issue'
+    assert not created_item.get('issue').get('regular')
+    assert created_item.get('issue').get('display_text') == 'irregular_issue'
+    new_issue_display, new_expected_date = \
+        holding._get_next_issue_display_text(holding.get('patterns'))
+    assert new_issue_display == issue_display
+    assert new_expected_date == expected_date
+
+    # Validation error if you try to create an issue with no holdings links
+    item = {
+        'issue': {
+            'status': 'received',
+            'display_text': 'irregular_issue',
+            'received_date': datetime.now().strftime('%Y-%m-%d'),
+            'expected_date': datetime.now().strftime('%Y-%m-%d'),
+            'regular': False
+        },
+        'status': 'on_shelf',
+        'location': holding.get('location'),
+        'document': holding.get('document'),
+        'item_type': holding.get('circulation_category'),
+        'type': 'issue'
+    }
+    with pytest.raises(RecordValidationError):
+        res, data = postdata(
+            client,
+            'invenio_records_rest.item_list',
+            item
+        )
+    # NO validation error if you try to update an issue with a holdings link
+    item = deepcopy(created_item)
+    created_item.update(data=item, dbcommit=True, reindex=True)
+    # Validation error if you try to update an issue with no holdings links
+    item.pop('holding')
+    with pytest.raises(RecordValidationError):
+        created_item.update(data=item, dbcommit=True, reindex=True)
+    # no errors when deleting an irregular issue
+    pid = created_item.pid
+    created_item.delete(dbcommit=True, delindex=True)
+    assert not Item.get_record_by_pid(pid)

--- a/tests/data/holdings.json
+++ b/tests/data/holdings.json
@@ -211,7 +211,7 @@
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "first_expected_date": "2020-03-01",
+      "next_expected_date": "2020-03-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -248,7 +248,7 @@
     "patterns": {
       "template": "no {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "first_expected_date": "2020-03-01",
+      "next_expected_date": "2020-03-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -285,7 +285,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1013",
-      "first_expected_date": "2020-01-02",
+      "next_expected_date": "2020-01-02",
       "values": [
         {
           "name": "first_enumeration",
@@ -313,7 +313,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} Edition {{first_chronology.level_1}}",
       "frequency": "rdafr:1013",
-      "first_expected_date": "2020-06-01",
+      "next_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -341,7 +341,7 @@
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1014",
-      "first_expected_date": "2020-03-03",
+      "next_expected_date": "2020-03-03",
       "values": [
         {
           "name": "first_enumeration",
@@ -383,7 +383,7 @@
     "patterns": {
       "template": "Jg. {{first_enumeration.level_1}} Heft {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "first_expected_date": "2020-09-01",
+      "next_expected_date": "2020-09-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -421,7 +421,7 @@
     "patterns": {
       "template": "ann\u00e9e {{first_chronology.level_1}} no {{first_enumeration.level_1}} {{second_chronology.level_2}} {{second_chronology.level_1}}",
       "frequency": "rdafr:1010",
-      "first_expected_date": "2020-03-20",
+      "next_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_chronology",
@@ -472,7 +472,7 @@
     "patterns": {
       "template": "N\u02da {{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "first_expected_date": "2020-03-20",
+      "next_expected_date": "2020-03-20",
       "values": [
         {
           "name": "first_enumeration",
@@ -507,7 +507,7 @@
     "patterns": {
       "template": "{{first_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1007",
-      "first_expected_date": "2020-01-15",
+      "next_expected_date": "2020-01-15",
       "values": [
         {
           "name": "first_enumeration",
@@ -546,7 +546,7 @@
     "patterns": {
       "template": "Ann\u00e9e {{first_enumeration.level_1}} no {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1012",
-      "first_expected_date": "2020-06-01",
+      "next_expected_date": "2020-06-01",
       "values": [
         {
           "name": "first_enumeration",
@@ -594,7 +594,7 @@
     "patterns": {
       "template": "Jg {{first_enumeration.level_1}} Nr {{second_enumeration.level_1}} {{first_chronology.level_2}} {{first_chronology.level_1}}",
       "frequency": "rdafr:1007",
-      "first_expected_date": "2020-01-05",
+      "next_expected_date": "2020-01-05",
       "values": [
         {
           "name": "first_enumeration",

--- a/tests/ui/holdings/test_holdings_patters.py
+++ b/tests/ui/holdings/test_holdings_patters.py
@@ -1,0 +1,550 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Holding Patterns Record tests."""
+
+from __future__ import absolute_import, print_function
+
+from copy import deepcopy
+from datetime import datetime
+
+import jinja2
+import pytest
+from invenio_accounts.testutils import login_user_via_session
+
+from rero_ils.modules.errors import RecordValidationError
+from rero_ils.modules.holdings.api import Holding
+from rero_ils.modules.items.api import Item
+
+
+def test_patterns_functions(holding_lib_martigny_w_patterns,
+                            holding_lib_martigny):
+    """Test holdings patterns functions."""
+    # test no prediction for standard holdings record
+    assert not holding_lib_martigny.increment_next_prediction()
+    assert not holding_lib_martigny.next_issue_display_text
+    assert not holding_lib_martigny.prediction_issues_preview(1)
+
+    holding = holding_lib_martigny_w_patterns
+    old_template = holding.get('patterns').get('template')
+    # test invalid syntax for pattern templates
+    template = 'no {{first_chronology.level_1}'
+    holding['patterns']['template'] = template
+    with pytest.raises(jinja2.exceptions.TemplateSyntaxError):
+        assert holding.next_issue_display_text
+
+    template = 'no {{unknown_chronology.level_1}}'
+    holding['patterns']['template'] = template
+    with pytest.raises(jinja2.exceptions.UndefinedError):
+        assert holding.next_issue_display_text
+    holding['patterns']['template'] = old_template
+
+
+def test_patterns_quarterly_one_level(holding_lib_martigny_w_patterns):
+    """Test holdings patterns annual two levels."""
+    holding = holding_lib_martigny_w_patterns
+    # test first issue
+    assert holding.next_issue_display_text == 'no 61 mars 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'no 62 juin 2020'
+    for r in range(11):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'no 73 mars 2023'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'no 85 mars 2026'
+
+
+def test_receive_regular_issue(holding_lib_martigny_w_patterns):
+    """Test holdings receive regular issues."""
+    holding = holding_lib_martigny_w_patterns
+    issue = holding.receive_regular_issue(dbcommit=True, reindex=True)
+    assert issue.location_pid == holding.location_pid
+    assert issue.item_type_pid == holding.circulation_category_pid
+    assert issue.document_pid == holding.document_pid
+    assert issue.holding_pid == holding.pid
+    assert issue.get('status') == 'on_shelf'
+    assert issue.item_record_type == 'issue'
+    assert issue.organisation_pid == holding.organisation_pid
+    assert issue.get('issue', {}).get('regular')
+    assert issue.issue_status == 'received'
+    assert issue.expected_date == '2023-03-01'
+    assert issue.display_text == 'no 73 mars 2023'
+    assert issue.received_date == datetime.now().strftime('%Y-%m-%d')
+
+    holding = Holding.get_record_by_pid(holding.pid)
+    issue = holding.receive_regular_issue(dbcommit=True, reindex=True)
+    assert issue.get('issue', {}).get('regular')
+    assert issue.issue_status == 'received'
+    assert issue.expected_date == '2020-06-01'
+    assert issue.display_text == 'no 62 juin 2020'
+    assert issue.received_date == datetime.now().strftime('%Y-%m-%d')
+    # test create customized regular issue
+    record = {
+        'issue': {
+            'regular': True,
+            'status': 'received',
+            'expected_date': datetime.now().strftime('%Y-%m-%d'),
+            'received_date': datetime.now().strftime('%Y-%m-%d'),
+            'display_text': 'free_text'
+        }
+    }
+    holding = Holding.get_record_by_pid(holding.pid)
+    issue = holding.receive_regular_issue(
+        item=record, dbcommit=True, reindex=True)
+    assert issue.get('issue', {}).get('regular')
+    assert issue.issue_status == 'received'
+    assert issue.expected_date == datetime.now().strftime('%Y-%m-%d')
+    assert issue.display_text == 'free_text'
+    assert issue.received_date == datetime.now().strftime('%Y-%m-%d')
+
+
+def test_patterns_yearly_one_level(
+        holding_lib_martigny_w_patterns,
+        pattern_yearly_one_level_data):
+    """Test pattern yearly one level."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = pattern_yearly_one_level_data['patterns']
+
+    # test first issue
+    assert holding.next_issue_display_text == '82 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == '83 2021'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == '108 2046'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == '120 2058'
+
+
+def test_patterns_yearly_one_level_with_label(
+        holding_lib_martigny_w_patterns,
+        pattern_yearly_one_level_with_label_data):
+    """Test pattern yearly one level with label."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = pattern_yearly_one_level_with_label_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == '29 Edition 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == '30 Edition 2021'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == '55 Edition 2046'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == '67 Edition 2058'
+
+
+def test_patterns_yearly_two_times(
+        holding_lib_martigny_w_patterns,
+        pattern_yearly_two_times_data):
+    """Test pattern yearly two times."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = pattern_yearly_two_times_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == 'Jg. 8 Nov. 2019'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Jg. 9 März 2020'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Jg. 21 Nov. 2032'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'Jg. 27 Nov. 2038'
+
+
+def test_patterns_quarterly_two_levels(
+        holding_lib_martigny_w_patterns,
+        pattern_quarterly_two_levels_data):
+    """Test pattern quarterly_two_levels."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = pattern_quarterly_two_levels_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == 'Jg. 20 Heft 1 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Jg. 20 Heft 2 2020'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Jg. 26 Heft 3 2026'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'Jg. 29 Heft 3 2029'
+
+
+def test_patterns_quarterly_two_levels_with_season(
+        holding_lib_martigny_w_patterns,
+        pattern_quarterly_two_levels_with_season_data):
+    """Test pattern quarterly_two_levels_with_season."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = \
+        pattern_quarterly_two_levels_with_season_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == \
+        'année 2019 no 277 printemps 2018'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'année 2019 no 278 été 2018'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == \
+        'année 2025 no 303 automne 2024'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'année 2028 no 315 automne 2027'
+
+
+def test_patterns_half_yearly_one_level(
+        holding_lib_martigny_w_patterns,
+        pattern_half_yearly_one_level_data):
+    """Test pattern half_yearly_one_level."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+
+    holding['patterns'] = \
+        pattern_half_yearly_one_level_data['patterns']
+
+    # test first issue
+    assert holding.next_issue_display_text == 'N˚ 48 printemps 2019'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'N˚ 49 automne 2019'
+    for r in range(13):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'N˚ 62 printemps 2026'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'N˚ 74 printemps 2032'
+
+
+def test_patterns_bimonthly_every_two_months_one_level(
+        holding_lib_martigny_w_patterns,
+        pattern_bimonthly_every_two_months_one_level_data):
+    """Test pattern quarterly_two_levels."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = \
+        pattern_bimonthly_every_two_months_one_level_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == '47 jan./fév. 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == '48 mars/avril 2020'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == '73 mai/juin 2024'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == '85 mai/juin 2026'
+
+
+def test_patterns_half_yearly_two_levels(
+        holding_lib_martigny_w_patterns,
+        pattern_half_yearly_two_levels_data):
+    """Test pattern half_yearly_two_levels."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = \
+        pattern_half_yearly_two_levels_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == 'Année 30 no 84 June 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Année 30 no 85 Dec. 2020'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Année 43 no 110 June 2033'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'Année 49 no 122 June 2039'
+
+
+def test_bimonthly_every_two_months_two_levels(
+        holding_lib_martigny_w_patterns,
+        pattern_bimonthly_every_two_months_two_levels_data):
+    """Test pattern bimonthly_every_two_months_two_levels."""
+    holding = holding_lib_martigny_w_patterns
+    holding = Holding.get_record_by_pid(holding.pid)
+    holding['patterns'] = \
+        pattern_bimonthly_every_two_months_two_levels_data['patterns']
+    # test first issue
+    assert holding.next_issue_display_text == 'Jg 51 Nr 1 Jan. 2020'
+    holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Jg 51 Nr 2 März 2020'
+    for r in range(25):
+        holding.increment_next_prediction()
+    assert holding.next_issue_display_text == 'Jg 55 Nr 3 Mai 2024'
+    # test preview
+    issues = holding.prediction_issues_preview(13)
+    assert issues[-1]['issue'] == 'Jg 57 Nr 3 Mai 2026'
+
+
+def test_validate_next_expected_date(
+        client, librarian_martigny_no_email,
+        journal, loc_public_sion, item_type_internal_sion, document,
+        pattern_yearly_two_times_data, json_header,
+        holding_lib_sion_w_patterns_data):
+    """Test create holding with regular frequency and missing
+
+    the next_expected_date.
+    """
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    holding = holding_lib_sion_w_patterns_data
+    holding['holdings_type'] = 'serial'
+    holding['patterns'] = \
+        pattern_yearly_two_times_data['patterns']
+    del holding['pid']
+    del holding['patterns']['next_expected_date']
+    # test will fail when the serial holding has no field
+    # next_expected_date for the regular frequency
+    with pytest.raises(RecordValidationError):
+        Holding.create(
+            data=holding,
+            delete_pid=False,
+            dbcommit=True,
+            reindex=True)
+
+
+def test_intervals_and_expected_dates(holding_lib_martigny_w_patterns):
+    """Test expected dates and intervals for holdings patterns."""
+    holding = holding_lib_martigny_w_patterns
+    patterns = {
+      'template': '{{first_chronology.level_1}}',
+      'next_expected_date': '2020-01-05',
+      'values': [
+        {
+          'name': 'first_chronology',
+          'levels': [
+            {
+              'number_name': 'level_1',
+              'starting_value': 1
+            }
+          ]
+        }
+      ]
+    }
+    holding['patterns'] = patterns
+
+    def update_pattern(holding, frequency):
+        """update holdings patterns with a new frequency."""
+        holding['patterns']['frequency'] = frequency
+        holding.update(holding, dbcommit=True, reindex=True)
+
+    # test daily pattern
+    update_pattern(holding, 'rdafr:1001')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert divmod(interval.days, 1)[0] == 1
+        previous_expected_date = expected_date
+
+    # test three times a week pattern
+    update_pattern(holding, 'rdafr:1002')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert divmod(interval.days, 1)[0] == 2
+        previous_expected_date = expected_date
+
+    # test Biweekly pattern
+    update_pattern(holding, 'rdafr:1003')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert divmod(interval.days, 1)[0] == 14
+        previous_expected_date = expected_date
+
+    # test Weekly pattern
+    update_pattern(holding, 'rdafr:1004')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert divmod(interval.days, 1)[0] == 7
+        previous_expected_date = expected_date
+
+    # test Semiweekly pattern
+    update_pattern(holding, 'rdafr:1005')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 3 <= divmod(interval.days, 1)[0] <= 4
+        previous_expected_date = expected_date
+
+    # test Three times a month pattern
+    update_pattern(holding, 'rdafr:1006')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 11 > divmod(interval.days, 1)[0] > 7
+        previous_expected_date = expected_date
+
+    # test Bimonthly pattern
+    update_pattern(holding, 'rdafr:1007')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 57 < divmod(interval.days, 1)[0] <= 62
+        previous_expected_date = expected_date
+
+    # test Monthly pattern
+    update_pattern(holding, 'rdafr:1008')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 27 < divmod(interval.days, 1)[0] < 32
+        previous_expected_date = expected_date
+
+    # test Semimonthly pattern
+    update_pattern(holding, 'rdafr:1009')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 13 < divmod(interval.days, 1)[0] < 16
+        previous_expected_date = expected_date
+
+    # test Quarterly pattern
+    update_pattern(holding, 'rdafr:1010')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 84 < divmod(interval.days, 1)[0] < 94
+        previous_expected_date = expected_date
+
+    # test Three times a year pattern
+    update_pattern(holding, 'rdafr:1011')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 112 < divmod(interval.days, 1)[0] < 125
+        previous_expected_date = expected_date
+
+    # test Semiannual pattern
+    update_pattern(holding, 'rdafr:1012')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 177 < divmod(interval.days, 1)[0] < 207
+        previous_expected_date = expected_date
+
+    # test annual pattern
+    update_pattern(holding, 'rdafr:1013')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 364 <= divmod(interval.days, 1)[0] <= 366
+        previous_expected_date = expected_date
+
+    # test Biennial pattern
+    update_pattern(holding, 'rdafr:1014')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 725 < divmod(interval.days, 1)[0] < 733
+        previous_expected_date = expected_date
+
+    # test Triennial pattern
+    update_pattern(holding, 'rdafr:1015')
+    issues = holding.prediction_issues_preview(13)
+    previous_expected_date = None
+    for issue in issues:
+        expected_date = datetime.strptime(
+            issue.get('expected_date'), '%Y-%m-%d')
+        if previous_expected_date:
+            interval = expected_date - previous_expected_date
+            assert 1092 < divmod(interval.days, 1)[0] < 1099
+        previous_expected_date = expected_date
+
+
+def test_regular_issue_creation_update_delete_api(
+        client, holding_lib_martigny_w_patterns, loc_public_martigny,
+        lib_martigny):
+    """Test create, update and delete of a regular issue API."""
+    holding = holding_lib_martigny_w_patterns
+    issue_display, expected_date = holding._get_next_issue_display_text(
+                        holding.get('patterns'))
+    issue = holding.receive_regular_issue(dbcommit=True, reindex=True)
+    item = deepcopy(issue)
+    item['issue']['status'] = 'deleted'
+    issue.update(data=item, dbcommit=True, reindex=True)
+    created_issue = Item.get_record_by_pid(issue.pid)
+    assert created_issue.get('issue').get('status') == 'deleted'
+    # Validation error if you try to create an issue with no holdings links
+    item.pop('holding')
+    with pytest.raises(RecordValidationError):
+        issue.update(data=item, dbcommit=True, reindex=True)
+    # no errors when deleting an irregular issue
+    pid = created_issue.pid
+    created_issue.delete(dbcommit=True, delindex=True)
+    assert not Item.get_record_by_pid(pid)


### PR DESCRIPTION
To allow librarians to receive new issues for holdings records. According to the
patterns of the holdings, the system correctly increments the next issues.
Librarians are able now to create irregular and exception issues.

The field first_expected_date is renamed to next_expected_date and it is now
updated automatically after a successful receive of a regular issue.

The new value of next_expected_date is the expected_date of the received issue
plus the frequency of the pattern.

The reroils patterns support now all the RDA standard frequencies.

The pattern preview API returns both the issue_display_text and expected_date.

A new API is now available to receive the next regular issue.

Only librarians of the holdings library may receive the issues  in addition
to the system_librarians of same organisation.

At item creation and update, relinking to a holding is done only for standard holdings.

* Updates fixtures to create minimum of 3 issues per pattern.
* Updates tests.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1483?kanban-status=1224894

## How to test?

`bootstrap` + `setup`

- preview_api: `~/api/holding/<holdings_pid>/patterns/preview`
- receive_issue_api: `~/api/holding/receive_regular_issue`

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [ ] Extracted translations?
