### PR TITLE
editor: display fields inline 

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -31,7 +31,9 @@
     "colorContent",
     "productionMethod",
     "bookFormat",
-    "dimensions"
+    "dimensions",
+    "duration",
+    "illustrativeContent"
   ],
   "additionalProperties": false,
   "properties": {
@@ -95,7 +97,10 @@
             "label": "Video",
             "value": "video"
           }
-        ]
+        ],
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-max-width"
+        }
       }
     },
     "title": {
@@ -140,7 +145,10 @@
                   "label": "Variant title",
                   "value": "bf:VariantTitle"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "cssClass": "rero-ils-editor-max-width"
+              }
             }
           },
           "mainTitle": {
@@ -200,6 +208,11 @@
             }
           }
         }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "responsibilityStatement": {
@@ -216,7 +229,10 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "titlesProper": {
@@ -233,6 +249,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
@@ -242,7 +261,10 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-max-width"
+        }
       }
     },
     "language": {
@@ -284,6 +306,11 @@
             "$ref": "#/definitions/language"
           }
         }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "translatedFrom": {
@@ -295,7 +322,10 @@
         "$ref": "#/definitions/language"
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "authors": {
@@ -311,9 +341,9 @@
             "title": "Person",
             "additionalProperties": false,
             "propertiesOrder": [
-              "type",
               "name",
               "$ref",
+              "type",
               "date",
               "qualifier"
             ],
@@ -329,6 +359,9 @@
                 ],
                 "default": "person",
                 "form": {
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  },
                   "options": [
                     {
                       "label": "Person",
@@ -342,6 +375,9 @@
                 "description": "Person's name.",
                 "type": "string",
                 "form": {
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  },
                   "type": "remoteautocomplete",
                   "hideExpression": "field.model.$ref != null"
                 }
@@ -353,7 +389,10 @@
                 "form": {
                   "wrappers": [
                     "ref"
-                  ]
+                  ],
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  }
                 }
               },
               "date": {
@@ -361,7 +400,10 @@
                 "description": "Information about the birth and the death of a person. Helpful to disambiguate people.",
                 "type": "string",
                 "form": {
-                  "hideExpression": "field.model.$ref != null || !field.model.name"
+                  "hideExpression": "field.model.$ref != null || !field.model.name",
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  }
                 }
               },
               "qualifier": {
@@ -369,8 +411,16 @@
                 "description": "Information about the person, ie her profession. Helpful to disambiguate people.",
                 "type": "string",
                 "form": {
-                  "hideExpression": "field.model.$ref != null || !field.model.name"
+                  "hideExpression": "field.model.$ref != null || !field.model.name",
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  }
                 }
+              }
+            },
+            "form": {
+              "templateOptions": {
+                "cssClass": "row"
               }
             }
           },
@@ -378,8 +428,8 @@
             "title": "Organisation",
             "additionalProperties": false,
             "propertiesOrder": [
-              "type",
-              "name"
+              "name",
+              "type"
             ],
             "required": [
               "name",
@@ -399,12 +449,25 @@
                       "label": "Organisation",
                       "value": "organisation"
                     }
-                  ]
+                  ],
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  }
                 }
               },
               "name": {
                 "title": "Name",
-                "type": "string"
+                "type": "string",
+                "form": {
+                  "templateOptions": {
+                    "cssClass": "col-lg-6"
+                  }
+                }
+              }
+            },
+            "form": {
+              "templateOptions": {
+                "cssClass": "row"
               }
             }
           }
@@ -413,6 +476,9 @@
       "form": {
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
@@ -427,7 +493,10 @@
         "minLength": 4
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "editionStatement": {
@@ -460,7 +529,10 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "provisionActivity": {
@@ -510,7 +582,10 @@
                   "label": "Production",
                   "value": "bf:Production"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "cssClass": "rero-ils-editor-max-width"
+              }
             }
           },
           "place": {
@@ -543,18 +618,21 @@
                         "value": "bf:Place"
                       }
                     ],
-                    "hide": true
+                    "templateOptions": {
+                      "cssClass": "col-lg-4"
+                    }
                   }
                 },
                 "country": {
-                  "title": "Country",
-                  "type": "string",
                   "$ref": "#/definitions/country"
                 },
                 "canton": {
-                  "title": "Canton",
-                  "type": "string",
                   "$ref": "#/definitions/canton"
+                }
+              },
+              "form": {
+                "templateOptions": {
+                  "cssClass": "row"
                 }
               }
             }
@@ -598,7 +676,10 @@
                         "label": "Date",
                         "value": "Date"
                       }
-                    ]
+                    ],
+                    "templateOptions": {
+                      "cssClass": "rero-ils-editor-max-width"
+                    }
                   }
                 },
                 "label": {
@@ -627,7 +708,10 @@
             "minimum": -9999,
             "maximum": 2050,
             "form": {
-              "hide": true
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
             }
           },
           "endDate": {
@@ -637,7 +721,10 @@
             "minimum": -9999,
             "maximum": 2050,
             "form": {
-              "hide": true
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
             }
           }
         }
@@ -646,19 +733,29 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
     "illustrativeContent": {
-      "title": "Illustrative content",
+      "title": "Illustrative contents",
       "description": "Record every different illustrative content in a new field. Use one or more RDA recommended terms, in the singular or plural (MARC 300$b).",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Illustrative content",
         "type": "string",
         "minLength": 3,
         "form": {
           "placeholder": "RDA recommended terms: illustrations, maps, photographs, portraits, ..."
+        }
+      },
+      "form": {
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
@@ -669,15 +766,19 @@
       "minLength": 2,
       "form": {
         "placeholder": "Example: 355 pages",
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "col-lg-5"
+        }
       }
     },
     "duration": {
-      "title": "Duration",
+      "title": "Durations",
       "description": "A playing time, performance time, running time, etc., of the content of an expression.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Duration",
         "type": "string",
         "minLength": 2,
         "form": {
@@ -685,15 +786,19 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "colorContent": {
-      "title": "Colour content",
-      "description": "A presence of colour, tone, etc., in the content of an expression. Record a colour content if considered important for identification or selection.",
+      "title": "Color contents",
+      "description": "A presence of color, tone, etc., in the content of an expression. Record a color content if considered important for identification or selection.",
       "type": "array",
       "minItems": 1,
       "items": {
+        "title": "Color content",
         "type": "string",
         "enum": [
           "rdacc:1002",
@@ -713,7 +818,10 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "productionMethod": {
@@ -832,7 +940,10 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "bookFormat": {
@@ -862,7 +973,10 @@
         ]
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "dimensions": {
@@ -879,7 +993,10 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "series": {
@@ -903,20 +1020,36 @@
           "name": {
             "title": "Title",
             "description": "Title of the series.",
-            "type": "string"
+            "type": "string",
+            "form": {
+              "templateOptions": {
+                "cssClass": "col-lg-5"
+              }
+            }
           },
           "number": {
             "title": "Numbering",
             "description": "Numbering of the resource within the series.",
             "type": "string",
             "form": {
-              "hide": true
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-7"
+              }
             }
+          }
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
           }
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "note": {
@@ -956,13 +1089,26 @@
                   "label": "Other physical details",
                   "value": "otherPhysicalDetails"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
             }
           },
           "label": {
             "title": "Label",
             "type": "string",
-            "minLength": 3
+            "minLength": 3,
+            "form": {
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
+            }
+          }
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
           }
         }
       },
@@ -970,6 +1116,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
@@ -990,7 +1139,10 @@
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "identifiedBy": {
@@ -1126,14 +1278,22 @@
                   "label": "URI",
                   "value": "uri"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "cssClass": "col-lg-4"
+              }
             }
           },
           "value": {
             "title": "Identifier value",
             "description": "Identifier value.",
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "form": {
+              "templateOptions": {
+                "cssClass": "col-lg-6 offset-lg-2"
+              }
+            }
           },
           "note": {
             "title": "Note",
@@ -1141,7 +1301,10 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hide": true
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
             }
           },
           "qualifier": {
@@ -1150,20 +1313,33 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hide": true
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
             }
           },
           "acquisitionTerms": {
             "title": "Acquisition terms",
             "description": "Acquisition terms of the resource.",
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "form": {
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
+            }
           },
           "source": {
             "title": "Source",
             "description": "Source of the identifier.",
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "form": {
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
+            }
           },
           "status": {
             "title": "Status",
@@ -1176,8 +1352,16 @@
               "invalid or cancelled"
             ],
             "form": {
-              "hide": true
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
             }
+          }
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
           }
         }
       },
@@ -1185,6 +1369,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
@@ -1202,6 +1389,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
         }
       }
     },
@@ -1230,7 +1420,12 @@
             "placeholder": "Example: https://www.rero.ch/",
             "type": "string",
             "format": "uri",
-            "minLength": 7
+            "minLength": 7,
+            "form": {
+              "templateOptions": {
+                "cssClass": "col-lg-4"
+              }
+            }
           },
           "type": {
             "title": "Type of link",
@@ -1264,7 +1459,10 @@
                   "label": "No info",
                   "value": "noInfo"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "cssClass": "col-lg-4"
+              }
             }
           },
           "content": {
@@ -1415,26 +1613,43 @@
                   "label": "Video",
                   "value": "video"
                 }
-              ]
+              ],
+              "templateOptions": {
+                "cssClass": "col-lg-4"
+              }
             }
           },
           "publicNote": {
-            "title": "Public note",
+            "title": "Public notes",
             "description": "Is displayed next to the link, as additional information.",
             "type": "array",
             "minItems": 1,
             "items": {
+              "title": "Public note",
               "type": "string",
               "minLength": 1,
               "form": {
                 "placeholder": "Example: Access only from the library"
               }
+            },
+            "form": {
+              "templateOptions": {
+                "cssClass": "col"
+              }
             }
+          }
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
           }
         }
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-title"
+        }
       }
     },
     "harvested": {
@@ -3877,7 +4092,10 @@
             "label": "lang_zza",
             "value": "zza"
           }
-        ]
+        ],
+        "templateOptions": {
+          "cssClass": "rero-ils-editor-max-width"
+        }
       }
     },
     "language_script_code": {
@@ -3935,6 +4153,9 @@
         "yid-hebr"
       ],
       "form": {
+        "templateOptions": {
+          "cssClass": "col-lg-5"
+        },
         "hide": true
       }
     },
@@ -3948,11 +4169,21 @@
       "required": [
         "value"
       ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "row"
+        }
+      },
       "properties": {
         "value": {
           "title": "value",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "form": {
+            "templateOptions": {
+              "cssClass": "col-lg-7"
+            }
+          }
         },
         "language": {
           "$ref": "#/definitions/language_script_code"
@@ -3962,6 +4193,11 @@
     "language_script_focus": {
       "title": "Values",
       "type": "object",
+      "form": {
+        "templateOptions": {
+          "cssClass": "row"
+        }
+      },
       "propertiesOrder": [
         "language",
         "value"
@@ -3975,6 +4211,9 @@
           "type": "string",
           "minLength": 1,
           "form": {
+            "templateOptions": {
+              "cssClass": "col-lg-7"
+            },
             "focus": true
           }
         },
@@ -5900,7 +6139,10 @@
             "label": "country_za",
             "value": "za"
           }
-        ]
+        ],
+        "templateOptions": {
+          "cssClass": "col-lg-4"
+        }
       }
     },
     "canton": {
@@ -6040,7 +6282,10 @@
             "label": "canton_zh",
             "value": "zh"
           }
-        ]
+        ],
+        "templateOptions": {
+          "cssClass": "col-lg-4"
+        }
       }
     }
   }


### PR DESCRIPTION
* Adds cssClass property in jsonschema to display fields inline.
* Reorders some properties in jsonschema.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

It's part of https://tree.taiga.io/project/rero21-reroils/us/1296?milestone=263424 (UX of editor)

## Dependencies

Needs https://github.com/rero/rero-ils-ui/pull/267 and https://github.com/rero/ng-core/pull/184

## How to test?

Please do code review only. Testing is described here: https://github.com/rero/ng-core/pull/184

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
