### PR TITLE
ui: keep current tab

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
+++ b/rero_ils/modules/documents/templates/rero_ils/detailed_view_documents.html
@@ -193,5 +193,18 @@
 {{ super() }}
 {% assets "rero_ils_documents_detailed_js" %}
 <script src="{{ ASSET_URL }}"></script>
+
+<script type="text/javascript">
+$( window ).load(function() {
+    /* Store state of view tab */
+    $('a[data-toggle="tab"]').on('click', function(e) {
+      localStorage.setItem('activeTabDoc', $(this).attr('href'));
+    });
+    var activeTab = localStorage.getItem('activeTabDoc');
+    if(activeTab) {
+      $('.nav-tabs a[href="' + activeTab + '"]').tab('show');
+    }
+});
+</script>
 {% endassets %}
 {% endblock javascript %}

--- a/rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html
+++ b/rero_ils/modules/persons/templates/rero_ils/detailed_view_persons.html
@@ -85,9 +85,9 @@
 $(document).ready(function() {
     /* Store state of view tab */
     $('a[data-toggle="tab"]').on('click', function(e) {
-      localStorage.setItem('activeTab', $(this).attr('href'));
+      localStorage.setItem('activeTabPers', $(this).attr('href'));
     });
-    var activeTab = localStorage.getItem('activeTab');
+    var activeTab = localStorage.getItem('activeTabPers');
     if(activeTab) {
       $('.nav-tabs a[href="' + activeTab + '"]').tab('show');
     }


### PR DESCRIPTION
* Keeps current tab for documents and persons detailed view on page
  reloads.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- selected tabs where lost during reload of page

## How to test?

- select a tab in documents or persons detailed view, select a tab and reload the page or change the language. The selected tab should not change.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
