### PR TITLE
nginx logging

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,11 +29,16 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    map "$request:$status:$body_bytes_sent" $loggable {
+            "OPTIONS / HTTP/1.0:200:0" 0;
+            default 1;
+        }
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /var/log/nginx/access.log  main if=$loggable;
 
     sendfile        on;
     tcp_nopush      on;


### PR DESCRIPTION
* Adds a filter to nginx logging to not log access on OPTIONS requests in
  kubernetes deployments.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- Deploy to an kubernetes cluster and verify there no logs with OPTIONS anymore.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
