### PR TITLE
translation: fix translations API

### DIFF
--- a/rero_ils/modules/views.py
+++ b/rero_ils/modules/views.py
@@ -23,7 +23,7 @@ import os
 from functools import wraps
 
 import polib
-from flask import Blueprint, abort, jsonify
+from flask import Blueprint, abort, current_app, jsonify
 from flask_babelex import get_domain
 from flask_login import current_user
 
@@ -91,5 +91,5 @@ def translations(ln):
             'unable to open po file: {po}'.format(po=po_file_name))
         abort(404)
     for entry in po:
-        data[entry.msgid] = entry.msgstr
+        data[entry.msgid] = entry.msgstr or entry.msgid
     return jsonify(data)

--- a/tests/api/test_translations.py
+++ b/tests/api/test_translations.py
@@ -16,21 +16,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Test translations API."""
-
-
+import mock
 from flask import url_for
 from utils import get_json
 
 
 def test_translations(client, app):
     """Test translations API."""
-    res = client.get(
-        url_for(
-            'api_blueprint.translations',
-            ln='doesnotexists'
-        )
-    )
-    assert res.status_code == 404
 
     for ln in app.extensions.get('invenio-i18n').get_languages():
         res = client.get(
@@ -41,3 +33,35 @@ def test_translations(client, app):
         )
         assert res.status_code == 200
         assert len(get_json(res)) > 0
+
+
+def test_translations_exceptions(client, app):
+    """Test exceptions raised by translations API."""
+
+    # Note : usage of type()
+    #   the usage of `type` allow to create on the fly a class with only
+    #   necessary attributes for the mock. In the Below case, we could replace
+    #   the type(...) by :
+    #
+    #   ... class FakeDomain(object):
+    #   ...     paths = []
+    #
+    magic_mock = mock.MagicMock(return_value=type(
+        'FakeDomain', (object,), dict(paths=[])
+    ))
+    with mock.patch('rero_ils.modules.views.get_domain', magic_mock):
+        res = client.get(
+            url_for(
+                'api_blueprint.translations',
+                ln='dummy_language'
+            )
+        )
+        assert res.status_code == 404
+
+    res = client.get(
+        url_for(
+            'api_blueprint.translations',
+            ln='doesnotexists'
+        )
+    )
+    assert res.status_code == 404


### PR DESCRIPTION
Fixes bug with translations API. If an exception occurred during
execution of this API, the exception should be logged into the
`current_app` logger. But `current_app` context was never loaded from
flask module before.
This PR also hacks translation files data : if a string is not
translated, rather than return an empty string, the original string will
be used.

* Adapts unitest to check theses cases.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
