### PR TITLE
loans: use datetime for [start|end]_date fields

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -23,6 +23,7 @@ python-editor = ">=0.3"
 [[package]]
 category = "main"
 description = "Low-level AMQP client for Python (fork of amqplib)."
+marker = "python_version < \"3.7\" or python_version >= \"3.7\""
 name = "amqp"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -145,6 +146,7 @@ tests = ["check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "pydo
 [[package]]
 category = "main"
 description = "Python multiprocessing fork with improvements and bugfixes"
+marker = "python_version < \"3.7\" or python_version >= \"3.7\""
 name = "billiard"
 optional = false
 python-versions = "*"
@@ -790,7 +792,7 @@ description = "Adds SQLAlchemy support to your Flask application."
 name = "flask-sqlalchemy"
 optional = false
 python-versions = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*"
-version = "2.4.1"
+version = "2.4.2"
 
 [package.dependencies]
 Flask = ">=0.10"
@@ -845,7 +847,6 @@ WTForms = "*"
 reference = "efc7ac3a3207fca0571ebdcbea8ba0fc13c415e8"
 type = "git"
 url = "https://github.com/rero/flask-wiki.git"
-
 [[package]]
 category = "main"
 description = "Simple integration of Flask and WTForms."
@@ -917,7 +918,6 @@ version = "1.2.0"
 [[package]]
 category = "main"
 description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -1473,7 +1473,6 @@ tests = ["check-manifest (>=0.35)", "coverage (>=4.3.4)", "isort (4.2.2)", "mock
 reference = "fe55e095a8e78b36cfad875f752f2facc2908bae"
 type = "git"
 url = "https://github.com/inveniosoftware/invenio-oaiharvester.git"
-
 [[package]]
 category = "main"
 description = "Invenio module that implements OAI-PMH server."
@@ -1911,8 +1910,16 @@ category = "main"
 description = "Python library for serializing any arbitrary object graph into JSON"
 name = "jsonpickle"
 optional = false
-python-versions = "*"
-version = "1.2"
+python-versions = ">=2.7"
+version = "1.4.1"
+
+[package.dependencies]
+importlib-metadata = "*"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["coverage (<5)", "pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sqlalchemy", "enum34", "jsonlib"]
+"testing.libs" = ["demjson", "simplejson", "ujson", "yajl"]
 
 [[package]]
 category = "main"
@@ -1975,6 +1982,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 [[package]]
 category = "main"
 description = "Messaging library for Python."
+marker = "python_version < \"3.7\" or python_version >= \"3.7\""
 name = "kombu"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -2454,15 +2462,15 @@ category = "dev"
 description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.8.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.9.0"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 category = "dev"
@@ -2606,7 +2614,7 @@ description = "Webpack integration layer for Python."
 name = "pywebpack"
 optional = false
 python-versions = "*"
-version = "1.0.3"
+version = "1.1.0"
 
 [package.dependencies]
 node-semver = ">=0.1.1"
@@ -2665,10 +2673,7 @@ description = "Redis Scheduler For Celery, Support Add Task Dynamic"
 name = "redisbeat"
 optional = false
 python-versions = "*"
-version = "1.2.4"
-
-[package.dependencies]
-jsonpickle = "1.2"
+version = "1.2.2"
 
 [[package]]
 category = "main"
@@ -2805,7 +2810,7 @@ description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.14.0"
+version = "1.15.0"
 
 [[package]]
 category = "dev"
@@ -2952,7 +2957,7 @@ description = "Versioning and auditing extension for SQLAlchemy."
 name = "sqlalchemy-continuum"
 optional = false
 python-versions = "*"
-version = "1.3.10"
+version = "1.3.11"
 
 [package.dependencies]
 SQLAlchemy = ">=1.0.8"
@@ -3123,6 +3128,7 @@ test = ["pytest (>=2.2.3)", "flake8 (>=2.4.0)", "isort (>=4.2.2)"]
 [[package]]
 category = "main"
 description = "Promises, promises, promises."
+marker = "python_version < \"3.7\" or python_version >= \"3.7\""
 name = "vine"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -3257,7 +3263,7 @@ version = "0.12.0"
 [[package]]
 category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" and (python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\")"
+marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -3572,8 +3578,8 @@ flask-shell-ipython = [
     {file = "flask_shell_ipython-0.4.1-py2.py3-none-any.whl", hash = "sha256:f212b4fad6831edf652799c719cd05fd0716edfaa5506eb41ff9ef09109890d3"},
 ]
 flask-sqlalchemy = [
-    {file = "Flask-SQLAlchemy-2.4.1.tar.gz", hash = "sha256:6974785d913666587949f7c2946f7001e4fa2cb2d19f4e69ead02e4b8f50b33d"},
-    {file = "Flask_SQLAlchemy-2.4.1-py2.py3-none-any.whl", hash = "sha256:0078d8663330dc05a74bc72b3b6ddc441b9a744e2f56fe60af1a5bfc81334327"},
+    {file = "Flask-SQLAlchemy-2.4.2.tar.gz", hash = "sha256:6cd9f71a97ef18ca5ae7d8bd316a32b82814efe7b088096ba68fddfd8a17cbe7"},
+    {file = "Flask_SQLAlchemy-2.4.2-py2.py3-none-any.whl", hash = "sha256:2298f6b874c2a2f1f048eaf21ce5d984e36a04ca849b0ac473050a67c8dae76f"},
 ]
 flask-talisman = [
     {file = "flask-talisman-0.5.0.tar.gz", hash = "sha256:e4e3ccba66895e1f46d5b62a9cc0f273731da601bc92d2b9af908011298c0e2b"},
@@ -3769,8 +3775,8 @@ jsonpatch = [
     {file = "jsonpatch-1.25.tar.gz", hash = "sha256:ddc0f7628b8bfdd62e3cbfbc24ca6671b0b6265b50d186c2cf3659dc0f78fd6a"},
 ]
 jsonpickle = [
-    {file = "jsonpickle-1.2-py2.py3-none-any.whl", hash = "sha256:d0c5a4e6cb4e58f6d5406bdded44365c2bcf9c836c4f52910cc9ba7245a59dc2"},
-    {file = "jsonpickle-1.2.tar.gz", hash = "sha256:d3e922d781b1d0096df2dad89a2e1f47177d7969b596aea806a9d91b4626b29b"},
+    {file = "jsonpickle-1.4.1-py2.py3-none-any.whl", hash = "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439"},
+    {file = "jsonpickle-1.4.1.tar.gz", hash = "sha256:e8d4b7cd0bd6826001a74377df1079a76ad8bae0f909282de2554164c837c8ba"},
 ]
 jsonpointer = [
     {file = "jsonpointer-2.0-py2.py3-none-any.whl", hash = "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"},
@@ -4044,8 +4050,8 @@ pytest-cache = [
     {file = "pytest-cache-1.0.tar.gz", hash = "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
-    {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
+    {file = "pytest-cov-2.9.0.tar.gz", hash = "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322"},
+    {file = "pytest_cov-2.9.0-py2.py3-none-any.whl", hash = "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"},
 ]
 pytest-flask = [
     {file = "pytest-flask-0.15.1.tar.gz", hash = "sha256:cbd8c5b9f8f1b83e9c159ac4294964807c4934317a5fba181739ac15e1b823e6"},
@@ -4093,8 +4099,8 @@ pytz = [
     {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 pywebpack = [
-    {file = "pywebpack-1.0.3-py2.py3-none-any.whl", hash = "sha256:eb818bfe4c93f0da80e07d6ad2e6d9b5eea51a805f8d1902a9b093f39986c464"},
-    {file = "pywebpack-1.0.3.tar.gz", hash = "sha256:38d99a26e11681ed3ee1d81632b2c011eb468491e98f02a6efd61bce2e75c1fc"},
+    {file = "pywebpack-1.1.0-py2.py3-none-any.whl", hash = "sha256:fea5eaa4f8ef718657fc6b74ce04c83e10819fea80bd56afbc46084465b3cc6f"},
+    {file = "pywebpack-1.1.0.tar.gz", hash = "sha256:7426895c50a76eb64c149f96df12adadabdc0b1ef7a3f2e5b6526be4e38c8972"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -4118,7 +4124,7 @@ redis = [
     {file = "redis-3.5.2.tar.gz", hash = "sha256:6d65e84bc58091140081ee9d9c187aab0480097750fac44239307a3bdf0b1251"},
 ]
 redisbeat = [
-    {file = "redisbeat-1.2.4.tar.gz", hash = "sha256:0b800c6c20168780442b575d583d82d83d7e9326831ffe35f763289ebcd8b4f6"},
+    {file = "redisbeat-1.2.2.tar.gz", hash = "sha256:59b7e9984cb9cde9eaea21093ca2b953f83995a64b6c240e4c36f1b2e9ed1e38"},
 ]
 regex = [
     {file = "regex-2020.5.14-cp27-cp27m-win32.whl", hash = "sha256:e565569fc28e3ba3e475ec344d87ed3cd8ba2d575335359749298a0899fe122e"},
@@ -4204,8 +4210,8 @@ simplekv = [
     {file = "simplekv-0.14.1.tar.gz", hash = "sha256:8953a36cb3741ea821c9de1962b5313bf6fe1b927f6ced2a55266eb8ce2cd0f6"},
 ]
 six = [
-    {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
-    {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
@@ -4273,7 +4279,7 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.3.17.tar.gz", hash = "sha256:156a27548ba4e1fed944ff9fcdc150633e61d350d673ae7baaf6c25c04ac1f71"},
 ]
 sqlalchemy-continuum = [
-    {file = "SQLAlchemy-Continuum-1.3.10.tar.gz", hash = "sha256:5a0ce8b60676da9d8d70acdf32ab459be9b244c12f15668e4e357308ad635132"},
+    {file = "SQLAlchemy-Continuum-1.3.11.tar.gz", hash = "sha256:bc13b0a96110129fd2c2b4c9e5b2f40f320bb26854b09c867e383394746a3eb1"},
 ]
 sqlalchemy-utils = [
     {file = "SQLAlchemy-Utils-0.35.0.tar.gz", hash = "sha256:01f0f0ebed696386bc7bf9231cd6894087baba374dd60f40eb1b07512d6b1a5e"},

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -81,13 +81,15 @@ class Loan(IlsRecord):
             'item': 'item'
         }
     }
-    DATE_FIELDS = [
-        "start_date",
+    DATE_FIELDS = []
+
+    DATETIME_FIELDS = [
         "end_date",
         "request_expire_date",
         "request_start_date",
+        "start_date",
+        "transaction_date"
     ]
-    DATETIME_FIELDS = ["transaction_date"]
 
     def __init__(self, data, model=None):
         """Loan init."""

--- a/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
+++ b/rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json
@@ -96,22 +96,22 @@
     },
     "start_date": {
       "type": "string",
-      "format": "date",
-      "title": "Transaction start date"
+      "format": "date-time",
+      "title": "Transaction start datetime"
     },
     "end_date": {
       "type": "string",
-      "format": "date",
-      "title": "Transaction end date"
+      "format": "date-time",
+      "title": "Transaction end datetime"
     },
     "request_expire_date": {
-      "format": "date",
-      "title": "Request expire date",
+      "format": "date-time",
+      "title": "Request expire datetime",
       "type": "string"
     },
     "request_start_date": {
-      "format": "date",
-      "title": "Request start date",
+      "format": "date-time",
+      "title": "Request start datetime",
       "type": "string"
     },
     "organisation": {

--- a/tests/api/test_items_rest.py
+++ b/tests/api/test_items_rest.py
@@ -683,8 +683,7 @@ def test_items_extend(client, librarian_martigny_no_email,
     # test renewal due date hour
     extended_loan = Loan.get_record_by_pid(loan_pid)
     end_date = ciso8601.parse_datetime(extended_loan.get('end_date'))
-    # TODO: uncomment this line and fix timezone problems
-    # check_timezone_date(lib_tz, end_date)
+    check_timezone_date(lib_tz, end_date)
 
     # second extenion
     res, _ = postdata(
@@ -1321,11 +1320,10 @@ def test_items_extend_end_date(client, librarian_martigny_no_email,
     current_date = datetime.now(timezone.utc)
     calc_date = current_date + renewal_duration
     # finally the comparison should give the same date (in UTC)!
-    # TODO: check why this is failing
-    # assert (
-    #     calc_date.strftime('%Y-%m-%d') == ciso8601.parse_datetime(
-    #         loan_date).astimezone(timezone.utc).strftime('%Y-%m-%d')
-    # )
+    assert (
+        calc_date.strftime('%Y-%m-%d') == ciso8601.parse_datetime(
+            loan_date).astimezone(timezone.utc).strftime('%Y-%m-%d')
+    )
 
     # checkin
     res, _ = postdata(

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -27,7 +27,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_circulation.api import get_loan_for_item
 from invenio_circulation.search.api import LoansSearch
-from utils import flush_index, get_json, postdata
+from utils import check_timezone_date, flush_index, get_json, postdata
 
 from rero_ils.modules.api import IlsRecordError
 from rero_ils.modules.items.api import Item
@@ -202,13 +202,11 @@ def test_due_soon_loans(client, librarian_martigny_no_email,
     loan_date = ciso8601.parse_datetime(checkout_loan.get('end_date'))
 
     # as instance timezone is Europe/Zurich, it should be either 21 or 22
-    # TODO: check why this fails
-    # check_timezone_date(pytz.utc, loan_date, [21, 22])
+    check_timezone_date(pytz.utc, loan_date, [21, 22])
 
     # should be 14:59/15:59 in US/Pacific (because of daylight saving time)
-    # TODO: check why these fail
-    # check_timezone_date(pytz.timezone('US/Pacific'), loan_date, [14, 15])
-    # check_timezone_date(pytz.timezone('Europe/Amsterdam'), loan_date)
+    check_timezone_date(pytz.timezone('US/Pacific'), loan_date, [14, 15])
+    check_timezone_date(pytz.timezone('Europe/Amsterdam'), loan_date)
 
     # checkin the item to put it back to it's original state
     res, _ = postdata(
@@ -553,8 +551,7 @@ It should be the same date, even if timezone changed."
     assert loan_datetime.month == lib_datetime.month, fail_msg
     assert loan_datetime.day == lib_datetime.day, fail_msg
     # Loan date differs regarding timezone, and day of the year (GMT+1/2).
-    # TODO: check why this fails
-    # check_timezone_date(pytz.utc, loan_datetime, [21, 22])
+    check_timezone_date(pytz.utc, loan_datetime, [21, 22])
 
 
 def test_librarian_request_on_blocked_user(


### PR DESCRIPTION
Before using invenio-circulation 1.0.0a21, loan use datetime format for
start_date and end_date fields.
RERO-ils uses hour in datetime fields to check timezone changes.

After invenio-circulation 1.0.0a21, start_date and end_date change to
date field only (it loses the hour).

This commit takes care of hour in start_date and end_date fields.

* Changes loan start_date and end_date to datetime field (to keep
hours/minutes)
* Uses tests on timezones again

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

- It implements check_timezone_date again

## How to test?

- tests should pass
- you can test on a full year (circa 5 hours):

```bash
./scripts/all_year_days poetry run pytest -vvs --no-cov --disable-warnings tests/api/test_items_rest.py
```

or with (circa 3 hours):

```bash
./scripts/all_year_days poetry run pytest -vvs --no-cov --disable-warnings tests/api/test_loans_rest.py
```

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
