### PR TITLE
document: delete link to item detail view

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -145,12 +145,7 @@
           <div class="col-10">
             <div class="row">
               <div class="col-sm-4">
-                {% if current_user|can_edit %}
-                <a
-                  href="{{ url_for('invenio_records_ui.item', viewcode=viewcode, pid_value=item.pid) }}">{{ item.barcode }}</a>
-                {% else %}
                 {{ item.barcode }}
-                {% endif %}
               </div>
               <div class="col-sm-3">
                 <i class="fa fa-circle text-{{ 'success' if item.available else 'danger' }}"></i>


### PR DESCRIPTION
In the detail document view, for standard holding, a link is still
present to go on item detail view. As the item detail view is no longer
exists this link cause an error. This PR deletes the link to avoid the
error.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
