### PR TITLE
translations: adds editor translations support

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -27,7 +27,7 @@ RUN pip install --upgrade setuptools wheel pip poetry
 # Install Node
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install --no-install-recommends -y nodejs && rm -rf /var/lib/apt/lists/*
-RUN npm install --silent node-sass@4.9.0 clean-css@3.4.19 uglify-js@2.7.3 requirejs@2.2.0 @angular/cli@7.0.4
+RUN npm install --silent  node-sass@4.14.1 clean-css-cli@4.3.0 uglify-js@3.9.4 requirejs@2.3.6
 
 # RUN npm update
 

--- a/babel.ini
+++ b/babel.ini
@@ -42,4 +42,4 @@ extract_messages = $._, jQuery._
 [ignore: **/**/document-v0.0.1.json]
 [ignore: **/**/document-minimal-v0.0.1.json]
 [json: **.json]
-keys_to_translate = ['^title$', '^label$', 'description', 'placeholder', 'validationMessage', 'name', 'add', '403', '.*Message']
+keys_to_translate = ['^title$', '^label$', 'description', 'placeholder', 'name', 'add', '403', '.*Message']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rero-ils"
-version = "0.8.0"
+version = "0.9.1"
 description = "Invenio digital library framework."
 authors = ["RERO <software@rero.ch>"]
 license = "GNU Affero General Public License v3.0"

--- a/rero_ils/config.py
+++ b/rero_ils/config.py
@@ -1540,19 +1540,6 @@ INDEXER_RECORD_TO_INDEX = 'rero_ils.modules.indexer_utils.record_to_index'
 
 SEARCH_UI_SEARCH_API = '/api/documents/'
 
-# RERO Specific Configuration
-# ===========================
-RERO_ILS_BABEL_TRANSLATE_JSON_KEYS = [
-    'title',
-    'label',
-    'description',
-    'placeholder',
-    'validationMessage',
-    'name',
-    'add',
-    '403',
-]
-
 RERO_ILS_APP_BASE_URL = 'https://ils.rero.ch'
 
 RERO_ILS_PERMALINK_RERO_URL = 'http://data.rero.ch/01-{identifier}'

--- a/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
+++ b/rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json
@@ -113,7 +113,7 @@
             }
           },
           "messages": {
-            "alreadyTakenMessage": "The invoice number is already taken"
+            "alreadyTakenMessage": "The invoice number is already taken."
           }
         }
       }
@@ -153,7 +153,6 @@
       "type": "string",
       "format": "date",
       "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
-      "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
       "form": {
         "type": "datepicker",
         "placeholder": "Select a date",
@@ -162,7 +161,7 @@
         ],
         "validation": {
           "messages": {
-            "pattern": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+            "patternMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
           }
         }
       }

--- a/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
+++ b/rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json
@@ -154,7 +154,7 @@
           "form": {
             "validation": {
               "messages": {
-                "pattern": "Should be in the following format: https://ils.rero.ch/api/documents/<PID>"
+                "patternMessage": "Should be in the following format: https://ils.rero.ch/api/documents/<PID>."
               }
             }
           }

--- a/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
+++ b/rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json
@@ -48,7 +48,7 @@
             }
           },
           "messages": {
-            "alreadyTakenMessage": "The order number is already taken"
+            "alreadyTakenMessage": "The order number is already taken."
           }
         }
       }
@@ -155,7 +155,6 @@
       "type": "string",
       "format": "date",
       "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
-      "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
       "form": {
         "type": "datepicker",
         "placeholder": "Select a date",
@@ -164,7 +163,7 @@
         ],
         "validation": {
           "messages": {
-            "pattern": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+            "patternMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
           }
         }
       }

--- a/rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json
+++ b/rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json
@@ -43,7 +43,7 @@
             }
           },
           "messages": {
-            "alreadyTakenMessage": "The budget name is already taken"
+            "alreadyTakenMessage": "The budget name is already taken."
           }
         }
       }
@@ -53,7 +53,6 @@
       "format": "date",
       "title": "Start date",
       "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
-      "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
       "form": {
         "type": "datepicker",
         "wrappers": [
@@ -61,7 +60,7 @@
         ],
         "validation": {
           "messages": {
-            "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
+            "patternMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
           }
         }
       }
@@ -71,7 +70,6 @@
       "format": "date",
       "title": "End date",
       "pattern": "\\d{4}-((0[1-9])|(1[0-2]))-(((0[1-9])|[1-2][0-9])|(3[0-1]))$",
-      "validationMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD).",
       "form": {
         "type": "datepicker",
         "wrappers": [
@@ -79,7 +77,7 @@
         ],
         "validation": {
           "messages": {
-            "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
+            "patternMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
           }
         }
       }

--- a/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json
@@ -1152,7 +1152,6 @@
             "title": "Status",
             "description": "Status of the ISBN/ISSN identifier.",
             "type": "string",
-            "validationMessage": "ISBN/ISSN status should be selected in the list below.",
             "enum": [
               "invalid",
               "cancelled",

--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json
@@ -1168,7 +1168,6 @@
             "title": "Status",
             "description": "Status of the ISBN/ISSN identifier.",
             "type": "string",
-            "validationMessage": "ISBN/ISSN status should be selected in the list below.",
             "enum": [
               "invalid",
               "cancelled",

--- a/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
+++ b/rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json
@@ -146,7 +146,7 @@
             "placeholder": "Vol. {{numbering.vol}}, {{chronology.year}}",
             "validation": {
               "messages": {
-                "pattern": "Should contains at least one variable between {{ }}."
+                "patternMessage": "Should contains at least one variable between {{ }}."
               }
             }
           }

--- a/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
+++ b/rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json
@@ -43,7 +43,7 @@
             }
           },
           "messages": {
-            "alreadyTakenMessage": "The item type name is already taken"
+            "alreadyTakenMessage": "The item type name is already taken."
           }
         }
       }
@@ -84,7 +84,7 @@
             }
           },
           "messages": {
-            "alreadyTakenMessage": "Another online item type exists in this organisation"
+            "alreadyTakenMessage": "Another online item type exists in this organisation."
           }
         }
       }

--- a/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
+++ b/rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json
@@ -44,7 +44,7 @@
             "valueAlreadyExists": {}
           },
           "messages": {
-            "alreadyTakenMessage": "The barcode is already taken"
+            "alreadyTakenMessage": "The barcode is already taken."
           }
         },
         "expressionProperties": {

--- a/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
+++ b/rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json
@@ -170,7 +170,7 @@
         },
         "validation": {
           "messages": {
-            "pattern": "Email should have at least one <code>@</code> and one <code>.</code>"
+            "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
           }
         }
       }

--- a/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
+++ b/rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json
@@ -26,7 +26,6 @@
     "name": {
       "title": "Name",
       "description": "Required. Name of the organisation.",
-      "validationMessage": "Required. Name of the organisation.",
       "type": "string",
       "minLength": 1
     },

--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -64,7 +64,7 @@
       "form": {
         "validation": {
           "messages": {
-            "pattern": "Should be in the ISO 8601, YYYY-MM-DD."
+            "patternMessage": "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
           }
         },
         "placeholder": "Example: 1985-12-29"
@@ -85,7 +85,7 @@
             }
           },
           "messages": {
-            "pattern": "Email should have at least one <code>@</code> and one <code>.</code>",
+            "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>.",
             "alreadyTakenMessage": "This email is already taken."
           }
         }
@@ -115,7 +115,7 @@
       "form": {
         "validation": {
           "messages": {
-            "pattern": "Phone number with the international prefix, without spaces, ie +41221234567."
+            "patternMessage": "Phone number with the international prefix, without spaces, ie +41221234567."
           }
         },
         "placeholder": "Example: +41791231212"

--- a/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
+++ b/rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json
@@ -47,7 +47,7 @@
             }
           },
           "messages": {
-            "alreadyTakenMessage": "The vendor name is already taken"
+            "alreadyTakenMessage": "The vendor name is already taken."
           }
         }
       }
@@ -155,7 +155,7 @@
           "form": {
             "validation": {
               "messages": {
-                "pattern": "Email should have at least one <code>@</code> and one <code>.</code>"
+                "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
               }
             }
           }
@@ -190,8 +190,7 @@
         "postal_code": {
           "title": "Postal code",
           "type": "string",
-          "minLength": 4,
-          "validationMessage": "A valid postal code with a min of 4 characters."
+          "minLength": 4
         },
         "city": {
           "title": "City",
@@ -218,7 +217,7 @@
           "form": {
             "validation": {
               "messages": {
-                "pattern": "Email should have at least one <code>@</code> and one <code>.</code>"
+                "patternMessage": "Email should have at least one <code>@</code> and one <code>.</code>."
               }
             }
           }

--- a/rero_ils/static/scss/rero_ils/variables.scss
+++ b/rero_ils/static/scss/rero_ils/variables.scss
@@ -32,7 +32,7 @@ $footer-height:                       50px;
 
 $form-check-input-margin-y:           .2rem !default;             // controls the checkbox vertical alignement
 
-$static-images:                       "static/images";
+$static-images:                       "/static/images";
 
 
 /*

--- a/rero_ils/translations/ar/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/ar/LC_MESSAGES/messages.po
@@ -6,12 +6,11 @@
 # Translators:
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Aly Badr <aly.badr@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Aly Badr <aly.badr@rero.ch>, 2020\n"
 "Language: ar\n"
@@ -79,8 +78,8 @@ msgid "author__it"
 msgstr "المؤلف"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "اللغة"
 
@@ -367,8 +366,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "المبلغ المخصص لحساب التزويد"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -379,8 +378,8 @@ msgid "Library"
 msgstr "مكتبة"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -389,10 +388,10 @@ msgid "Library URI"
 msgstr "URI للمكتبة"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -405,15 +404,15 @@ msgstr "URI للمكتبة"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "الشبكة"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -421,7 +420,7 @@ msgstr "الشبكة"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "URI للشبكة"
 
@@ -473,7 +472,7 @@ msgid "Price per unit"
 msgstr "السعر للوحدة"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "مبلغ التخفيض"
@@ -495,7 +494,7 @@ msgid "Invoice number"
 msgstr "رقم الفاتورة"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
+msgid "The invoice number is already taken."
 msgstr "رقم الفاتورة محجوز"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
@@ -528,81 +527,81 @@ msgstr "تم الحذف"
 msgid "Date"
 msgstr "التاريخ"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "يجب أن تكون بالتنسيق: 2022-12-31 (YYYY-MM-DD)."
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr "اختار تاريخ"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "يجب أن تكون بالتنسيق: 2022-12-31 (YYYY-MM-DD)."
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "ملاحظات"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "الضرائب"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "نوع الضرائب"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr "الشحن والمناولة"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "ضرائب المقاطعة"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "مختلفة"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "المبلغ"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr "مبلغ التخفيض"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "النسبة المئوية"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr "النسبة المئوية للتخفيض"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "قائمة سطور الفاتورة"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "المورد"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "URI المورد"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "اختار المورد"
 
@@ -658,7 +657,7 @@ msgid "Quantity"
 msgstr "كمية"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "المبلغ الاجمالي"
 
@@ -691,6 +690,12 @@ msgstr "طلب شراء التزويد"
 msgid "Acquisition order URI"
 msgstr "URI لطلب شراء التزويد"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "طلب شراء التزويد"
@@ -708,7 +713,7 @@ msgid "AcqOrder ID"
 msgstr "ID طلب شراء"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
+msgid "The order number is already taken."
 msgstr "رقم طلب شراء محجوز"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
@@ -772,18 +777,18 @@ msgid "Name of the budget."
 msgstr "إسم الميزانية"
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
+msgid "The budget name is already taken."
 msgstr "إسم الميزانية محجوز"
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "تاريخ البدء"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "تاريخ الانتهاء"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "فعال"
 
@@ -990,9 +995,9 @@ msgid "Sound"
 msgstr "صوت"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "فيديو"
 
@@ -1268,11 +1273,11 @@ msgid "type"
 msgstr "نوع"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "البلد"
 
@@ -1797,4749 +1802,4749 @@ msgstr "الحالة"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "حالة معرف ISBN/ISSN"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "حالة المعرف ISBN/ISSN يجب اختيارها من القائمة "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "المواضيع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "موضوع المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "الموضوع"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr "معلومات مطلوبة لتحديد والإتصال بالمصدر الإلكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "سجل URL وحيد هنا."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "مثال: https://www.rero.ch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "تصنيف الرابط"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "إصدار المصدر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "مصدر ذو صلة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "URL مخفي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "لا يوجد معلومات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "تصنيف المحتوى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "يتم عرضه كنص الرابط"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "ملصق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "صوت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "كرت بريدي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "إضافة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "تلخيص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "وثائق العروض"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "خطأ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "لوحة كتب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "استخلاص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "ورقة تعليمية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "الرسوم التوضيحية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "صورة الغلاف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "معلومات التسليم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "معلومات ببليوجرافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "مقدمة/تمهيد"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "صف القراءة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "أدوات المعلم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "ملاحظة الناشر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "ملاحظة عن  المحتوى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "صفحة العنوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "التصوير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "تلخيص"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "الموارد عبر الإنترنت من خلال RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "استعراض الصحافة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "موقع الكتروني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "جدول المحتويات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "النص الكامل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr "ملاحظة عامة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr "يتم عرض بجوار الرابط ، كمعلومات إضافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "مثال: الوصول هنا فقط عن طريق المكتبة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "محصود"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "يتم حصاد المستند أم لا ، سيتم تعطيل إصدار السجل أو ما شابه"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "قيمة اللغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "الأفارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "الأبخازية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "الأتشينيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "الأكولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "الأدانجمية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "الأديغة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "lang_afa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "الأفريهيلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "الأفريقانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "الآينوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "الأكانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "الأكادية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "lang_alb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "الأليوتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "lang_alg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "الألطائية الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "الأمهرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "الإنجليزية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "الأنجيكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "lang_apa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "العربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "الآرامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "الأراغونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "lang_arm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "المابودونغونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "الأراباهو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "lang_art"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "الأراواكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "الأسامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "الأسترية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "lang_ath"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "lang_aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "الأوارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "الأفستية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "الأوادية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "الأيمارا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "الأذربيجانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "lang_bad"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "lang_bai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "الباشكيرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "البلوشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "البامبارا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "البالينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "lang_baq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "الباسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "lang_bat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "البيجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "البيلاروسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "البيمبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "البنغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "lang_ber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "البهوجبورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "lang_bih"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "البيكولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "البينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "البيسلامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "السيكسيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "lang_bnt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "البوسنية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "البراجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "البريتونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "lang_btk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "البرياتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "البجينيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "البلغارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "lang_bur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "البلينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "الكادو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "lang_cai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "الكاريبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "الكتالانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "القوقازيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "السيبيوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "lang_cel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "التشامورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "التشيبشا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "الشيشانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "التشاجاتاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "الصينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "التشكيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "الماري"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "الشينوك جارجون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "الشوكتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "الشيباوايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "الشيروكي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "سلافية كنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "التشوفاشي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "الشايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "lang_cmc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "lang_cnr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "القبطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "الكورنية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "الكورسيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "lang_cpe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "lang_cpf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "lang_cpp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "الكرى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "لغة تتار القرم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "lang_crp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "الكاشبايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "lang_cus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "lang_cze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "الداكوتا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "الدانمركية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "الدارجوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "lang_day"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "الديلوير"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "السلافية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "الدوجريب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "الدنكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "المالديفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "الدوجرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "lang_dra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "صوربيا السفلى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "الديولا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "الهولندية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "lang_dut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "الدايلا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "الزونخاية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "الإفيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "المصرية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "الإكاجك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "الإمايت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "الإنجليزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "الإنجليزية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "الإسبرانتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "الإستونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "الإيوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "الإيوندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "الفانج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "الفاروية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "الفانتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "الفيجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "الفلبينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "الفنلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "lang_fiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "الفون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "الفرنسية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "الفرنسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "الفريزينية الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "الفريزينية الشرقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "الفريزيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "الفولانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "الفريلايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "الجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "الجايو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "الجبيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "lang_gem"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "lang_geo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "الالمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "الجعزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "لغة أهل جبل طارق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "الغيلية الأسكتلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "الأيرلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "الجاليكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "المنكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "الألمانية العليا الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "الألمانية العليا القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "الجندي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "الجورونتالو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "القوطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "الجريبو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "اليونانية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "lang_gre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "الغوارانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "الألمانية السويسرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "الغوجاراتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "غوتشن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "الهيدا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "الكريولية الهايتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "الهوسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "لغة هاواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "العبرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "الهيريرو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "الهيليجينون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "lang_him"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "الهندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "الحثية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "الهمونجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "الهيري موتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "الكرواتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "الصوربية العليا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "الهنغارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "الهبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "الإيبان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "الإيجبو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "lang_ice"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "الإيدو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "السيتشيون يي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "lang_ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "الإينكتيتت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "الإنترلينج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "الإيلوكو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "اللّغة الوسيطة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "lang_inc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "الإندونيسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "lang_ine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "الإنجوشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "الإينبياك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "lang_ira"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "lang_iro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "الإيطالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "الجاوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "اللوجبان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "اليابانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "الفارسية اليهودية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "العربية اليهودية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "الكارا-كالباك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "القبيلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "الكاتشين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "الكالاليست"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "الكامبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "الكانادا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "lang_kar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "الكشميرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "الكانوري"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "الكوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "الكازاخستانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "الكاباردايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "الكازية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "lang_khi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "الخميرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "الخوتانيز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "الكيكيو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "الكينيارواندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "القيرغيزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "الكيمبندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "الكونكانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "الكومي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "الكونغو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "الكورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "الكوسراين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "الكبيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "الكاراتشاي-بالكار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "الكاريلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "lang_kro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "الكوروخ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "الكيونياما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "القموقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "الكردية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "الكتيناي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "اللادينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "اللاهندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "اللامبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "اللاوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "اللاتينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "اللاتفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "الليزجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "الليمبورغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "اللينجالا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "الليتوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "منغولى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "اللوزي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "اللكسمبورغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "اللبا-لؤلؤ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "اللوبا كاتانغا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "الغاندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "اللوسينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "اللوندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "اللو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "الميزو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "lang_mac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "المادريز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "الماجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "المارشالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "المايثيلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "الماكاسار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "المالايالامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "الماندينغ"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "lang_mao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "lang_map"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "الماراثية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "الماساي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "lang_may"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "الموكشا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "الماندار"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "الميند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "الأيرلندية الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "الميكماكيونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "المينانجكاباو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "lang_mis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "lang_mkh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "الملغاشي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "المالطية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "المانشو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "المانيبورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "lang_mno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "الموهوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "المنغولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "الموسي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "لغات متعددة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "lang_mun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "الكريك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "الميرانديز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "الماروارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "lang_myn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "الأرزية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "lang_nah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "lang_nai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "النابولية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "النورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "النافاجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "النديبيل الجنوبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "النديبيل الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "الندونجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "الألمانية السفلى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "النيبالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "النوارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "النياس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "lang_nic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "النيوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "النرويجية نينورسك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "النرويجية بوكمال"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "النوجاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "النورس القديم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "النرويجية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "أنكو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "السوتو الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "lang_nub"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "النوارية التقليدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "النيانجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "النيامويزي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "النيانكول"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "النيورو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "النزيما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "الأوكسيتانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "الأوجيبوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "الأورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "الأورومية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "الأوساج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "الأوسيتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "التركية العثمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "lang_oto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "lang_paa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "البانجاسينان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "البهلوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "البامبانجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "البنجابية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "البابيامينتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "البالوان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "الفارسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "lang_per"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "lang_phi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "الفينيقية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "البالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "البولندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "البوهنبيايان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "البرتغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "lang_pra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "البروفانسية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "البشتو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "الكويتشوا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "الراجاسثانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "الراباني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "الراروتونجاني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "lang_roa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "الرومانشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "الغجرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "lang_rum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "الرندي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "الأرومانيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "الروسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "السانداوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "السانجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "الساخيّة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "lang_sai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "lang_sal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "الآرامية السامرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "السنسكريتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "الساساك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "السانتالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "الصقلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "الأسكتلندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "السيلكب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "lang_sem"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "الأيرلندية القديمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "lang_sgn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "الشان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "السيدامو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "السنهالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "lang_sio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "lang_sit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "lang_sla"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "lang_slo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "السلوفانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "السامي الجنوبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "سامي الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "lang_smi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "اللول سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "الإيناري سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "الساموائية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "السكولت سامي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "الشونا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "السندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "السونينك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "السوجدين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "الصومالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "lang_son"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "السوتو الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "الإسبانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "السردينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "السرانان تونجو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "الصربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "السرر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "lang_ssa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "السواتي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "السوكوما"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "السوندانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "السوسو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "السومارية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "السواحلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "السويدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "سريانية تقليدية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "السريانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "التاهيتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "lang_tai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "التاميلية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "التترية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "التيلوغوية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "التيمن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "التيرينو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "التيتم"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "الطاجيكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "التاغالوغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "التايلاندية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "lang_tib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "التيغرية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "التغرينية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "التيف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "التوكيلاو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "الكلينجون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "التلينغيتية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "التاماشيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "تونجا - نياسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "التونغية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "التوك بيسين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "التسيمشيان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "التسوانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "السونجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "التركمانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "التامبوكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "lang_tup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "التركية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "lang_tut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "التوفالو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "التوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "التوفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "الأدمرت"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "اليجاريتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "الأويغورية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "الأوكرانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "الأمبندو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "لغة غير معروفة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "الأوردية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "الأوزبكية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "الفاي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "الفيندا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "الفيتنامية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "لغة الفولابوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "الفوتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "lang_wak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "الولاياتا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "الواراي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "الواشو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "lang_wel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "lang_wen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "الولونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "الولوفية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "الكالميك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "الخوسا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "الياو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "اليابيز"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "اليديشية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "اليوروبا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "lang_ypk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "الزابوتيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "رموز المعايير الأساسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "الزيناجا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "الزهيونج"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "lang_znd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "الزولو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "الزونية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "بدون محتوى لغوي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "زازا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "قيمات"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "قيمة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "country_aa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "country_abc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "country_ac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "country_aca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "country_ae"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "country_af"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "country_ag"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "country_ai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "country_air"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "country_aj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "country_ajr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "country_aku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "country_alu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "country_am"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "country_an"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "country_ao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "(aq) أنتيغوا وبربودا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "country_aru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "country_as"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "country_at"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "country_au"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "country_aw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "country_ay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "country_azu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "country_ba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "(bb) بربادوس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "(bbc) كولومبيا البريطانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "country_bd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "country_be"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "country_bf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "country_bg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "country_bh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "country_bi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "country_bl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "country_bm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "country_bn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "country_bo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "(bp) جزر سليمان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "country_br"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "country_bs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "(bt) بوتان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "country_bu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "(bv) جزيرة بوفيه"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "(bw) بيلاروس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "country_bwr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "(bx) بروناي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "country_ca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "(cau) كاليفورنيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "country_cb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "(cc) الصين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "country_cd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "country_ce"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "(cf) كونجو برازفيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "country_cg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "country_ch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "country_ci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "(cj) جزر كايمان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "country_ck"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "(cl) تشيلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "country_cm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "country_cn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "country_co"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "country_cou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "country_cp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "(cq) جزر القمر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "country_cr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "country_cs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "country_ctu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "country_cu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "country_cv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "(cw) جزر كوك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "(cx) جمهورية أفريقيا الوسطى"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "country_cy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "(cz) قناة الزون"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "country_dcu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "country_deu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "country_dk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "country_dm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "(dq) دومينيكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "country_dr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "country_ea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "(ec) الإكوادور"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "country_eg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "country_em"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "country_enk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "country_er"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "country_err"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "country_es"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "country_et"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "country_fa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "(fg) غويانا الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "country_fi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "country_fj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "(fk) جزر الفوكلاند"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "country_flu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "country_fm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "(fp) بولينيزيا الفرنسية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "country_fr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "country_fs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "country_ft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "country_gau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "country_gb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "country_gd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "country_ge"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "country_gg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "country_gh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "country_gi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "country_gl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "country_gm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "country_gn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "country_go"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "(gp) غوادلوب"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "country_gr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "country_gs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "country_gsr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "country_gt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "country_gu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "country_gv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "country_gw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "country_gy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "country_gz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "country_hiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "country_hk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "country_hm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "country_ho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "country_ht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "country_hu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "country_iau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "country_ic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "country_idu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "country_ie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "country_ii"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "country_ilu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "country_im"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "country_inu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "country_io"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "(iq) العراق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "country_ir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "country_is"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "country_it"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "country_iu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "country_iv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "(iw) المناطق المنزوعة السلاح بين إسرائيل والأردن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "country_iy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "country_ja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "(je) جيرسي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "country_ji"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "(jm) جامايكا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "country_jn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "country_jo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "country_ke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "(kg) قيرغيزستان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "country_kgr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "country_kn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "country_ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "country_ksu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "country_ku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "(kv) كوسوفو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "country_kyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "country_kz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "country_kzr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "country_lau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "country_lb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "country_le"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "country_lh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "country_li"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "country_lir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "country_ln"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "country_lo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "country_ls"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "country_lu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "country_lv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "country_lvr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "(ly) ليبيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "country_mau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "country_mbc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "country_mc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "country_mdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "country_meu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "country_mf"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "country_mg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "country_mh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "country_miu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "country_mj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "country_mk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "country_ml"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "(mm) مالطا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "country_mnu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "country_mo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "country_mou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "(mp) منغوليا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "(mq) جزر المارتينيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "country_mr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "country_msu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "country_mtu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "country_mu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "country_mv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "country_mvr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "country_mw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "(mx) المكسيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "country_my"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "(mz) موزمبيق"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "country_na"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "country_nbu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "country_ncu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "country_ndu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "country_ne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "country_nfc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "country_ng"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "country_nhu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "country_nik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "country_nju"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "country_nkc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "country_nl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "country_nm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "country_nmu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "country_nn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "country_no"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "country_np"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "country_nq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "country_nr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "country_nsc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "country_ntc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "country_nu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "country_nuc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "country_nvu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "country_nw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "(nx) جزيرة نورفولك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "country_nyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "country_nz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "country_ohu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "country_oku"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "country_onc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "country_oru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "country_ot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "(pau) بنسلفانيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "(pc) جزيرة بيتكيرن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "country_pe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "(pf) جزر باراسيل"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "country_pg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "country_ph"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "country_pic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "country_pk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "country_pl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "country_pn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "country_po"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "country_pp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "country_pr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "(pt) تيمور البرتغالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "(pw) بالاو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "(py) باراغواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "(qa) قطر"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "country_qea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "country_quc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "country_rb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "country_re"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "country_rh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "country_riu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "country_rm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "country_ru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "country_rur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "country_rw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr "country_ry"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "country_sa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "country_sb"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "country_sc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "country_scu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "country_sd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "country_sdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "country_se"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "(sf) ساو تومي وبرينسيبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "country_sg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "country_sh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "country_si"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "country_sj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "country_sk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "country_sl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "country_sm"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "country_sn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "country_snc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "country_so"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "country_sp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "(sq) إسواتيني"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "country_sr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "country_ss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "country_st"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "country_stk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "country_su"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "country_sv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "country_sw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "country_sx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "country_sy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "(sz) سويسرا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "country_ta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "country_tar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "(tc) جزر توركس وكايكوس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "country_tg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "country_th"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "country_ti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "country_tk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "country_tkr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "country_tl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "country_tma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "country_tnu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "country_to"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "country_tr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "country_ts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "country_tt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "country_tu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "country_tv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "country_txu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "country_tz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "country_ua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "(uc) الولايات المتحدة متفرقات. جزر الكاريبي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "country_ug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "country_ui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "country_uik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "country_uk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "country_un"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "country_unr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "country_up"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "country_ur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "country_us"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "country_utu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "(uv) بوركينا فاسو"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "(uy) أورغواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "country_uz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "country_uzr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "country_vau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "(vb) جزر فيرجن البريطانية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "(vc) مدينة الفاتيكان"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "country_ve"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "country_vi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "(vm) فيتنام"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "country_vn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "(vp) أماكن متعددة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "country_vra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "(vs) فيتنام الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "country_vtu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "country_wau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "(wb) برلين الغربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "country_wea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "(wf) جزر والس وفوتونا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "country_wiu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "(wj) الضفة الغربية لنهر الأردن"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "(wk) جزيرة ويك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "country_wlk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "country_ws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "(wvu) فرجينيا الغربية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "country_wyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "country_xa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "(xb) جزر كوكوس (كيلينغ)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "(xc) جزر المالديف"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "(xd) سانت كيتس-نيفيس"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "(xe) جزر مارشال"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "(xf) جزر ميدواي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "country_xga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "country_xh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "(xi) سانت كيتس-نيفيس أنغيلا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "(xj) سانت هيلانة"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "(xk) سانت لوسيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "country_xl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "(xm) سانت فنسنت وجزر غرينادين"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "(xn) مقدونيا الشمالية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "country_xna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "country_xo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "country_xoa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "(xp) جزيرة سبراتلي"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "(xr) التشيك"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "country_xra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "(xs) جورجيا الجنوبية وجزر ساندويتش الجنوبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "(xv) سلوفينيا"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "country_xx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "country_xxc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "country_xxk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "country_xxr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "country_xxu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "country_ye"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "country_ykc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "(ys) الجمهورية اليمنية الديمقراطية الشعبية"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "country_yu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "country_za"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "canton_ag"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "canton_ai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "canton_ar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "canton_be"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "canton_bl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "canton_bs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "canton_fr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "canton_ge"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "canton_gl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "canton_gr"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "canton_ju"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "canton_lu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "canton_ne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "canton_nw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "canton_ow"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "canton_sg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "canton_sh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "canton_so"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "canton_sz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "canton_tg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "canton_ti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "canton_ur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "canton_vd"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "canton_vs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "canton_zg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "canton_zh"
 
@@ -6701,6 +6706,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr ""
@@ -6822,7 +6831,6 @@ msgid "Barcode"
 msgstr "باركود"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "يوجد تصنيف نسخة آخر في هذه الشبكة"
 
@@ -6847,7 +6855,7 @@ msgid "Name of the ItemType."
 msgstr "إسم تصنيف النسخة"
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
+msgid "The item type name is already taken."
 msgstr "إسم تصنيف النسخة محجوز"
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
@@ -6861,6 +6869,10 @@ msgstr "تصنيف نوع الاعارة"
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "اساسي"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "يوجد تصنيف نسخة آخر في هذه الشبكة"
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6901,7 +6913,8 @@ msgid "Item ID"
 msgstr "رقم النسخة"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
 msgstr "الرقم الممغنط محجوز"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
@@ -6951,7 +6964,7 @@ msgstr "رقم المكتبة"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "رمز"
 
@@ -6964,7 +6977,7 @@ msgid "Name of the library."
 msgstr "إسم المكتبة"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "عنوان"
 
@@ -6976,7 +6989,7 @@ msgstr "عنوان المكتبة"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "البريد الإلكتروني"
 
@@ -7194,6 +7207,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7279,39 +7299,38 @@ msgid "Organisation ID"
 msgstr "ID للشبكة"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "إجباري. إسم الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "عنوان الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "كود الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "ال ID الحالي للميزانية"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "ال ID الحالي لميزانية الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "العملة الافتراضية"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "عملة الشبكة"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "مصدر مباشر محصود"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "مصدر مباشر محصود كما تم اعداده للكتاب الالكتروني"
 
@@ -7513,6 +7532,10 @@ msgstr "إسم العائلة"
 msgid "Date of birth"
 msgstr "تاريخ الميلاد"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "مثال: 1985-12-29"
@@ -7543,20 +7566,26 @@ msgstr "رقم البريد"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "المدينة"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "رقم الهاتف"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "رقم الهاتف مع البادئة الدولية ، دون مسافات"
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "رقم الهاتف مع البادئة الدولية ، دون مسافات"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7579,10 +7608,6 @@ msgstr "URI ل تصنيف مستخدم"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "الرقم الممغنط او رقم البطاقة للمستخدم"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "الرقم الممغنط محجوز"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7830,7 +7855,7 @@ msgid "Vendor ID"
 msgstr "ID المورد"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
+msgid "The vendor name is already taken."
 msgstr "اسم المورد محجوز"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
@@ -7865,15 +7890,11 @@ msgstr "شخص الاتصال"
 msgid "Name of the vendor contact person."
 msgstr "إسم شخص الاتصال "
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "رمز بريدي صالح لا يقل عن 4 أحرف."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "العملة"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "نسبة VAT"
 
@@ -8053,4 +8074,10 @@ msgstr "انقر هنا لإعادة تعيين كلمة المرور الخاص
 
 #~ msgid "requested"
 #~ msgstr "مطلوب"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "الرقم الممغنط محجوز"
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "رمز بريدي صالح لا يقل عن 4 أحرف."
 

--- a/rero_ils/translations/de/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/de/LC_MESSAGES/messages.po
@@ -12,12 +12,11 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
 # Peter Weber <peter.weber@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Peter Weber <peter.weber@rero.ch>, 2020\n"
 "Language: de\n"
@@ -84,8 +83,8 @@ msgid "author__it"
 msgstr "Autor"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "Sprache"
 
@@ -372,8 +371,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "Zugewiesener Betrag"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -384,8 +383,8 @@ msgid "Library"
 msgstr "Bibliothek"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -394,10 +393,10 @@ msgid "Library URI"
 msgstr "URI der Bibliothek"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -410,15 +409,15 @@ msgstr "URI der Bibliothek"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "Organisation"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -426,7 +425,7 @@ msgstr "Organisation"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "URI der Organisation"
 
@@ -478,7 +477,7 @@ msgid "Price per unit"
 msgstr "Preis pro Einheit"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "Rabattbetrag"
@@ -500,7 +499,7 @@ msgid "Invoice number"
 msgstr "Rechnungsnummer"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
+msgid "The invoice number is already taken."
 msgstr "Die Rechnungsnummer ist bereits vergeben."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
@@ -533,81 +532,81 @@ msgstr "Gelöscht"
 msgid "Date"
 msgstr "Datum"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "Sollte im folgenden Format sein: 2022-12-31 (JJJJ-MM-TT)"
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr "Wähle ein Datum"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "Sollte im folgenden Format sein: 2022-12-31 (JJJJ-MM-TT)"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "Anmerkung"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "Steuern"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "Typ der Steuer"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr "Versand und Handhabung"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "Staatliche Steuern"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "Sonstiges"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Betrag"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr "Rabattbetrag"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "Prozentualer Anteil"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr "Rabatt-Prozentsatz"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "Liste der Rechnungszeilen"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "Lieferant"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "URI des Lieferanten"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "Wählen Sie einen Lieferanten"
 
@@ -663,7 +662,7 @@ msgid "Quantity"
 msgstr "Anzahl"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "Gesamtbetrag"
 
@@ -696,6 +695,12 @@ msgstr "Bestellung"
 msgid "Acquisition order URI"
 msgstr "URI der Bestellung"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "Bestellung"
@@ -713,8 +718,8 @@ msgid "AcqOrder ID"
 msgstr "ID der Bestellung"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
-msgstr "Die Bestellnummer ist bereits vergeben"
+msgid "The order number is already taken."
+msgstr "Die Bestellnummer ist bereits vergeben."
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
 msgid "Order type"
@@ -777,18 +782,18 @@ msgid "Name of the budget."
 msgstr "Name des Budgets."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
-msgstr "Der Name des Budgets ist bereits vergeben"
+msgid "The budget name is already taken."
+msgstr "Der Name des Budgets ist bereits vergeben."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "Datum 1"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "Datum 2"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "Aktiv"
 
@@ -997,9 +1002,9 @@ msgid "Sound"
 msgstr "Ton"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "Film"
 
@@ -1282,11 +1287,11 @@ msgid "type"
 msgstr "Typ"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Land"
 
@@ -1829,4751 +1834,4751 @@ msgstr "Status"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status des ISBN/ISSN Identifikators"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Der ISBN/ISSN-Status muss in der folgenden Liste ausgewählt werden."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "Schlagworte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "Schlagwort der Ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "Schlagwort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr "Elektronische Standorte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informationen, die benötigt werden, um eine elektronische Ressource zu "
 "finden und darauf zuzugreifen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr "Elektronischer Standort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "Geben Sie eine eindeutige URL ein."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "Beispiel: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "Typ des Links"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "Andere version der Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "Verwandte Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "versteckte URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "keine Informationen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "Inhaltstyp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "Wird als Text des Links angezeigt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "Plakat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "Postkarte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "Ergänzung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "Protokoll"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "Ausstellungsdokumentation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "Exlibris"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "Auszug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "Unterrichtsmaterial"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "Abbildungen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "Titelbild"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "Informationen zum Transport"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Biografische Angaben"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "Einführung/Vorwort"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "Klassenlektüre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "Themenkoffer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "Hinweis des Verlags"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "Inhaltstext"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "Titelblatt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "Fotografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "Zusammenfassung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "Online-Ressource über RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "Presseschau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "Website"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "Inhaltsverzeichnis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "Volltext"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr "Öffentliche Anmerkung"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr "Wird neben dem Link als zusätzliche Information angezeigt."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "Beispiel: Zugang nur von der Bibliothek aus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "Gesammelt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Dokument wird gesammelt oder nicht, deaktiviert Bearbeitung von Records"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "Sprachewert."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "Abchasisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "Achinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "Acholi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "Dangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "Adygeisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "Afroasiatische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "Albanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "Aleutisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "Algonkin Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "Südaltaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "Amharisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "Altenglisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "Apache Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "Reichsaramäisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "Aragonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "Armenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "Konstruierte Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "Assamesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "Athapaskische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "Australische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "Awarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "Aserbaidschanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "Banda Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "Bamileke Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "Baschkirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "Belutschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "Balinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "Basaa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "Baltische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "Bedscha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "Weissrussisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "Bengalisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "Berbersprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "Bikolano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "Edo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "Blackfoot"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "Bantusprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "Braj-Bhakha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "Bretonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "Bataksprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "Burjatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "Buginesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "Bulgarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "Birmanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "Blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "Mesoamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "Karib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "Katalanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "Kaukasisch (anderes)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "Keltische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "Tschechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "Tschagataisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "Chinesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "Chuukesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "Chinook Wawa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "Kirchenslawisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "Tschuwaschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "Chamische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "Montenegrinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "Kornisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "Korsisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "Englisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "Französisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "Portugiesisch-basierte Kreols und Pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "Krimtatarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "Kreol- und Pidginsprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "Kaschubisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "Kuschitische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "Tschechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "Dänisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "Darginisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "Land-Dayak-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "Delawarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "Dhivehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "Dravidische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "Niedersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "Mittelniederländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "Niederländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "Dioula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "Ägyptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "Elamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "Englisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "Mittelenglisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "Estnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "Färöisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "Fante"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "Fidschi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "Finnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "Finno-ugrische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "Französisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "Mittelfranzösisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "Altfranzösisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "Nordfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "Ostfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "Westfriesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "Fulfulde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "Germanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "Deutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "Geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "Kiribatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "Schottisch-gälisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "Irisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "Mittelhochdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "Althochdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "Gotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "Altgriechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "Griechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "Schweizerdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "Gwich'in (Sprache)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "Haitianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "Hawaiisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "Hebräisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "Otjiherero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "West-Paharisprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "Hethitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "Hmong-Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "Hiri-Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "Obersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "Ungarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "Hoopa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "Isländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "Ijo-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "Ilokano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "Indoarische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "Indogermanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "Inguschisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "Iranische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "Irokesische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "Italienisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "Javanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "Japanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "Judäo-Persisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "Judäo-Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "Karakalpakisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "Jingpo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "Grönländisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "Kikamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "Karenische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "Kaschmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "Kasachisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "Kabardinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "Khoisansprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "Khotanesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "Kirgisisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "Kikongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "Koreanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "Kosraeanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "Karatschai-balkarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "Kru-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "Kwanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "Kumykisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "Kurdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "Kutanaha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "Judenspanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "Laotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "Latein"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "Lettisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "Lesgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "Limburgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "Lingála"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "Litauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "Lomongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "Luxemburgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "Tschiluba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "Kiluba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "Chilunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "Luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "Mazedonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "Maduresisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "Magadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "Marschallesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "Makassar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "Manding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "Austronesische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "Maa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "Malaiisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "Mokschanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "Mittelirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "Míkmawísimk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "Minangkabauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "Verschiedene Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "Mon-Khmer-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "Maltesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "Mandschurisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "Meithei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "Manobo Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "Mongolisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "Mòoré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "Mehrsprachig"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "Munda-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "Muskogee-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "Mirandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "Maya Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "Ersjanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "Nordamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "Neapolitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "Nauruisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "Süd-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "Nord-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "Niederdeutsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "Niger-Kongo-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "Niueanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "Nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "Bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "Nogaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "Altnordisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "Norwegisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "Nord-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "Nubische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "Klassisches Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "Chichewa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "Nyamwesi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "Runyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "Runyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "Nzema"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "Okzitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "Ojibwe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "Osmanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "Oto-Pame-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "Papuasprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "Pangasinensisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "Mittelpersisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "Kapampangan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "Papiamentu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "Palauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "Altpersisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "Persisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "Philippinische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "Phönizisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "Polnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "Pohnpeanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "Portugiesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "Altokzitanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "Paschtunisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "Rarotonganisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "Romanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "Bündnerromanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "Rumänisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "Aromunisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "Sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "Jakutisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "Südamerikanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "Salish-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "Samaritanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "Sizilianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "Scots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "Selkupisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "Semitische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "Altirisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "Gebärdensprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "Sidama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "Singhalesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "Sioux-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "Sinotibetische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "Slawische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "Slowakisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "Slowenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "Südsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "Nordsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "Samische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "Lulesamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "Inarisamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "Samoanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "Skoltsamisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "Somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "Songhai-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "Sesotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "Spanisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "Sardisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "Serbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "Nilosaharanische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "Sundanesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "Susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "Sumerisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "Suaheli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "Schwedisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "Nordost-Neuaramäisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "Tahitianisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "Tai-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "Tatarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "Temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "Terena"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "Tadschikisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "Tibetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "Tokelauisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "Klingonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "Tuareg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "Tongaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "Setswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "Xitsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "Turkmenisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "Tupí-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "Türkisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "Altaische Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "Tuvaluisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "Tuwinisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "Udmurtisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "Ugaritisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "Uigurisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "Ukrainisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "Unbekannte Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "Usbekisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "Tshivenda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "Vietnamesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "Wotisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "Wakash-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "Wáray-Wáray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "Washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "Walisisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "Sorbische Sprache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "Wallonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "Kalmückisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "Yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "Yapesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "Yupik-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "Zapotekisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "Bliss-Symbole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "Zande-Sprachen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "Zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "Keine Sprachinhalte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "Zazaisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "Werte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "Wert"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "Albanien (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "Ashmore und Cartierinseln (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "Australisches Hauptstadtterritorium (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "Algerien (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "Argentinien (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "Armenien (Republik) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "Armenische Sozialistische Sowjetrepublik (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "Aserbaidschan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "Aserbaidschanische Sozialistische Sowjetrepublik (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "Antigua und Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "Amerikanisch-Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "Australien (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "Österreich (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "Antarktis (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "Bahrain (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "Britisch-Kolumbien (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "Belgien (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "Bangladesch (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "Britisches Territorium im Indischen Ozean (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "Brasilien (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "Bermudainseln (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "Bosnien und Herzegowina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "Bolivien (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "Salomonen (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "Botsuana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "Bulgarien (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "Bouvetinsel (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "Weißrussland (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "Weißrussische Sozialistische Sowjetrepublik (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "Karibische Niederlande (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "Kalifornien (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "Kambodscha (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "Tschad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "Kongo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "Kongo (Demokratische Republik) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "China (Republik: 1949- ) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "Kroatien (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "Kaimaninseln (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "Kolumbien (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "Kamerun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "Kanada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "Kanton und Enderbury-Inseln (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "Komoren (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "Tschechoslowakei (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "Kuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "Kap Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "Cookinseln (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "Zentralafrikanische Republik (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "Zypern (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "Panamakanalzone (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "Dänemark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "Dominikanische Republik (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "Äquatorialguinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "Osttimor (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "England (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "Estland (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "Estnische Sozialistische Sowjetrepublik (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "Äthiopien (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "Färöer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "Französisch-Guayana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "Finnland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "Fidschi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "Falklandinseln (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "Mikronesien (Föderierten Staaten) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "Französisch-Polynesien (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "Frankreich (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "Französische Süd- und Antarktisgebiete (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "Dschibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "OstDeutschland (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "Grönland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "Gilbert- und Elliceinseln (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "Gabun (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "Griechenland (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "Georgien (Republik) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "Georgische Sozialistische Sowjetrepublik (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "Deutschland (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "Gazastreifen (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "Sonderverwaltungsregion Hongkong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "Heard und McDonald-Inseln (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "Ungarn (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "Island (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "Irland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "Indien (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "Insel Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "Indonesien (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "Italien (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "Israel-Syrien Entmilitarisierte Zonen (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "Elfenbeinküste (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "Israelisch-jordanische entmilitarisierte Zonen (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "Irak-Saudi-Arabien Neutrale Zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "Johnston-Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "Jamaika (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "Jordanien (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "Kirgisistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "Kirgisische Sozialistische Sowjetrepublik (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "Nordkorea (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "Südkorea (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "Kasachstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "Kasachische Sozialistische Sowjetrepublik (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "Libanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "Litauen (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "Litauen (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "Zentrale und südliche Linieninseln (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "Luxemburg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "Lettland (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "Lettland (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "Libyen (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "Madagaskar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "Sonderverwaltungsregion Macau (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "Mongolei (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "Marokko (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "Mauretanien (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "Republik Moldau (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "Moldauische Sozialistische Sowjetrepublik (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "Mexiko (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "Mosambik (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "Niederländische Antillen (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "Niederlande (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "Neufundland und Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "Nordirland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "Neubraunschweig (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "Neukaledonien (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "Nördliche Marianen (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "Norwegen (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "Neuschottland (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "Nordwest-Territorien (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "Nördliche Marianen (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "Norfolkinsel (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "New York (Staat) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "Neuseeland (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "Insel Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "Paracel-Inseln (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "Philippinen (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "Prinz-Edward-Insel (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "Polen (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "Papua-Neuguinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "Portugiesisch-Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "Katar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "Quebec (Provinz) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "Serbien (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "Simbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "Rumänien (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "Russland (Föderation) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "Russische Sozialistische Föderative Sowjetrepublik (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr "Ryūkyū-Inseln (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "Südafrika (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "Spitzbergen (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "Südsudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "Seychellen (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "São Tomé und Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "Spanisch Nordafrika (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "Singapur (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "Sankt Martin (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "Spanien (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "Westsahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "St. Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "Schottland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "Saudi-Arabien (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "Schwaneninseln (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "Schweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "Syrien (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "Schweiz (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "Tadschikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "Tadschikische Sozialistische Sowjetrepublik (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "Turks- und Caicosinseln (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "Tunesien (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "Turkmenische Sozialistische Sowjetrepublik (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "Tasmanien (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "Trinidad und Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "Vereinigte Arabische Emirate (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "Treuhand-Territorium der Pazifischen Inseln (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "Türkei (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "Tansania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "Ägypten (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "Vereinigte Staaten Diverses Karibische Inseln (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "Vereinigtes Königreich Diverses Inseln (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "Vereinigtes Königreich Diverses Inseln (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "Vereinigtes Königreich (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "Vereinigte Staaten Diverses Pazifische Inseln (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "Sowjetunion (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "Vereinigte Staaten (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "Usbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "Usbekische Sozialistische Sowjetrepublik (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "Britische Jungferninseln (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "Vatikanstadt (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "Amerikanische Jungferninseln (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "Vietnam, Norden (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "Verschiedene Orte (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "Vietnam, Süden (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "Washington (Staat) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "Westberlin (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "Westaustralien (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "Wallis und Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "Westjordanland (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "Wake (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "Weihnachtsinsel (Indischer Ozean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "Kokosinseln (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "Malediven (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "St. Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "Marshallinseln (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "Midway-Inseln (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "Korallenmeer-Insel-Territorium (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "St. Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "Heilige Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "St. Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "St. Pierre und Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "St. Vincent und die Grenadinen (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "Nordmazedonien (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "Neusüdwales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "Slowakei (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "Nordterritorium (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "Spratly-Insel (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "Tschechien (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "Südaustralien (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "Südgeorgien und die Südlichen Sandwichinseln (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "Slowenien (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "Kein Ort, unbekannt oder unbestimmt (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "Kanada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "Vereinigtes Königreich (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "Sowjetunion (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "Vereinigte Staaten (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "Jemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "Yukon-Territorium (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "Jemen (Demokratische Volksrepublik) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "Serbien und Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "Sambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Kantone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "AG (Aargau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "AI (Appenzell Innerrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "AR (Appenzell Ausserrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "BE (Bern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "BL (Basel-Landschaft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "BS (Basel-Stadt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "FR (Freiburg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "GE (Genf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "GL (Glarus)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "GR (Graubünden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "LU (Luzern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "NE (Neuenburg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "SG (St. Gallen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "SH (Schaffhausen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "SO (Solothurn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "TG (Thurgau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "TI (Tessin)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "VD (Waadt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "VS (Wallis)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "ZH (Zürich)"
 
@@ -6740,6 +6745,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr "Vorhersage-Muster"
@@ -6871,7 +6880,6 @@ msgid "Barcode"
 msgstr "Strichcode"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Ein anderer Exemplartyp \"online\" existiert bereits in Organisation"
 
@@ -6896,8 +6904,8 @@ msgid "Name of the ItemType."
 msgstr "Name des Exemplartypen."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
-msgstr "Der Name des Exemplartypen ist bereits vergeben"
+msgid "The item type name is already taken."
+msgstr "Der Name des Exemplartypen ist bereits vergeben."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
 msgid "Description of the ItemType."
@@ -6910,6 +6918,10 @@ msgstr "Typ der Ausleihkategorie"
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "Standard"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "Ein anderer Exemplartyp \"online\" existiert bereits in Organisation."
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6950,8 +6962,9 @@ msgid "Item ID"
 msgstr "PID des Exemplars"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
-msgstr "Der Barcode ist bereits vergeben"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
+msgstr "Der Barcode ist bereits vergeben."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -7000,7 +7013,7 @@ msgstr "ID der Bibliothek"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "Code"
 
@@ -7013,7 +7026,7 @@ msgid "Name of the library."
 msgstr "Name der Bibliothek."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "Adresse"
 
@@ -7025,7 +7038,7 @@ msgstr "Bibliotheksaddresse."
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "E-Mail"
 
@@ -7253,6 +7266,13 @@ msgstr ""
 "Geben Sie eineE-Mail-Adresse an, die für die Benachrichtigung verwendet "
 "wird."
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7340,39 +7360,38 @@ msgid "Organisation ID"
 msgstr "ID der Organisation"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "Erforderlich. Name der Organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "Einrichtungsadresse."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "Organisationscode."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "Aktuelle ID des Budgets"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "Die Die des aktuellen Budgets der Organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "Standardwährung"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "Die Standardwährung der Organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "Online gesammelte Quelle"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Online gesammelte Quelle, wie im Ebook-Server eingestellt."
 
@@ -7578,6 +7597,10 @@ msgstr "Nachname"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Beispiel: 1985-12-29"
@@ -7608,20 +7631,26 @@ msgstr "Postleitzahl"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "Stadt"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "Telefonnummer"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "Telefonnummer mit internationaler Anzeige, ohne Leerzeichen."
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "Telefonnummer mit internationaler Anzeige, ohne Leerzeichen."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7644,10 +7673,6 @@ msgstr "URI des Lesertypen"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "Lesers Barcode oder Kartennummer"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "Der Barcode ist bereits vergeben."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7895,8 +7920,8 @@ msgid "Vendor ID"
 msgstr "ID des Lieferanten"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
-msgstr "Der Name des Lieferanten ist bereits vergeben"
+msgid "The vendor name is already taken."
+msgstr "Der Name des Lieferanten ist bereits vergeben."
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
 msgid "Website"
@@ -7930,15 +7955,11 @@ msgstr "Name des Kontaktes"
 msgid "Name of the vendor contact person."
 msgstr "Name der Kontaktperson des Lieferanten."
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "Eine gültige Postleitzahl mit mindestens 4 Zeichen."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "Währung"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "Mehrwertsteuersatz"
 
@@ -8114,4 +8135,10 @@ msgstr "Hier klicken um Passwort zurückzusetzen."
 
 #~ msgid "requested"
 #~ msgstr "Bestellt"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "Der Barcode ist bereits vergeben"
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "Eine gültige Postleitzahl mit mindestens 4 Zeichen."
 

--- a/rero_ils/translations/en/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/en/LC_MESSAGES/messages.po
@@ -12,12 +12,11 @@
 # Bertrand Zuchuat, 2020
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: en\n"
@@ -84,8 +83,8 @@ msgid "author__it"
 msgstr "author"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "language"
 
@@ -372,8 +371,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "Allocated amount."
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -384,8 +383,8 @@ msgid "Library"
 msgstr "Library"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -394,10 +393,10 @@ msgid "Library URI"
 msgstr "Library URI"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -410,15 +409,15 @@ msgstr "Library URI"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "Organisation"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -426,7 +425,7 @@ msgstr "Organisation"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "Organisation URI"
 
@@ -478,7 +477,7 @@ msgid "Price per unit"
 msgstr "Price per unit"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "Discount amount"
@@ -500,8 +499,8 @@ msgid "Invoice number"
 msgstr "Invoice number"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
-msgstr "The invoice number is already taken"
+msgid "The invoice number is already taken."
+msgstr "The invoice number is already taken."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
 msgid "Invoice price"
@@ -533,81 +532,81 @@ msgstr "Deleted"
 msgid "Date"
 msgstr "Date"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr "Select a date"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "Notes"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "Taxes"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "Type of taxe"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr "Shipping and handling"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "State taxes"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "Miscellaneous"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Amount"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr "Discount"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "Percentage"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr "Discount percentage."
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "List of invoice lines"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "Vendor"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "Vendor URI"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "Choose a vendor"
 
@@ -663,7 +662,7 @@ msgid "Quantity"
 msgstr "Quantity"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "Total amount"
 
@@ -696,6 +695,12 @@ msgstr "Order"
 msgid "Acquisition order URI"
 msgstr "Order URI"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "Order"
@@ -713,8 +718,8 @@ msgid "AcqOrder ID"
 msgstr "Order ID"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
-msgstr "The order number is already taken"
+msgid "The order number is already taken."
+msgstr "The order number is already taken."
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
 msgid "Order type"
@@ -777,18 +782,18 @@ msgid "Name of the budget."
 msgstr "Name of the budget."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
-msgstr "The budget name is already taken"
+msgid "The budget name is already taken."
+msgstr "The budget name is already taken."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "Start date"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "End date"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "Active"
 
@@ -995,9 +1000,9 @@ msgid "Sound"
 msgstr "Sound"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "Video"
 
@@ -1277,11 +1282,11 @@ msgid "type"
 msgstr "type"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Country"
 
@@ -1806,4749 +1811,4749 @@ msgstr "Status"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status of the ISBN/ISSN identifier."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "ISBN/ISSN status should be selected in the list below."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "Subjects"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "Subject of the resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "Subject"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Information needed to locate and access an electronic resource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "Record a unique URL here."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "Example: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "Type of link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "Resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "Version of resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "Related resource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "Hidden URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "No info"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "Content type"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "Is displayed as the text of the link."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "Poster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "Postcard"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "Addition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "Debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "Exhibition documentation"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "Bookplate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "Extract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "Educational sheet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "Illustrations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "Cover image"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "Delivery information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Biographical information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "Introduction/preface"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "Class reading"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "Teacher's kit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "Publisher's note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "Note on content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "Title page"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "Photography"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "Summarization"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "Online resource via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "Press review"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "Web site"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "Full text"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr "Public note"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr "Is displayed next to the link, as additional information."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "Example: Access only from the library"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "Harvested"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Document is harvested or not, will disable record edition or similar."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "Language value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "Abkhazian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "Achinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "Acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "Adyghe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "Afroasiatic (other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "Afrihili (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "Akkadian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "Albanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "Aleut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "Algonquian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "Altai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "Amharic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "English, Old (ca. 450-1100)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "Apache languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "Arabic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "Aramaic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "Aragonese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "Armenian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "Mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "Artificial (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "Assamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "Bable"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "Athapascan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "Australian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "Avaric"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "Avestan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "Azerbaijani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "Banda languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "Bamileke languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "Bashkir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "Baluchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "Balinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "Basque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "Basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "Baltic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "Beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "Belarusian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "Bengali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "Berber (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "Bihari (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "Edo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "Bantu (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "Bosnian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "Braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "Breton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "Batak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "Buriat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "Bugis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "Bulgarian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "Burmese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "Bilin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "Central American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "Carib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "Catalan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "Caucasian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "Celtic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "Chechen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "Chinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "Chuukese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "Chinook jargon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "Church Slavic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "Chuvash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "Chamic languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "Montenegrin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "Coptic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "Corsican"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "Creoles and Pidgins, English-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "Creoles and Pidgins, French-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "Creoles and Pidgins, Portuguese-based (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "Crimean Tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "Creoles and Pidgins (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "Kashubian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "Cushitic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "Czech"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "Danish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "Dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "Delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "Divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "Dravidian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "Lower Sorbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "Dutch, Middle (ca. 1050-1350)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "Dutch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "Egyptian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "Elamite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "English"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "English, Middle (1100-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "Estonian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "Faroese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "Fijian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "Finnish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "Finno-Ugrian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "French"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "French, Middle (ca. 1300-1600)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "French, Old (ca. 842-1300)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "North Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "East Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "Frisian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "Fula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "Gã"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "Germanic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "Georgian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "Ethiopic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "Gilbertese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "Scottish Gaelic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "Irish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "Galician"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "German, Middle High (ca. 1050-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "German, Old High (ca. 750-1050)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "Gothic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "Greek, Ancient (to 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "Greek, Modern (1453- )"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "Swiss German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "Gwich'in"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "Haitian French Creole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "Hawaiian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "Hebrew"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "Herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "Western Pahari languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "Hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "Croatian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "Upper Sorbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "Hungarian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "Icelandic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "Sichuan Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "Ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "Interlingua (International Auxiliary Language Association)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "Indic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "Indonesian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "Indo-European (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "Ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "Iranian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "Iroquoian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "Javanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "Lojban (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "Japanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "Judeo-Persian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "Judeo-Arabic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "Kara-Kalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "Kabyle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "Kalâtdlisut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "Karen languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "Kashmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "Kazakh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "Kabardian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "Khoisan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "Khotanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "Kyrgyz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "Korean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "Kosraean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "Karachay-Balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "Karelian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "Kru (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "Kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "Kurdish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "Kootenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "Lahndā"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "Lamba (Zambia and Congo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "Lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "Latin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "Latvian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "Lezgian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "Limburgish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "Lithuanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "Mongo-Nkundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "Luxembourgish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "Ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "Luo (Kenya and Tanzania)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "Lushai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "Macedonian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "Madurese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "Marshallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "Makasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "Austronesian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "Maasai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "Malay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "Moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "Irish, Middle (ca. 1100-1550)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "Micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "Miscellaneous languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "Mon-Khmer (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "Maltese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "Manchu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "Manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "Manobo languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "Mongolian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "Mooré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "Multiple languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "Munda (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "Creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "Mirandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "Mayan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "Erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "North American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "Neapolitan Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "Nauru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "Ndebele (South Africa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "Ndebele (Zimbabwe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "Low German"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "Niger-Kordofanian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "Niuean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "Norwegian (Nynorsk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "Norwegian (Bokmål)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "Old Norse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "Norwegian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "N'Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "Northern Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "Nubian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "Newari, Old"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "Occitan (post-1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "Ossetic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "Turkish, Ottoman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "Otomian languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "Papuan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "Papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "paluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "Old Persian (ca. 600-400 B.C.)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "Persian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "Philippine (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "Phoenician"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "Polish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "Pohnpeian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "Portuguese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "Prakrit languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "Provençal (to 1500)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "Pushto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "Romance (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "Raeto-Romance"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "Romanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "Rundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "Aromanian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "Russian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "Sango (Ubangi Creole)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "Yakut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "South American Indian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "Salishan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "Samaritan Aramaic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "Sicilian Italian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "Scots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "Selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "Semitic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "Irish, Old (to 1100)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "Sign languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "Sinhalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "Siouan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "Sino-Tibetan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "Slavic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "Slovak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "Slovenian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "Southern Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "Northern Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "Lule Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "Inari Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "Samoan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "Skolt Sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "Sogdian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "Somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "Songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "Spanish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "Sardinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "Sranan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "Serbian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "Nilo-Saharan (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "Sundanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "Susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "Sumerian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "Swedish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "Syriac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "Syriac, Modern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "Tahitian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "Tai (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "Tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "Temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "Terena"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "Tajik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "Tibetan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "Tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "Tokelauan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "Klingon (Artificial language)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "Tonga (Nyasa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "Tongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "Turkmen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "Tupi languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "Turkish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "Altaic (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "Tuvaluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "Tuvinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "Udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "Ugaritic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "Uighur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "Ukrainian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "Undetermined"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "Uzbek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "Venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "Vietnamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "Votic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "Wakashan languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "Wolayta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "Waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "Washoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "Sorbian (Other)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "Walloon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "Oirat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "Yao (Africa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "Yapese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "Yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "Yupik languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "Blissymbolics"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "Zande languages"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "No linguistic content"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "Zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "Values"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "value"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "Ashmore and Cartier Islands (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "Australian Capital Territory (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "Algeria (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "Armenia (Republic) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "Armenian S.S.R. (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "Azerbaijan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "Azerbaijan S.S.R. (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "Antigua and Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "American Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "Antarctica (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "Bahrain (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "British Columbia (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "Belgium (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "British Indian Ocean Territory (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "Brazil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "Bermuda Islands (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "Bosnia and Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "Solomon Islands (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "Bouvet Island (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "Belarus (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "Byelorussian S.S.R. (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "Caribbean Netherlands (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "California (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "Cambodia (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "Chad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "Congo (Democratic Republic) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "China (Republic : 1949- ) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "Croatia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "Cayman Islands (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "Cameroon (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "Canton and Enderbury Islands (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "Comoros (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "Czechoslovakia (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "Cabo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "Cook Islands (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "Central African Republic (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "Cyprus (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "Canal Zone (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "Denmark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "Dominican Republic (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "Equatorial Guinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "Timor-Leste (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "England (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "Estonia (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "Ethiopia (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "Faroe Islands (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "French Guiana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "Finland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "Fiji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "Falkland Islands (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "Micronesia (Federated States) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "French Polynesia (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "France (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "Germany (East) (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "Greenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "Gilbert and Ellice Islands (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "Greece (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "Georgia (Republic) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "Georgian S.S.R. (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "Germany (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "Gaza Strip (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "Heard and McDonald Islands (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "Hungary (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "Iceland (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "Ireland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "Isle of Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "Iraq (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "Italy (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "Israel-Syria Demilitarized Zones (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "Côte d'Ivoire (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "Israel-Jordan Demilitarized Zones (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "Iraq-Saudi Arabia Neutral Zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "Johnston Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "Jordan (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "Kyrgyzstan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "Kirghiz S.S.R. (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "Korea (North) (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "Korea (South) (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "Kazakhstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "Kazakh S.S.R. (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "Lebanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "Lithuania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "Lithuania (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "Central and Southern Line Islands (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "Luxembourg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "Latvia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "Latvia (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "Libya (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "Morocco (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "Moldova (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "Moldavian S.S.R. (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "Mexico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "Netherlands Antilles (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "Netherlands (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "Northern Ireland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "New Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "New Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "Northern Mariana Islands (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "Norway (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "Nova Scotia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "Northwest Territories (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "Northern Mariana Islands (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "Norfolk Island (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "New York (State) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "New Zealand (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "Pitcairn Island (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "Paracel Islands (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "Philippines (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "Prince Edward Island (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "Poland (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "Papua New Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "Portuguese Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "Romania (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "Russia (Federation) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "Russian S.F.S.R. (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr "Ryukyu Islands, Southern (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "South Africa (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "South Sudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "Sao Tome and Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "Spanish North Africa (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "Spain (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "Western Sahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "Scotland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "Saudi Arabia (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "Swan Islands (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "Sweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "Syria (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "Switzerland (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "Tajikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "Tajik S.S.R. (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "Turks and Caicos Islands (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "Tunisia (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "Turkmen S.S.R. (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "Trinidad and Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "United Arab Emirates (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "Trust Territory of the Pacific Islands (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "Turkey (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "Egypt (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "United States Misc. Caribbean Islands (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "United Kingdom Misc. Islands (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "United Kingdom Misc. Islands (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "United Kingdom (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "United States Misc. Pacific Islands (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "Soviet Union (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "United States (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "Uzbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "Uzbek S.S.R. (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "British Virgin Islands (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "Vatican City (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "Virgin Islands of the United States (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "Vietnam, North (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "Various places (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "Vietnam, South (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "Washington (State) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "West Berlin (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "Western Australia (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "Wallis and Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "West Bank of the Jordan River (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "Wake Island (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "Christmas Island (Indian Ocean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "Cocos (Keeling) Islands (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "Maldives (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "Saint Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "Marshall Islands (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "Midway Islands (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "Coral Sea Islands Territory (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "Saint Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "Saint Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "Saint Pierre and Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "Saint Vincent and the Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "North Macedonia (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "New South Wales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "Slovakia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "Northern Territory (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "Spratly Island (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "Czech Republic (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "South Australia (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "South Georgia and the South Sandwich Islands (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "Slovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "No place, unknown, or undetermined (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "United Kingdom (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "Soviet Union (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "United States (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "Yukon Territory (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "Yemen (People's Democratic Republic) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "Serbia and Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "AG (Aargau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "AI (Appenzell Innerrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "AR (Appenzell Ausserrhoden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "BE (Bern)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "BL (Basel-Country)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "BS (Basel-City)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "FR (Fribourg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "GE (Geneva)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "GL (Glarus)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "GR (Grisons)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "LU (Lucerne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "SG (St. Gallen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "SH (Shaffhouse)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "SO (Solothurn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "TG (Thurgau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "TI (Ticino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "ZH (Zurich)"
 
@@ -6710,6 +6715,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr ""
@@ -6831,7 +6840,6 @@ msgid "Barcode"
 msgstr "Barcode"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Another online item type exists in this organisation"
 
@@ -6856,8 +6864,8 @@ msgid "Name of the ItemType."
 msgstr "Name of the item type."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
-msgstr "The item type name is already taken"
+msgid "The item type name is already taken."
+msgstr "The item type name is already taken."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
 msgid "Description of the ItemType."
@@ -6870,6 +6878,10 @@ msgstr "Type of the circulation category."
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "Standard"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "Another online item type exists in this organisation."
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6910,8 +6922,9 @@ msgid "Item ID"
 msgstr "Item ID"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
-msgstr "The barcode is already taken"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
+msgstr "The barcode is already taken."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -6960,7 +6973,7 @@ msgstr "Library ID"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "Code"
 
@@ -6973,7 +6986,7 @@ msgid "Name of the library."
 msgstr "Name of the library."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "Address"
 
@@ -6985,7 +6998,7 @@ msgstr "Address of the library."
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "Email"
 
@@ -7205,6 +7218,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7290,39 +7310,38 @@ msgid "Organisation ID"
 msgstr "Organisation ID"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "Required. Name of the organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "Address of the organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "Code of the organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "Current ID of the budget"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "The ID of the current budget of the organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "Default currency"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "The default currency of the organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "Online harvested source"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Online harvested source as configured in ebooks server."
 
@@ -7524,6 +7543,10 @@ msgstr "Last name"
 msgid "Date of birth"
 msgstr "Date of birth"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Example: 1985-12-29"
@@ -7554,20 +7577,26 @@ msgstr "Postal code"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "City"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "Phone number"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "Phone number with the international prefix, without spaces."
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "Phone number with the international prefix, without spaces."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7590,10 +7619,6 @@ msgstr "Patron Type URI"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "Patron's barcode or card number"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "The barcode is already taken."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7841,8 +7866,8 @@ msgid "Vendor ID"
 msgstr "Vendor ID"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
-msgstr "The vendor name is already taken"
+msgid "The vendor name is already taken."
+msgstr "The vendor name is already taken."
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
 msgid "Website"
@@ -7876,15 +7901,11 @@ msgstr "Contact name"
 msgid "Name of the vendor contact person."
 msgstr "Name of the contact person by the vendor."
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "A valid postal code with a min of 4 characters."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "Currency"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "VAT rate"
 
@@ -8060,4 +8081,10 @@ msgstr "Click here to reset your password"
 
 #~ msgid "requested"
 #~ msgstr "requested"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "The barcode is already taken"
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "A valid postal code with a min of 4 characters."
 

--- a/rero_ils/translations/es/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/es/LC_MESSAGES/messages.po
@@ -8,12 +8,11 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # bibsys UCL <bibsys@uclouvain.be>, 2020
 # ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: es\n"
@@ -80,8 +79,8 @@ msgid "author__it"
 msgstr "Autores"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "idioma"
 
@@ -368,8 +367,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "Monto asignado para la cuenta."
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -380,8 +379,8 @@ msgid "Library"
 msgstr "Biblioteca"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -390,10 +389,10 @@ msgid "Library URI"
 msgstr "URI de la biblioteca"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -406,15 +405,15 @@ msgstr "URI de la biblioteca"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "Organización"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -422,7 +421,7 @@ msgstr "Organización"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "URI de la organización"
 
@@ -474,7 +473,7 @@ msgid "Price per unit"
 msgstr "Precio por unidad"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "Descuento"
@@ -496,8 +495,8 @@ msgid "Invoice number"
 msgstr "Número de factura."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
-msgstr "El número de la factura está utilizado"
+msgid "The invoice number is already taken."
+msgstr "El número de la factura está utilizado."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
 msgid "Invoice price"
@@ -529,81 +528,81 @@ msgstr "Suprimido"
 msgid "Date"
 msgstr "Fecha"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "Debería estar en el siguiente formato: 2022-12-31 (AAAA-MM-DD)."
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr "Selecciona una fecha"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "Debería estar en el siguiente formato: 2022-12-31 (AAAA-MM-DD)."
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "Notas"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "Impuestos"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "Tipo de impuesto"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr "Envío y manejo"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "Impuestos estatales"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "Miscelánea"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Monto"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr "Descuento"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "Porcentaje"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr "Porcentaje de descuento."
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "Lista de las líneas de la factura"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "URI del proveedor"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "Elija un proveedor"
 
@@ -659,7 +658,7 @@ msgid "Quantity"
 msgstr "Cantidad"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "El monto total"
 
@@ -692,6 +691,12 @@ msgstr "Pedido"
 msgid "Acquisition order URI"
 msgstr "URI del pedido"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "Pedido"
@@ -709,8 +714,8 @@ msgid "AcqOrder ID"
 msgstr "ID del pedido"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
-msgstr "El número del pedido está utilizado"
+msgid "The order number is already taken."
+msgstr "El número del pedido está utilizado."
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
 msgid "Order type"
@@ -773,18 +778,18 @@ msgid "Name of the budget."
 msgstr "Nombre del presupuesto"
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
-msgstr "El nombre del presupuesto está utilizado"
+msgid "The budget name is already taken."
+msgstr "El nombre del presupuesto está utilizado."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "Fecha 1"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "Fecha 2"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "Activo"
 
@@ -995,9 +1000,9 @@ msgid "Sound"
 msgstr "Sonido"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "Video"
 
@@ -1278,11 +1283,11 @@ msgid "type"
 msgstr "tipo"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "País"
 
@@ -1809,4751 +1814,4751 @@ msgstr "Estado"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Estado del identificador ISBN/ISSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 "El estado del ISBN/ISSN tiene que ser seleccionado en la lista a "
 "continuación."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "Sujetos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "Sujeto del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "Sujeto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Información necesaria para localizar y acceder a un recurso electrónico."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "Registra una URL única aquí."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "Ejemplo: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "Tipo de enlace"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "Recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "Versión del recurso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "Recurso relacionado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "URL oculto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "No hay información"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "Se muestra como el texto del enlace."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "Póster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "Postal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "Adición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "Informe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "Documentación de la exposición"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "Placa de libro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "Extracto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "Hoja educativa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "Ilustraciones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "Imagen de portada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "Información sobre la entrega"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Información bibliográfica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "Introducción/prefacio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "Lectura continuada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "Paquete educativo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "Nota del editor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "Nota sobre el contenido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "Página de título "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "Fotografía"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "Resumen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "Recurso en línea a través de RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "Revista de prensa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "Sitio web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "Tabla de contenidos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "Texto completo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr "Nota pública"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "Ejemplo: Acceso sólo desde la biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "Importado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "El documento importado o no, no permitirá la edición de noticia."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "Valor del idioma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "abjasio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "acehnés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "adigué"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "lenguas afroasiáticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "afrikáans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "acadio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "albanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "aleutiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "lenguas algonquinas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "altái meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "amárico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "inglés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "lenguas apaches"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "árabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "arameo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "aragonés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "armenio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "idiomas artificiales"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "arahuaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "asamés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "idiomas Athapaskan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "idiomas australianos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "avar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "avéstico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "avadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "aimara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "azerbaiyano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "idiomas de la banda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "lenguas bamileké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "baskir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "baluchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "balinés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "vasco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "basaa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "lenguas bálticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "bielorruso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "bengalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "lenguas bereberes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "bhoyapurí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "bicol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "lenguas bantúes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "bosnio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "bretón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "lenguas Batak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "buriato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "buginés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "búlgaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "birmano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "lenguas indígenas centroamericanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "caribe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "catalán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "lenguas celtas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "checheno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "chagatái"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "chino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "trukés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "marí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "jerga chinuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "cheroqui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "eslavo eclesiástico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "chuvasio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "cheyene"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "idioma Cham"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "copto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "córnico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "corso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "criollos y pidgins basados en el inglés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "criollos y pidgins basados en el francés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "criollos y pidgins basados en portugués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "tártaro de Crimea"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "criollos y pidgins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "casubio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "lenguajes couchiticos"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "checo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "danés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "dargva"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "idiomas Land Dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "slave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "lenguas dravidianas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "bajo sorbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "neerlandés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "holandés, flamenco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "diula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "egipcio antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "elamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "inglés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "inglés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "estonio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "ewé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "feroés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "fiyiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "finés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "lenguas fino-úgricas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "francés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "francés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "francés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "frisón septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "frisón oriental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "frisón occidental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "fula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "friulano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "lenguas germánicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "alemán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "gilbertés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "gaélico escocés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "irlandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "gallego"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "manés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "alto alemán medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "alto alemán antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "gótico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "griego antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "griego moderno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "alemán suizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "guyaratí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "kutchin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "criollo haitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "hebreo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "hitita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "croata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "alto sorbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "húngaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "islandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "yi de Sichuán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "lenguas indoarias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "indonesio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "lenguas indoeuropeas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "lenguas iraníes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "lenguas iroquesas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "italiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "javanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "japonés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "judeo-persa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "judeo-árabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "karakalpako"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "cabila"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "groenlandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "canarés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "lenguas karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "cachemiro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "kazajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "kabardiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "idiomas khoisan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "jemer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "kotanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "kirguís"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "konkaní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "coreano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "kosraeano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "karachay-balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "carelio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "lenguas krou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "kurdo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "latín"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "letón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "lezgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "limburgués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "lituano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "luxemburgués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "macedonia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "madurés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "marshalés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "macasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "māori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "idiomas austronesios"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "maratí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "masái"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "malayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "irlandés medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "idiomas no codificados"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "lenguas mon-Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "maltés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "manchú"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "lenguas manobo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "mongol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "varios idiomas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "lenguas funda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "mirandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "lenguas mayas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "náhuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "lenguas indígenas norteamericanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "napolitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "nauruano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "ndebele meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "ndebele septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "bajo alemán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "nepalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "lenguas nigerianas y congolesas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "niueano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "noruego nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "noruego bokmal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "nórdico antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "noruego"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "sotho septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "lenguas nubias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "newari clásico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "occitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "oriya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "osético"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "turco otomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "idioma otomí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "lenguas papúes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "pangasinán"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "panyabí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "persa antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "persa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "lenguas filipinas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "polaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "pohnpeiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "portugués"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "prácrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "provenzal antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "pastún"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "rarotongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "lenguas románicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "romanche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "romaní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "rumano, moldavo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "arrumano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "ruso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "sakha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "lenguas indígenas sudamericanas "
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "lenguas salishas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "arameo samaritano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "sánscrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "escocés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "lenguas semíticas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "irlandés antiguo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "lenguaje de señas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "cingalés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "lenguas sioux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "lenguas sino-tibetanas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "lenguas eslavas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "eslovaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "esloveno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "sami meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "sami septentrional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "lenguas sami"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "sami lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "sami inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "samoano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "soninké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "somalí"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "lenguas songhay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "sotho meridional"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "español"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "sardo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "serbio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "lenguas nilo-saharianas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "suazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "sundanés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "sumerio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "suajili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "sueco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "siríaco clásico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "tahitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "lenguas tai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "tártaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "tetún"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "tayiko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "tagalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "tailandés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "tigriña"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "tokelauano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "tonga del Nyasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "tongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "tsimshiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "setsuana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "turcomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "lenguas tupíes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "turco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "lenguas altaicas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "tuvaluano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "tuviniano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "ugarítico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "uigur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "ucraniano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "lengua desconocida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "uzbeko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "vótico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "lenguas wakash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "wolayta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "galés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "lenguas sorabas"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "valón"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "wólof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "yapés"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "yidis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "lenguas yupik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "zapoteco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "símbolos Bliss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "zulú"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "sin contenido lingüístico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "zazaki"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "Valores"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "Valor"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "Islas Ashmore y Cartier (-ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "Territorio de la capital australiana (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "Argelia (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "Afganistán (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "Armenia (república) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "R.S.S. de Armenia (-air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "Azerbaiyán (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "R.S.S. de Azerbaiyán (-ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "Anguila (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "Antigua y Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "Samoa Americana (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "Antártida (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "Baréin (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "Columbia Británica (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "Bélgica (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "Bangladés (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "Belice (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "Territorio Británico del Océano Índico (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "Brasil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "Islas Bermudas (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "Bosnia y Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "Islas Salomón (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "Birmania (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "Botsuana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "Bután (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "Isla Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "Bielorrusia (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "R.S.S. de Bielorrusia (-bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "[Brunei] (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "Caribe neerlandés (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "Camboya (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "Chad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "Congo (República Democrática) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "China (República: 1949-) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "Croacia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "Islas Caimán (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "Chile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "Camerún (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "Canadá (-cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "Curazao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "Islas Cantón y Enderbury (-cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "Comoras (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "Checoslovaquia (-cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "Cabo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "Islas Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "República Centroafricana (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "Chipre (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "Zona del canal (-cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "Distrito de Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "Dinamarca (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "Benín (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "República Dominicana (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "Guinea Ecuatorial (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "Timor-Leste (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "Inglaterra (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "Estonia (-err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "Etiopía (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "Islas Feroe (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "Guayana Francesa (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "Finlandia (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "Fiyi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "Islas Malvinas (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "Micronesia (Estados Federados) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "Polinesia Francesa (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "Francia (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "Tierras australes y antárticas francesas (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "Yibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "Granada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "Alemania (este) (-ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "Groenlandia (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "Islas Gilbert y Ellice (-gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "Gabón (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "Guadalupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "Grecia (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "Georgia (república) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "R.S.S. de Georgia (-gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "Alemania (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "Franja de Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "Hawai (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "R.A.E. de Hong Kong (China) (-hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "Islas Heard y McDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "Haití (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "Hungría (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "Islandia (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "Irlanda (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "Isla de Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "Israel (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "Italia (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "Zonas desmilitarizadas entre Israel y Siria (-iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "Costa de Marfil (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "Zonas desmilitarizadas entre Israel y Jordania (-iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "Zona neutral Iraq-Arabia Saudita (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "Japón (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "Atolón Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "Jan Mayen (-jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "Jordania (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "Kirguistán (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "R.S.S. de Kirguistán (-kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "Corea del Norte (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "Corea del Sur (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "[Kosovo] (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "Kazajistán (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "R.S.S. de Kazajstán (-kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "Luisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "Líbano (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "Lituania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "Lituania (-lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "Islas de la línea central y sur (-ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "Lesoto (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "Luxemburgo (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "Letonia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "Letonia (-lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "Libia (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "Mónaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "Mauricio (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "R.A.E. de Macao (China) (-mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "Omán (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "Misuri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "Martinica (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "Marruecos (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "Misisipí (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "Moldavia (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "R.S.S. de Moldavia (-mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "Malaui (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "México (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "Malasia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "Antillas Holandesas (-na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "Carolina del Norte (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "Dakota del Norte (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "Países Bajos (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "Níger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "Nuevo Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "Irlanda del Norte (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "Nuevo Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "Nueva Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "Islas Marianas del Norte (-nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "Nuevo Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "Noruega (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "Nueva Escocia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "Territorios del Noroeste (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "Islas Marianas del Norte (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "Isla Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "Estado de Nueva York (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "Nueva Zelanda (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "Oregón (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "Pensilvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "Isla Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "Perú (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "Islas Paracel (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "Guinea-Bisáu (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "Filipinas (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "Isla del Príncipe Eduardo (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "Pakistán (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "Polonia (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "Panamá (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "Papúa Nueva Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "Timor portugués (-pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "Palaos (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "Catar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "Quebec (provincia) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "Reunión (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "Zimbabue (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "Rumanía (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "Federacion Rusa (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "R.S.F.S. de Rusia (-rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr "Islas Ryukyu, Sur (-ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "Sudáfrica (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "Svalbard (-sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "San Bartolomé (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "Carolina del Sur (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "Sudán del Sur (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "Dakota del Sur (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "Santo Tomé y Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "África española (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "Singapur (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "Sudán (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "Sikkim (-sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "Sierra Leona (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "España (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "Esuatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "Sáhara Occidental (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "Escocia (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "Arabia Saudí (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "Islas del Cisne (-sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "Suecia (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "Siria (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "Suiza (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "Tayikistán (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "R.S.S. de Tayikistán (-tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "Islas Turcas y Caicos (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "Tailandia (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "Túnez (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "Turkmenistán (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "R.S.S. de Turkmenistán (-tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "Trinidad y Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "Emiratos Árabes Unidos (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "Territorio en Fideicomiso de las Islas del Pacífico (-tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "Turquía (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "Egipto (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "[United States Misc. Caribbean Islands] (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "Reino Unido Misc. Islas(-ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "Reino Unido Misc. Islas (-uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "Reino Unido (-uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "Ucrania (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "Ucrania (-unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "Estados Unidos Misc. Islas del pacifico (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "Unión soviética (-ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "Estados Unidos (-us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "Uzbekistán (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "R.S.S. de Uzbekistán (-uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "Islas Vírgenes Británicas (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "Ciudad del vaticano (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "Islas Vírgenes de EE. UU. (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "Vietnam del norte (-vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "Varios lugares (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "Vietnam del sur (-vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "Washington (estado) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "Berlín occidental (-wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "Australia occidental (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "Wallis y Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "Cisjordania del río Jordán (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "Isla Wake (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "Gales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "Virginia del Oeste (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "Isla Christmas (Océano Índico) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "Islas Cocos (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "Maldivas (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "San Cristóbal y Nieves (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "Islas Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "Islas Midway (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "Territorio de las Islas del Mar del Coral (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "San Cristóbal-Nevis-Anguila (-xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "Santa helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "Santa Lucía (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "San Pedro y Miquelón (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "San Vicente y las Granadinas (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "Macedonia del Norte (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "Nueva Gales del Sur (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "Eslovaquia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "Territorio del Norte (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "Isla Spratly (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "Chequia (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "Australia Meridional (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "Islas Georgia del Sur y Sandwich del Sur (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "Eslovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "Ningún lugar, desconocido o indeterminado (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "Canadá (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "Reino Unido (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "Unión soviética (-xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "Estados Unidos (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "Yukón (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "Yemen (República Democrática Popular) (-ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "Serbia y Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Cantones"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "AG (Argovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "AI (Appenzell Rodas Interiores)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "AR (Appenzell Rodas Exteriores)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "BE (Berna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "BL (Basilea-Campiña)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "BS (Basilea-Ciudad)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "FR (Friburgo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "GE (Ginebra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "GL (Glaris)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "GR (Grisones)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "JU (JURA)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "LU (Lucerna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "NW (Nidwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "OW (Obwalden)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "SG (San Galo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "SH (Schaffhausen)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "SO (Soleura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "SZ (Schwyz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "TG (Turgovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "TI (Tesino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "ZG (Zug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "ZH (Zúrich)"
 
@@ -6715,6 +6720,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr ""
@@ -6836,7 +6845,6 @@ msgid "Barcode"
 msgstr "Código de barras"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Existe otro tipo de ejemplar en línea en esta organización"
 
@@ -6861,8 +6869,8 @@ msgid "Name of the ItemType."
 msgstr "Nombre del tipo de ejemplar"
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
-msgstr "El nombre para el tipo de ejemplar está utilizado"
+msgid "The item type name is already taken."
+msgstr "El nombre para el tipo de ejemplar está utilizado."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
 msgid "Description of the ItemType."
@@ -6875,6 +6883,10 @@ msgstr "Tipo de la categoría de préstamo"
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "Estándar"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "Existe otro tipo de ejemplar en línea en esta organización."
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6915,7 +6927,8 @@ msgid "Item ID"
 msgstr "ID del ejemplar"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
 msgstr "El código de barras está utilisado."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
@@ -6965,7 +6978,7 @@ msgstr "Identificador de la biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "Código"
 
@@ -6978,7 +6991,7 @@ msgid "Name of the library."
 msgstr "Nombre de la biblioteca."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "Dirección"
 
@@ -6990,7 +7003,7 @@ msgstr "Dirección de la biblioteca."
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -7210,6 +7223,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7295,39 +7315,38 @@ msgid "Organisation ID"
 msgstr "ID de la organización"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "Obligatorio. Nombre de la organización."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "Dirección de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "Código de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "ID actual del presupuesto"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "El ID del presupuesto actual de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "La moneda por defecto"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "La moneda por defecto de la organización"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "Fuente recolectada en línea"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Fuente recolectada en línea como configurada en el servidor de ebooks."
 
@@ -7529,6 +7548,10 @@ msgstr "Apellido"
 msgid "Date of birth"
 msgstr "Fecha de nacimiento"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Ejemplo: 1985-12-29"
@@ -7559,20 +7582,26 @@ msgstr "Código postal"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "Ciudad"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "Número de teléfono."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "Número de teléfono con el prefijo internacional, sin espacios."
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "Número de teléfono con el prefijo internacional, sin espacios."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7595,10 +7624,6 @@ msgstr "URI del tipo de usuario"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "Código de barras o número de tarjeta del usuario"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "El código de barras está utilisado."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7846,8 +7871,8 @@ msgid "Vendor ID"
 msgstr "ID del proveedor"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
-msgstr "El nombre del proveedor está utilizado"
+msgid "The vendor name is already taken."
+msgstr "El nombre del proveedor está utilizado."
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
 msgid "Website"
@@ -7881,15 +7906,11 @@ msgstr "Nombre del contacto"
 msgid "Name of the vendor contact person."
 msgstr ""
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "Obligatorio. Un código postal válido con un mínimo de 4 caracteres."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "Moneda"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "Tasa de IVA"
 
@@ -8065,4 +8086,10 @@ msgstr "Haga clic aquí para restablecer su contraseña"
 
 #~ msgid "requested"
 #~ msgstr "Reservado"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "El código de barras está utilisado."
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "Obligatorio. Un código postal válido con un mínimo de 4 caracteres."
 

--- a/rero_ils/translations/fr/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/fr/LC_MESSAGES/messages.po
@@ -15,12 +15,11 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # MarionRERO <marion.davis@rero.ch>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -87,8 +86,8 @@ msgid "author__it"
 msgstr "auteur"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "langue"
 
@@ -375,8 +374,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "Montant alloué"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -387,8 +386,8 @@ msgid "Library"
 msgstr "Bibliothèque"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -397,10 +396,10 @@ msgid "Library URI"
 msgstr "URI de la bibliothèque"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -413,15 +412,15 @@ msgstr "URI de la bibliothèque"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "Organisation"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -429,7 +428,7 @@ msgstr "Organisation"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "URI de l'organisation"
 
@@ -481,7 +480,7 @@ msgid "Price per unit"
 msgstr "Prix par unité"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "Montant du rabais"
@@ -503,7 +502,7 @@ msgid "Invoice number"
 msgstr "Numéro de facture"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
+msgid "The invoice number is already taken."
 msgstr "Le numéro de facture est déjà utilisé."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
@@ -536,81 +535,81 @@ msgstr "Supprimé"
 msgid "Date"
 msgstr "Date"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "La date doit être au format suivant: 2022-12-31 (AAAA-MM-JJ)"
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr "Choisir une date"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "La date doit être au format suivant: 2022-12-31 (AAAA-MM-JJ)"
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "Notes"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "Frais"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "Type de frais"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr "Expédition et manutention"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "Taxes étatiques"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "Divers"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "montant"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr "Rabais"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "Pourcentage"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr "Pourcentage de rabais"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "Liste des lignes de facture"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "Fournisseur"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "URI du fournisseur"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "Choisir un fournisseur"
 
@@ -666,7 +665,7 @@ msgid "Quantity"
 msgstr "quantité"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "montant total"
 
@@ -699,6 +698,12 @@ msgstr "Commande"
 msgid "Acquisition order URI"
 msgstr "URI de la commande"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "Commande"
@@ -716,7 +721,7 @@ msgid "AcqOrder ID"
 msgstr "ID de la commande"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
+msgid "The order number is already taken."
 msgstr "Le numéro de commande est déjà utilisé."
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
@@ -780,18 +785,18 @@ msgid "Name of the budget."
 msgstr "Nom du budget"
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
+msgid "The budget name is already taken."
 msgstr "Le nom du budget est déjà utilisé."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "Date 1"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "Date 2"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "Actif"
 
@@ -1000,9 +1005,9 @@ msgid "Sound"
 msgstr "son"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "vidéo"
 
@@ -1284,11 +1289,11 @@ msgid "type"
 msgstr "Type"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Pays"
 
@@ -1815,4749 +1820,4749 @@ msgstr "Statut"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Statut de l'identifiant ISBN/ISSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Le status de l'ISBN/ISSN doit être sélectionné dans la liste ci-dessous."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "Sujets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "Sujet de la ressource."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "Sujet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr "Information nécessaire pour accéder à une ressource électronique."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "Entrez une URL unique."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "Exemple: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "Type de lien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "Ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "Autre version de la ressource"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "Ressource en lien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "URL caché"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "Aucune information"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "Type de contenu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "Est affiché comme texte du lien."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "Affiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "Carte postale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "Complément"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "Compte-rendu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "Documentation d'exposition"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "Ex-libris"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "Extrait"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "Fiche pédagogique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "Illustrations"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "Image de couverture"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "Information sur la livraison"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Informations biographiques"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "Introduction/préface"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "Lecture suivie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "Mallette pédagogique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "Note de l'éditeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "Note sur le contenu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "Page de titre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "Photographie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "Résumé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "Ressource en ligne via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "Revue de presse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "Site web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "Table des matières"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "Texte intégral"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr "Note publique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr "s'affiche à côté du lien, comme information supplémentaire"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "Exemple: Accès uniquement depuis la bibliothèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "Importé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr "Document moissonné ou non, désactivera l'édition de la notice."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "Valeur de la langue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "abkhaze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "aceh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "acoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "adyguéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "afro-asiatiques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "aïnou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "akkadien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "albanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "aléoute"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "algonquines, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "altaï du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "amharique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "ancien anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "apaches, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "arabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "araméen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "aragonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "arménien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "artificielles, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "assamais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "asturien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "athapascanes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "australiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "avar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "avestique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "azéri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "banda, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "bamilékés, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "bachkir"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "baloutchi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "balinais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "basque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "bassa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "baltes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "bedja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "biélorusse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "bengali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "berbères, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "bhodjpouri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "bichelamar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "bantoues, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "bosniaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "breton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "batak, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "bouriate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "bugi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "bulgare"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "birman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "indiennes d'Amérique centrale, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "caribe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "catalan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "caucasiens, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "celtique, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "tchétchène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "tchaghataï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "chinois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "chuuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "jargon chinook"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "slavon d’église"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "tchouvache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "monténégrin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "copte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "cornique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "corse"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "créoles et pidgins anglais, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "créoles et pidgins français, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "créoles et pidgins portugais, autres"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "turc de Crimée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "créoles et pidgins divers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "kachoube"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "couchitiques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "tchèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "danois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "Land Dayak, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "esclave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "maldivien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "dravidiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "bas-sorabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "douala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "moyen néerlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "néerlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "dioula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "éfik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "égyptien ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "ékadjouk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "élamite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "moyen anglais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "espéranto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "estonien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "éwé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "éwondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "féroïen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "fidjien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "filipino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "finnois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "finno-ougriennnes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "moyen français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "ancien français"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "frison du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "frison oriental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "frison occidental"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "peul"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "frioulan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "germaniques, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "géorgien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "guèze"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "gilbertin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "gaélique écossais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "galicien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "mannois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "moyen haut-allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "ancien haut allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "gotique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "grec ancien (jusqu'à 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "grec moderne (après 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "guarani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "suisse allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "goudjerati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "créole haïtien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "haoussa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "hawaïen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "hébreu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "héréro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "croate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "haut-sorabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "hongrois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "islandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "yi du Sichuan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "ijo, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "indo-aryennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "indonésien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "indo-européennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "ingouche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "iraniennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "iroquois, langues (famille)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "italien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "javanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "japonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "judéo-persan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "judéo-arabe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "karakalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "kabyle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "groenlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "karen, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "cachemiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "kanouri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "kazakh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "kabarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "khoisan, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "khotanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "kirghize"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "kimboundou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "kikongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "coréen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "kosraéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "kpellé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "karatchaï balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "carélien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "krou, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "kouroukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "koumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "kurde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "latin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "letton"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "lezghien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "limbourgeois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "lituanien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "luxembourgeois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "luba-kasaï (ciluba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "luba-katanga (kiluba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "lushaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "macédonien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "madurais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "marshallais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "maïthili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "makassar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "mandingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "malayo-polynésiennes, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "maasaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "malais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "mokcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "mendé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "moyen irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "diverses, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "môn-khmer, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "maltais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "mandchou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "manobo, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "mongol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "moré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "multilingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "mounda, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "muskogee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "mirandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "marwarî"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "maya, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "nahuatl, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "indiennes d'Amérique du Nord, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "napolitain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "nauruan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "ndébélé du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "ndébélé du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "bas-allemand"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "népalais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "niha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "nigéro-congolaises,langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "niuéen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "norvégien nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "norvégien bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "nogaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "vieux norrois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "norvégien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "sotho du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "nubiennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "newarî classique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "chewa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "nyankolé"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "nzema"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "occitan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "ossète"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "turc ottoman"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "otomi, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "papoues, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "pampangan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "pendjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "paluan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "persan ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "persan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "philippin, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "phénicien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "polonais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "pohnpei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "portugais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "prâkrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "provençal ancien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "pachto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "rarotongien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "romanes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "romanche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "roumain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "roundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "aroumain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "russe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "iakoute"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "indiennes d'Amérique du Sud, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "salish, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "araméen samaritain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "sanskrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "sicilien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "écossais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "selkoupe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "sémitiques, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "ancien irlandais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "langue des signes"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "cingalais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "sioux, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "sino-tibétaines, autres langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "slaves, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "slovaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "slovène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "same du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "same du Nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "sâmes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "same de Lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "same d’Inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "samoan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "same skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "soninké"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "sogdien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "somali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "sotho du Sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "espagnol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "sarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "serbe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "sérère"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "nilo-sahariennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "swati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "soukouma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "soundanais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "soussou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "sumérien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "suédois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "syriaque classique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "syriaque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "tahitien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "tai, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "tamoul"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "tatar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "télougou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "timné"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "tétoum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "tadjik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "thaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "tibétain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "tigré"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "tigrigna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "tamacheq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "tonga nyasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "tongien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "turkmène"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "tupi, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "turc"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "altaïques, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "touvain"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "oudmourte"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "ougaritique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "ouïghour"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "ukrainien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "langue indéterminée"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "ourdou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "ouzbek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "vaï"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "vietnamien"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "vote"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "wakashennes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "walamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "gallois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "sorabes, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "wallon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "kalmouk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "yapois"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "yupik, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "zapotèque"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "symboles Bliss"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "zandé, langues"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "zoulou"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "sans contenu linguistique"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "zazaki"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "Valeurs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "valeur"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "Albanie (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "Îles Ashmore-et-Cartier (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "Territoire de la capitale australienne (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "Algérie (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "Argentine (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "Arménie (République) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "R.S.S. d'Arménie (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "Azerbaïdjan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "R.S.S. d'Azerbaïjan (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "Andorre (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "Antigua-et-Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "Samoa américaines (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "Australie (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "Autriche (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "Antarctique (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "Bahreïn (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "Barbade (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "Colombie Britannique (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "Belgique (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "Territoire britannique de l’océan Indien (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "Brésil (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "Îles Bermudes (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "Bosnie-Herzégovine (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "Bolivie (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "Îles Salomon (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "Birmanie (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "Bhoutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "Bulgarie (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "Île Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "Biélorussie (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "R.S.S. de Biélorussie (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "Pays-Bas caribéens  (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "Californie (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "Cambodge (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "Chine (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "Tchad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "Congo-Brazzaville (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "République démocratique du Congo (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "République populaire de Chine (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "Croatie (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "Îles Caïmans (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "Colombie (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "Chili (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "Cameroun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "Îles de Canton et Enderbury (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "Comores (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "Tchécoslovaquie (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "Cap-Vert (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "Îles Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "République centrafricaine (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "Chypre (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "Zone du Canal de Panama (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "District de Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "[Delaware] (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "Danemark (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "Bénin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "Dominique (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "République dominicaine (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "Érythrée (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "Équateur (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "Guinée équatoriale (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "Timor oriental (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "Angleterre (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "Estonie (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "R.S.S. d'Estonie (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "Éthiopie (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "Îles Féroé (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "Guyane française (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "Finlande (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "Fidji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "Îles Malouines (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "Floride (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "États fédérés de Micronésie (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "Polynésie française (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "France (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "Géorgie (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "Grenade (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "Allemagne de l'Est (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "Guernesey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "Groenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "Gambie (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "Îles Gilbert et Ellice (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "Grèce (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "République de Géorgie (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "R.S.S. de Géorgie (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "Guinée (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "Allemagne (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "Guyane (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "Bande de Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "Hawaï (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "R.A.S. chinoise de Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "Îles Heard-et-MacDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "Haïti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "Hongrie (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "Islande (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "Irlande (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "Inde (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "Île de Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "Indonésie (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "Israël (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "Italie (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "Zones démilitarisées Israël-Syrie (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "Côte d’Ivoire (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "Zones démilitarisées Israël-Jordanie (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "Zone neutre Irak-Arabie saoudite (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "Japon (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "Atoll de Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "Jamaïque (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "Île Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "Jordanie (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "Kirghizistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "R.S.S. kirghize (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "Corée du Nord (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "Corée du Sud (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "Koweït (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "Kazakhstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "R.S.S. Kazakhe (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "Louisiane (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "Libéria (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "Liban (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "Lituanie (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "Lituanie (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "Îles de la Ligne Centrale et du Sud (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "Luxembourg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "Lettonie (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "Lettonie (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "Libye (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "Maurice (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "R.A.S. chinoise de Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "Malte (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "Monténégro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "Mongolie (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "Maroc (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "Mauritanie (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "Moldavie (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "R.S.S. Moldave (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "Mexique (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "Malaisie (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "Antilles néerlandaises (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "Caroline du Nord (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "Dakota du Nord (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "Pays-Bas (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "Terre-Neuve et Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "Irlande du Nord (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "Nouveau Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "Nouvelle-Calédonie (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "Îles Mariannes du Nord (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "Nouveau Mexique (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "Norvège (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "Népal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "Nigéria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "Nouvelle-Ecosse (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "Territoires du Nord-Ouest (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "Îles Mariannes du Nord (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "Île Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "État de New York (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "Nouvelle-Zélande (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "Pennsylvanie (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "Île Pitcairn (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "Pérou (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "Îles Paracels (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "Guinée-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "Philippines (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "Île du Prince Edouard (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "Pologne (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "Papouasie-Nouvelle-Guinée (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "Porto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "Timor portugais (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "Palaos (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "Serbie (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "La Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "Roumanie (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "Russie (Fédération) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "RSFS de Russie (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr " îles Ryūkyū du Sud (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "Afrique du Sud (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "Caroline du Sud (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "Soudan du Sud (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "Dakota du Sud (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "Sao Tomé-et-Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "Sénégal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "Afrique espagnole (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "Singapour (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "Soudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "Saint-Marin (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "Saint-Martin (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "Somalie (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "Espagne (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "Eswatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "Suriname (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "Sahara occidental (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "Écosse (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "Arabie saoudite (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "Îles du Cygne (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "Suède (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "Namibie (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "Syrie (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "Suisse (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "Tadjikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "R.S.S. du Tadjikistan (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "Îles Turques-et-Caïques (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "Thaïlande (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "Tunisie (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "Turkménistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "R.S.S. du Turkménistan (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "Tasmanie (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "[Tennessee] (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "Trinité-et-Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "Émirats arabes unis (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "Territoire sous tutelle des îles du Pacifique (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "Turquie (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "Tanzanie (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "Égypte (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "États-Unis, diverses îles caribéennes (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "Ouganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "Royaume-Uni, diverses îles (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "Royaume-Uni, diverses îles (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "Royaume-Uni (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "Ukraine (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "Ukraine (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "États-Unis, diverses îles du Pacifique (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "Union soviétique (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "États-Unis (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "Ouzbékistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "R.S.S. d'Ouzbékistan (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "Virginie (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "Îles Vierges britanniques (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "Vatican (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "Vénézuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "Îles Vierges des États-Unis (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "[Vietnam, North] (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "Plusieurs pays (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "Terre Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "[Vietnam, South] (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "Washington (État) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "Berlin Ouest (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "Australie-Occidentale (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "Wallis-et-Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "Cisjordanie (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "Wake (atoll) (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "Pays de Galles (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "Virginie-Occidentale (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "Île Christmas (Océan Indien) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "Îles Cocos (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "Maldives (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "Saint Kitts-et-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "Îles Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "Îles Midway (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "Territoire des îles de la mer de Corail (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "Saint Kitts-et-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "Sainte-Hélène (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "Sainte-Lucie (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "Saint-Pierre-et-Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "Saint-Vincent-et-les-Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "Macédoine du Nord (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "Nouvelle-Galles du Sud (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "Slovaquie (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "Territoire du Nord (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "Îles Spratleys (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "Tchéquie (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "Australie-Méridionale (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "Géorgie du Sud et îles Sandwich du Sud (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "Slovénie (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "Aucun pays, inconnu, indéterminé (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "Royaume-Uni (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "Union soviétique (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "États-Unis (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "Yémen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "Territoire du Yukon (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "Yémen (République démocratique populaire) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "Serbie et Monténégro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "Zambie (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Cantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "AG (Argovie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "AI (Appenzell Rhodes-Intérieures)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "AR (Appenzell Rhodes-Extérieures)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "BE (Berne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "BL (Bâle-Campagne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "BS (Bâle-Ville)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "FR (Fribourg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "GE (Genève)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "GL (Glaris)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "GR (Grisons)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "JU (Jura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "LU (Lucerne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "NW (Nidwald)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "OW (Obwald)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "SG (Saint-Gall)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "SH (Schaffhouse)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "SO (Soleure)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "SZ (Schwytz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "TG (Thurgovie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "TI (Tessin)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "VS (Valais)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "ZG (Zoug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "ZH (Zurich)"
 
@@ -6719,6 +6724,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr "schémas de prédiction"
@@ -6840,7 +6849,6 @@ msgid "Barcode"
 msgstr "Code-barre"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Un autre type d'exemplaire \"en ligne\" existe dans cette organisation."
 
@@ -6865,8 +6873,8 @@ msgid "Name of the ItemType."
 msgstr "Nom du type d'exemplaire"
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
-msgstr "Le nom du type d'exemplaire est déjà utilisé"
+msgid "The item type name is already taken."
+msgstr "Le nom du type d'exemplaire est déjà utilisé."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
 msgid "Description of the ItemType."
@@ -6879,6 +6887,10 @@ msgstr "Type de la catégorie de prêt."
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "Standard"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "Un autre type d'exemplaire \"en ligne\" existe dans cette organisation."
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6919,8 +6931,9 @@ msgid "Item ID"
 msgstr "ID de l'exemplaire"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
-msgstr "Le code-barres est déjà utilisé"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
+msgstr "Le code-barres est déjà utilisé."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -6969,7 +6982,7 @@ msgstr "ID de la bibliothèque."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "Code"
 
@@ -6982,7 +6995,7 @@ msgid "Name of the library."
 msgstr "Nom de la bibliothèque."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "Adresse"
 
@@ -6994,7 +7007,7 @@ msgstr "Adresse de la bibliothèque."
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "Email"
 
@@ -7214,6 +7227,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7299,39 +7319,38 @@ msgid "Organisation ID"
 msgstr "ID de l'organisation"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "Obligatoire. Nom de l'organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "Adresse de l'organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "Code de l'organisation."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "ID actuel du budget"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "L'ID du budget actuel de l'organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "Devise par défaut"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "La devise par défaut de l'organisation"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "Source moissonnée en ligne"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Source moissonnée en ligne, comme configuré dans le serveur d'ebooks."
 
@@ -7533,13 +7552,17 @@ msgstr "Nom de famille"
 msgid "Date of birth"
 msgstr "Date de naissance"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Exemple: 1985-12-29"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:89
 msgid "This email is already taken."
-msgstr ""
+msgstr "Cet e-mail est déjà utilisé."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:95
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:25
@@ -7563,20 +7586,26 @@ msgstr "Code postal"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "Ville"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "Numéro de téléphone avec l'indicatif international, sans espaces."
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "Numéro de téléphone avec l'indicatif international, sans espaces."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7599,10 +7628,6 @@ msgstr "URI du type de lecteur"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "Code-barres ou numéro de carte du lecteur"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "Le code-barres est déjà utilisé."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7850,8 +7875,8 @@ msgid "Vendor ID"
 msgstr "ID du fournisseur"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
-msgstr "Le nom du fournisseur est déjà utilisé"
+msgid "The vendor name is already taken."
+msgstr "Le nom du fournisseur est déjà utilisé."
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
 msgid "Website"
@@ -7885,15 +7910,11 @@ msgstr "Nom du contact"
 msgid "Name of the vendor contact person."
 msgstr "Nom de la personne de contact du fournisseur"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "Obligatoire. Code postal valide d'au moins 4 caractères."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "Devise"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "taux de TVA"
 
@@ -8073,4 +8094,10 @@ msgstr "Cliquez ici pour réinitialiser votre mot de passe"
 
 #~ msgid "requested"
 #~ msgstr "demandé"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "Le code-barres est déjà utilisé"
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "Obligatoire. Code postal valide d'au moins 4 caractères."
 

--- a/rero_ils/translations/it/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/it/LC_MESSAGES/messages.po
@@ -14,12 +14,11 @@
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2020\n"
 "Language: it\n"
@@ -86,8 +85,8 @@ msgid "author__it"
 msgstr "autore"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "lingua"
 
@@ -374,8 +373,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "L'importo stanziato al conto."
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -386,8 +385,8 @@ msgid "Library"
 msgstr "Biblioteca"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -396,10 +395,10 @@ msgid "Library URI"
 msgstr "URI della biblioteca"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -412,15 +411,15 @@ msgstr "URI della biblioteca"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "Ente"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -428,7 +427,7 @@ msgstr "Ente"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "URI dell'organizzazione"
 
@@ -480,7 +479,7 @@ msgid "Price per unit"
 msgstr "Prezzo per unità"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "Importo dello sconto"
@@ -502,8 +501,8 @@ msgid "Invoice number"
 msgstr "Numero della fattura"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
-msgstr "Il numero della fattura è già utilizzato"
+msgid "The invoice number is already taken."
+msgstr "Il numero della fattura è già utilizzato."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
 msgid "Invoice price"
@@ -535,81 +534,81 @@ msgstr "Eliminato"
 msgid "Date"
 msgstr "Data"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "Deve essere nel formato seguente: 2022-12-31 (AAAA-MM-GG)."
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "Deve essere nel formato seguente: 2022-12-31 (AAAA-MM-GG)."
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "Nota"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "Imposte"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "Tipo di imposta"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "Tasse statali"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "Varie"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Importo"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "Percentuale"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "Elenco delle righe della fattura"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "Fornitore"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "URI del fornitore"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "Seleziona un fornitore"
 
@@ -665,7 +664,7 @@ msgid "Quantity"
 msgstr "Quantità"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "Importo totale"
 
@@ -698,6 +697,12 @@ msgstr "Ordine"
 msgid "Acquisition order URI"
 msgstr "URI dell'ordine"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "Ordine"
@@ -715,8 +720,8 @@ msgid "AcqOrder ID"
 msgstr "ID dell'ordine"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
-msgstr "Il numero dell'ordine è già utilizzato"
+msgid "The order number is already taken."
+msgstr "Il numero dell'ordine è già utilizzato."
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
 msgid "Order type"
@@ -779,18 +784,18 @@ msgid "Name of the budget."
 msgstr "Nome del bilancio."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
-msgstr "Il nome del bilancio è già utilizzato"
+msgid "The budget name is already taken."
+msgstr "Il nome del bilancio è già utilizzato."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "Data 1"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "Data 2"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "Attivo"
 
@@ -999,9 +1004,9 @@ msgid "Sound"
 msgstr "Audio"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "Video"
 
@@ -1282,11 +1287,11 @@ msgid "type"
 msgstr "tipo"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Paese"
 
@@ -1813,4753 +1818,4753 @@ msgstr "Stato"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Stato dell'identificatore ISBN/SSSN."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Stato del codice ISSB/ISSN deve essere selezionato nell'elenco."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "Oggetti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "Oggetto della risorsa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "Oggetto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informazioni necessarie per localizzare una risorsa elettronica e "
 "accedervi."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "Registrare qui un URL univoco."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "Esempio: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "Tipo di link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "Risorsa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "versione della risorsa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "Risorse correlate"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "URL nascosto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "No info"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "Tipo di contenuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "Viene visualizzato come testo del link."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "Poster"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "Cartolina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "Aggiunta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "Debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "Documentazione della mostra"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "Piastra per libri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "Estratto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "Scheda didattica"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "Illustrazioni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "Immagine di copertina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "Informazioni sulla consegna"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Informazioni biografiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "Introduzione/prefazione"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "Lettura di classe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "Kit per insegnanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "Nota dell'editore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "Nota sul contenuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "Frontespizio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "Fotografia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "Riassunto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "Risorsa online tramite RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "Rassegna stampa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "Sito web"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "Indice dei contenuti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "Testo completo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "Esempio: Accesso solo dalla biblioteca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "Raccolto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 "Documento è stato raccolto o no, disattiva la possibilità di modificare "
 "il record o vice versa."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "Codice di lingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "abcaso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "accinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "acioli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "adyghe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "afroasiatiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "accado"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "albanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "aleuto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "lingue algonchine"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "altai meridionale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "amarico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "inglese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "lingue apache"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "arabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "aramaico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "aragonese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "armeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "lingua artificiale (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "aruaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "assamese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "lingue athabaska"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "lingue australiane aborigene"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "avaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "avestan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "azerbaigiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "banda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "lingue bamileke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "baschiro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "beluci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "balinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "basco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "lingue baltiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "begia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "bielorusso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "wemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "bengalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "lingue berbere"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "bicol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "bantu (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "bosniaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "bretone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "batak (indonesia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "buriat"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "bugi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "bulgaro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "birmano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "indiane centro-americane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "caribico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "catalano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "lingue caucasiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "lingue celtiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "ceceno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "ciagataico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "cinese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "chuukese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "gergo chinook"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "slavo della Chiesa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "ciuvascio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "copto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "cornico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "corso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "creoli e pidgin basati sull'inglese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "creoli e pidgin basati sul francese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "creoli e pidgin basati sul portoghese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "turco crimeo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "creoli e pidgin (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "kashubian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "lingue cushitiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "ceco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "danese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "dayak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "slave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "dinca"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "dravidiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "basso sorabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "olandese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "olandese; fiammingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "diula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "egiziano antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "ekajuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "elamitico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "inglese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "inglese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "estone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "faroese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "figiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "filippino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "finlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "ugrofinniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "francese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "francese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "francese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "frisone settentrionale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "frisone orientale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "frisone occidentale"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "fulah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "friulano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "lingue germaniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "tedesco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "geez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "gilbertese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "gaelico scozzese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "irlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "galiziano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "mannese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "tedesco medio alto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "tedesco antico alto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "gotico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "greco antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "greco moderno (dal 1453)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "tedesco svizzero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "haitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "ebraico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "ilongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "hittite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "croato"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "alto sorabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "ungherese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "islandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "sichuan yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "ijo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "lingue indoarie (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "indonesiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "lingue indoeuropee (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "ingush"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "inupiak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "lingue iraniche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "lingue irochesi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "italiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "giavanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "giapponese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "giudeo persiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "giudeo arabo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "kara-kalpak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "cabilo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "groenlandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "kashmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "kazako"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "cabardino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "khoisan (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "khotanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "kirghiso"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "coreano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "kosraean"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "karachay-Balkar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "careliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "kru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "curdo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "giudeo-spagnolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "lao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "latino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "lettone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "lesgo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "limburghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "lituano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "lolo bantu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "lussemburghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "ganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "luiseno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "lushai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "macedone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "madurese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "marshallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "makasar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "austronesiano (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "masai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "malay"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "irlandese medio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "micmac"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "menangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "ainu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "mon-khmer (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "malgascio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "maltese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "manchu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "lingue manobo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "mongolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "multilingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "lingue munda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "mirandese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "maya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "erzya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "indiano nordamericano (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "napoletano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "nauru"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "ndebele del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "ndebele del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "basso tedesco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "nepalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "niger-kordofaniane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "niue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "norvegese nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "norvegese bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "norse antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "norvegese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "sotho del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "lingue nubiane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "newari classico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "occitano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "ossetico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "turco ottomano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "lingue otomiane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "papuasiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "punjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "palauano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "persiano antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "persiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "filippine (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "polacco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "ponape"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "portoghese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "lingue pracrite"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "provenzale antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "pashto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "rarotonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "lingue romanze (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "romancio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "romeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "rundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "arumeno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "russo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "yakut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "lingue indiane sudamericane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "lingue salish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "aramaico samaritano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "sanscrito"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "scozzese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "selkup"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "lingue semitiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "irlandese antico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "lingua dei segni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "singalese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "lingue sioux"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "sinotibetane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "lingue slave (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "slovacco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "sloveno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "sami del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "sami del nord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "lingue sami (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "sami di Lule"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "sami di Inari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "samoano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "somalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "sotho del sud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "spagnolo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "sardo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "serbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "lingue nilo-sahariane (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "swati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "sundanese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "susu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "sumero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "svedese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "siriaco classico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "taitiano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "thailandese (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "tataro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "temne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "tetum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "tagico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "tigrino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "nyasa del Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "tongano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "turcomanno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "lingue tupi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "turco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "altaiche (altre)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "ci"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "tuvinian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "ugaritico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "uiguro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "ucraino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "mbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "lingua imprecisata"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "uzbeco"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "voto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "lingue wakash"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "walamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "gallese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "lingue lusaziane"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "vallone"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "yao (bantu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "yapese"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "lingue yupik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "blissymbol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "zulu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "nessun contenuto linguistico"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "Valori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "valore"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "Albania (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "Isole Ashmore e Cartier (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "Territorio della Capitale Australiana (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "Algeria (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "Argentina (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "Armenia (Repubblica) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "R.S.S. di Armenia (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "Azerbaigian (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "R.S.S. dell' Azerbaigian (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "Antigua e Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "Samoa americane (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "Australia (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "Austria (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "Antartide (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "Bahrein (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "Columbia Britannica (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "Belgio (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "Bahamas (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "Territorio britannico dell’Oceano Indiano (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "Brasile (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "Bermuda (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "Bosnia ed Erzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "Isole Salomone (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "Birmania (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "Bulgaria (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "Isola Bouvet (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "Bielorussia (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "R.S.S. Bielorussia (bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "Paesi Bassi caraibici (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "California (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "Cambogia (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "Cina (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "Ciad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "Congo-Brazzaville (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "Repubblica Democratica del Congo (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "Repubblica Popolare Cinese (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "Croazia (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "Isole Cayman (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "Cile (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "Camerun (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "Isole Canton ed Enderbury (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "Comore (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "Cecoslovacchia (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "Capo Verde (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "Isole Cook (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "Repubblica Centrafricana (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "Cipro (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "Zona del Canale di Panama (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "Distretto di Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "Danimarca (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "Repubblica Dominicana (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "Guinea Equatoriale (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "Timor Est (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "Inghilterra (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "Estonia (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "R.S.S. di Estonia (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "Etiopia (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "Isole Fær Øer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "Guyana francese (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "Finlandia (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "Figi (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "Isole Falkland (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "Stati Federati di Micronesia (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "Polinesia francese (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "Francia (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "Terre australi e antartiche francesi (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "Gibuti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "Georgia (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "Repubblica Democratica Tedesca (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "Gibilterra (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "Groenlandia (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "Isole Gilbert ed Ellice (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "Guadalupa (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "Grecia (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "Georgia (Repubblica) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "R.S.S. Georgiana (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "Guinea (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "Germania (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "Striscia di Gaza (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "RAS di Hong Kong (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "Isole Heard e McDonald (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "Haiti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "Ungheria (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "Islanda (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "Irlanda (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "Isola di Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "Indonesia (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "Iraq (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "Iràn (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "Israele (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "Italia (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "Zone demilitarizzate Israele-Siria (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "Costa d’Avorio (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "Zone demilitarizzate Israele-Giordania (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "zona neutrale iracheno-saudita (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "Giappone (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "atollo Johnston (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "Giamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "Giordania (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "Kenya (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "Kirghizistan (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "R.S.S. Kirghiza (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "Corea del Nord (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "Corea del Sud (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "Kuwait (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "Kazakistan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "R.S.S. Kazaka (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "Libano (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "Lituania (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "R.S.S. Lituana (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "Sporadi Equatoriali (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "Lussemburgo (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "Lettonia (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "R.S.S. Lettone (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "Libia (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "Madagascar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "RAS di Macao (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "Mongolia (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "Martinica (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "Marocco (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "Mauritania (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "Moldavia (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "R.S.S. Moldava (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "Messico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "Malaysia (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "Mozambico (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "Antille Olandesi (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "Carolina del Nord  (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "Dakota del Nord (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "Paesi Bassi (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "Terranova e Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "Irlanda del Nord (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "Nuovo Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "Nuova Caledonia (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "Isole Marianne settentrionali (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "Nuovo Messico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "Norvegia (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "[Nova Scotia] (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "[Northwest Territories] (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "[Nunavut] (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "[Nevada] (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "Isole Marianne settentrionali (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "Isola Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "[New York (State)] (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "Nuova Zelanda (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "[Ohio] (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "[Oklahoma] (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "[Ontario] (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "[Oregon] (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "[Pitcairn Island] (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "Perù (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "[Paracel Islands] (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "Guinea-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "Filippine (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "[Prince Edward Island] (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "Polonia (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "Panamá (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "Portogallo (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "Papua Nuova Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "Portorico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "[Portuguese Timor] (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "[Queensland] (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "[Québec (Province)] (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "Serbia (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "Riunione (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "[Rhode Island] (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "Romania (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "[Russia (Federation)] (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "[Russian S.F.S.R.] (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "Ruanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr "[Ryukyu Islands, Southern] (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "Sudafrica (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "[Svalbard] (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "[Saint-Barthélemy] (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "[South Carolina] (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "Sud Sudan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "[South Dakota] (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "Seychelles (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "São Tomé e Príncipe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "[Spanish North Africa] (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "Sudan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "[Sikkim] (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "[Sint Maarten] (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "[Saskatchewan] (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "Somalia (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "Spagna (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "Swaziland (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "[Surinam] (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "Sahara occidentale (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "[Saint-Martin] (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "[Scotland] (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "Arabia Saudita (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "[Swan Islands] (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "Svezia (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "Namibia (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "[Syria] (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "Svizzera (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "Tagikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "[Tajik S.S.R.] (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "Isole Turks e Caicos (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "Thailandia (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "Tunisia (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "[Turkmen S.S.R.] (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "[Tasmania] (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "[Tennessee] (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "Trinidad e Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "Emirati Arabi Uniti (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "[Trust Territory of the Pacific Islands] (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "Turchia (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "[Texas] (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "Egitto (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "[United States Misc. Caribbean Islands] (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "Uganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "[United Kingdom Misc. Islands] (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "[United Kingdom Misc. Islands] (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "Regno Unito (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "Ucraina (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "Ucraina (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "[United States Misc. Pacific Islands] (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "[Soviet Union] (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "Stati Uniti (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "[Utah] (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "Uzbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "[Uzbek S.S.R.] (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "[Virginia] (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "Isole Vergini Britanniche (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "[Vatican City] (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "Isole Vergini Americane (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "[Vietnam, North] (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "[Various places] (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "[Victoria] (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "[Vietnam, South] (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "[Vermont] (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "[Washington (State)] (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "[West Berlin] (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "[Western Australia] (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "Wallis e Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "[Wisconsin] (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "[West Bank of the Jordan River] (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "[Wake Island] (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "[Wales] (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "[West Virginia] (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "[Wyoming] (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "[Christmas Island (Indian Ocean)] (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "Isole Cocos (Keeling) (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "Maldive (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "[Saint Kitts-Nevis] (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "Isole Marshall (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "[Midway Islands] (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "[Coral Sea Islands Territory] (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "[Saint Kitts-Nevis-Anguilla] (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "[Saint Helena] (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "Saint-Pierre e Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "Saint Vincent e Grenadine (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "Macedonia del Nord (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "[New South Wales] (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "Slovacchia (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "[Northern Territory] (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "[Spratly Island] (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "Cechia (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "[South Australia] (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "Georgia del Sud e Sandwich australi (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "Slovenia (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "[No place, unknown, or undetermined] (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "Regno Unito (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "[Soviet Union] (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "Stati Uniti (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "Yemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "[Yukon Territory] (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "[Yemen (People's Democratic Republic)] (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "[Serbia and Montenegro] (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Cantoni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "AG (Argovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "AI (Appenzello Interno)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "AR (Appenzello Esterno)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "BE (Berna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "BL (Basilea Campagna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "BS (Basilea Città)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "FR (Friburgo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "GE (Ginevra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "GL (Glarona)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "GR (Grigioni)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "JU (Giura)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "LU (Lucerna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "NE (Neuchâtel)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "NW (Nidvaldo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "OW (Obvaldo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "SG (San Gallo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "SH (Sciaffusa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "SO (Soletta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "SZ (Svitto)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "TG (Turgovia)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "TI (Ticino)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "UR (Uri)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "VD (Vaud)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "VS (Vallese)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "ZG (Zugo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "ZH (Zurigo)"
 
@@ -6721,6 +6726,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr ""
@@ -6842,7 +6851,6 @@ msgid "Barcode"
 msgstr "Codice a barre"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Un'altro tipo di esemplare online esiste in questa organizzazione"
 
@@ -6867,8 +6875,8 @@ msgid "Name of the ItemType."
 msgstr "Nome del tipo di esemplare."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
-msgstr "Il nome del tipo di esemplare è già utilizzato"
+msgid "The item type name is already taken."
+msgstr "Il nome del tipo di esemplare è già utilizzato."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
 msgid "Description of the ItemType."
@@ -6881,6 +6889,10 @@ msgstr "Tipo della categoria di prestito"
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "Standard"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "Un'altro tipo di esemplare online esiste in questa organizzazione."
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6921,8 +6933,9 @@ msgid "Item ID"
 msgstr "ID dell'esemplare"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
-msgstr "Il codice a barre è già utilizzato"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
+msgstr "Il codice a barre è già utilizzato."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
 msgid "Item Type"
@@ -6971,7 +6984,7 @@ msgstr "ID della biblioteca"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "Codice"
 
@@ -6984,7 +6997,7 @@ msgid "Name of the library."
 msgstr "Nome della biblioteca."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "Indirizzo"
 
@@ -6996,7 +7009,7 @@ msgstr "Indirizzo della biblioteca"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "Email"
 
@@ -7216,6 +7229,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7301,39 +7321,38 @@ msgid "Organisation ID"
 msgstr "Ente ID"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "Richiesto. Nome di un'organizzazione."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "Indirizzo dell'organizzazione."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "Codice dell'organizzazione."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "Attuale ID del bilancio"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "L'ID del attuale bilancio dell'organizzazione"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "Valuta predefinita"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "La valuta predefinita dell'organizzazione"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "Fonte raccolta online"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Fonte raccolta online, come configurato nel server di ebooks"
 
@@ -7535,6 +7554,10 @@ msgstr "Cognome"
 msgid "Date of birth"
 msgstr "Data di nascita"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Esempio: 1985-12-29"
@@ -7565,20 +7588,26 @@ msgstr "Codice postale"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "Città"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "Numero di telefono"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "Numero di telefono con l'indicazione internazionale, senza spazi."
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "Numero di telefono con l'indicazione internazionale, senza spazi."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7601,10 +7630,6 @@ msgstr "URI del tipo di lettore"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "Numero di codice a barre o di tessera del lettore"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "Il codice a barre è già utilizzato."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7852,8 +7877,8 @@ msgid "Vendor ID"
 msgstr "ID del fornitore"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
-msgstr "Il nome del fornitore é già utilizzato"
+msgid "The vendor name is already taken."
+msgstr "Il nome del fornitore é già utilizzato."
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
 msgid "Website"
@@ -7887,15 +7912,11 @@ msgstr "Nome di contatto"
 msgid "Name of the vendor contact person."
 msgstr ""
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "Un codice postale valido con un minimo di 4 caratteri."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "Valuta"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "aliquota IVA"
 
@@ -8075,4 +8096,10 @@ msgstr "Clicca qui per reimpostare la password"
 
 #~ msgid "requested"
 #~ msgstr "richiesto"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "Il codice a barre è già utilizzato"
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "Un codice postale valido con un minimo di 4 caratteri."
 

--- a/rero_ils/translations/messages.pot
+++ b/rero_ils/translations/messages.pot
@@ -3,12 +3,11 @@
 # This file is distributed under the same license as the rero-ils project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
-
 msgid ""
 msgstr ""
-"Project-Id-Version: rero-ils 0.8.0\n"
+"Project-Id-Version: rero-ils 0.9.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,8 +72,8 @@ msgid "author__it"
 msgstr ""
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr ""
 
@@ -361,8 +360,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr ""
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -373,8 +372,8 @@ msgid "Library"
 msgstr ""
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -383,10 +382,10 @@ msgid "Library URI"
 msgstr ""
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -399,15 +398,15 @@ msgstr ""
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr ""
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -415,7 +414,7 @@ msgstr ""
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr ""
 
@@ -467,7 +466,7 @@ msgid "Price per unit"
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr ""
@@ -489,7 +488,7 @@ msgid "Invoice number"
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
+msgid "The invoice number is already taken."
 msgstr ""
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
@@ -522,81 +521,81 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr ""
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr ""
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr ""
 
@@ -652,7 +651,7 @@ msgid "Quantity"
 msgstr ""
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr ""
 
@@ -685,6 +684,12 @@ msgstr ""
 msgid "Acquisition order URI"
 msgstr ""
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr ""
@@ -702,7 +707,7 @@ msgid "AcqOrder ID"
 msgstr ""
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
+msgid "The order number is already taken."
 msgstr ""
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
@@ -766,18 +771,18 @@ msgid "Name of the budget."
 msgstr ""
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
+msgid "The budget name is already taken."
 msgstr ""
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr ""
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr ""
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr ""
 
@@ -984,9 +989,9 @@ msgid "Sound"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr ""
 
@@ -1260,11 +1265,11 @@ msgid "type"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr ""
 
@@ -1783,4749 +1788,4749 @@ msgstr ""
 msgid "Status of the ISBN/ISSN identifier."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
-msgid "Subject of the resource."
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+msgid "Subject of the resource."
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
-msgid "Resource"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
-msgid "Version of resource"
+msgid "Resource"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
-msgid "Related resource"
+msgid "Version of resource"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
-msgid "Hidden URL"
+#: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
+msgid "Related resource"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+msgid "Hidden URL"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
-msgid "Poster"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
-msgid "Audio"
+msgid "Poster"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
-msgid "Postcard"
+msgid "Audio"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
-msgid "Addition"
+msgid "Postcard"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
-msgid "Debriefing"
+msgid "Addition"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
-msgid "Exhibition documentation"
+msgid "Debriefing"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
-msgid "Erratum"
+msgid "Exhibition documentation"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
-msgid "Bookplate"
+msgid "Erratum"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
-msgid "Extract"
+msgid "Bookplate"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
-msgid "Educational sheet"
+msgid "Extract"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
-msgid "Illustrations"
+msgid "Educational sheet"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
-msgid "Cover image"
+#: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
+msgid "Illustrations"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
-msgid "Delivery information"
+msgid "Cover image"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+msgid "Delivery information"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
-msgid "Introduction/preface"
-msgstr ""
-
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
-msgid "Class reading"
+msgid "Introduction/preface"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
-msgid "Teacher's kit"
+msgid "Class reading"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
-msgid "Publisher's note"
+msgid "Teacher's kit"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
-msgid "Note on content"
+msgid "Publisher's note"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
-msgid "Title page"
+msgid "Note on content"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
-msgid "Photography"
+msgid "Title page"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
-msgid "Summarization"
+msgid "Photography"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
-msgid "Online resource via RERO DOC"
+msgid "Summarization"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
-msgid "Press review"
+msgid "Online resource via RERO DOC"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
-msgid "Web site"
+msgid "Press review"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
-msgid "Table of contents"
+msgid "Web site"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+msgid "Table of contents"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
-msgid "lang_aar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
-msgid "lang_abk"
+msgid "lang_aar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
-msgid "lang_ace"
+msgid "lang_abk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
-msgid "lang_ach"
+msgid "lang_ace"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
-msgid "lang_ada"
+msgid "lang_ach"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
-msgid "lang_ady"
+msgid "lang_ada"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
-msgid "lang_afa"
+msgid "lang_ady"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
-msgid "lang_afh"
+msgid "lang_afa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
-msgid "lang_afr"
+msgid "lang_afh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
-msgid "lang_ain"
+msgid "lang_afr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
-msgid "lang_aka"
+msgid "lang_ain"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
-msgid "lang_akk"
+msgid "lang_aka"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
-msgid "lang_alb"
+msgid "lang_akk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
-msgid "lang_ale"
+msgid "lang_alb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
-msgid "lang_alg"
+msgid "lang_ale"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
-msgid "lang_alt"
+msgid "lang_alg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
-msgid "lang_amh"
+msgid "lang_alt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
-msgid "lang_ang"
+msgid "lang_amh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
-msgid "lang_anp"
+msgid "lang_ang"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
-msgid "lang_apa"
+msgid "lang_anp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
-msgid "lang_ara"
+msgid "lang_apa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
-msgid "lang_arc"
+msgid "lang_ara"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
-msgid "lang_arg"
+msgid "lang_arc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
-msgid "lang_arm"
+msgid "lang_arg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
-msgid "lang_arn"
+msgid "lang_arm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
-msgid "lang_arp"
+msgid "lang_arn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
-msgid "lang_art"
+msgid "lang_arp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
-msgid "lang_arw"
+msgid "lang_art"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
-msgid "lang_asm"
+msgid "lang_arw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
-msgid "lang_ast"
+msgid "lang_asm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
-msgid "lang_ath"
+msgid "lang_ast"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
-msgid "lang_aus"
+msgid "lang_ath"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
-msgid "lang_ava"
+msgid "lang_aus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
-msgid "lang_ave"
+msgid "lang_ava"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
-msgid "lang_awa"
+msgid "lang_ave"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
-msgid "lang_aym"
+msgid "lang_awa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
-msgid "lang_aze"
+msgid "lang_aym"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
-msgid "lang_bad"
+msgid "lang_aze"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
-msgid "lang_bai"
+msgid "lang_bad"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
-msgid "lang_bak"
+msgid "lang_bai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
-msgid "lang_bal"
+msgid "lang_bak"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
-msgid "lang_bam"
+msgid "lang_bal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
-msgid "lang_ban"
+msgid "lang_bam"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
-msgid "lang_baq"
+msgid "lang_ban"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
-msgid "lang_bas"
+msgid "lang_baq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
-msgid "lang_bat"
+msgid "lang_bas"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
-msgid "lang_bej"
+msgid "lang_bat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
-msgid "lang_bel"
+msgid "lang_bej"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
-msgid "lang_bem"
+msgid "lang_bel"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
-msgid "lang_ben"
+msgid "lang_bem"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
-msgid "lang_ber"
+msgid "lang_ben"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
-msgid "lang_bho"
+msgid "lang_ber"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
-msgid "lang_bih"
+msgid "lang_bho"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
-msgid "lang_bik"
+msgid "lang_bih"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
-msgid "lang_bin"
+msgid "lang_bik"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
-msgid "lang_bis"
+msgid "lang_bin"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
-msgid "lang_bla"
+msgid "lang_bis"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
-msgid "lang_bnt"
+msgid "lang_bla"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
-msgid "lang_bos"
+msgid "lang_bnt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
-msgid "lang_bra"
+msgid "lang_bos"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
-msgid "lang_bre"
+msgid "lang_bra"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
-msgid "lang_btk"
+msgid "lang_bre"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
-msgid "lang_bua"
+msgid "lang_btk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
-msgid "lang_bug"
+msgid "lang_bua"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
-msgid "lang_bul"
+msgid "lang_bug"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
-msgid "lang_bur"
+msgid "lang_bul"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
-msgid "lang_byn"
+msgid "lang_bur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
-msgid "lang_cad"
+msgid "lang_byn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
-msgid "lang_cai"
+msgid "lang_cad"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
-msgid "lang_car"
+msgid "lang_cai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
-msgid "lang_cat"
+msgid "lang_car"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
-msgid "lang_cau"
+msgid "lang_cat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
-msgid "lang_ceb"
+msgid "lang_cau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
-msgid "lang_cel"
+msgid "lang_ceb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
-msgid "lang_cha"
+msgid "lang_cel"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
-msgid "lang_chb"
+msgid "lang_cha"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
-msgid "lang_che"
+msgid "lang_chb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
-msgid "lang_chg"
+msgid "lang_che"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
-msgid "lang_chi"
+msgid "lang_chg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
-msgid "lang_chk"
+msgid "lang_chi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
-msgid "lang_chm"
+msgid "lang_chk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
-msgid "lang_chn"
+msgid "lang_chm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
-msgid "lang_cho"
+msgid "lang_chn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
-msgid "lang_chp"
+msgid "lang_cho"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
-msgid "lang_chr"
+msgid "lang_chp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
-msgid "lang_chu"
+msgid "lang_chr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
-msgid "lang_chv"
+msgid "lang_chu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
-msgid "lang_chy"
+msgid "lang_chv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
-msgid "lang_cmc"
+msgid "lang_chy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
-msgid "lang_cnr"
+msgid "lang_cmc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
-msgid "lang_cop"
+msgid "lang_cnr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
-msgid "lang_cor"
+msgid "lang_cop"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
-msgid "lang_cos"
+msgid "lang_cor"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
-msgid "lang_cpe"
+msgid "lang_cos"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
-msgid "lang_cpf"
+msgid "lang_cpe"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
-msgid "lang_cpp"
+msgid "lang_cpf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
-msgid "lang_cre"
+msgid "lang_cpp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
-msgid "lang_crh"
+msgid "lang_cre"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
-msgid "lang_crp"
+msgid "lang_crh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
-msgid "lang_csb"
+msgid "lang_crp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
-msgid "lang_cus"
+msgid "lang_csb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
-msgid "lang_cze"
+msgid "lang_cus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
-msgid "lang_dak"
+msgid "lang_cze"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
-msgid "lang_dan"
+msgid "lang_dak"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
-msgid "lang_dar"
+msgid "lang_dan"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
-msgid "lang_day"
+msgid "lang_dar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
-msgid "lang_del"
+msgid "lang_day"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
-msgid "lang_den"
+msgid "lang_del"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
-msgid "lang_dgr"
+msgid "lang_den"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
-msgid "lang_din"
+msgid "lang_dgr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
-msgid "lang_div"
+msgid "lang_din"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
-msgid "lang_doi"
+msgid "lang_div"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
-msgid "lang_dra"
+msgid "lang_doi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
-msgid "lang_dsb"
+msgid "lang_dra"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
-msgid "lang_dua"
+msgid "lang_dsb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
-msgid "lang_dum"
+msgid "lang_dua"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
-msgid "lang_dut"
+msgid "lang_dum"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
-msgid "lang_dyu"
+msgid "lang_dut"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
-msgid "lang_dzo"
+msgid "lang_dyu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
-msgid "lang_efi"
+msgid "lang_dzo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
-msgid "lang_egy"
+msgid "lang_efi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
-msgid "lang_eka"
+msgid "lang_egy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
-msgid "lang_elx"
+msgid "lang_eka"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
-msgid "lang_eng"
+msgid "lang_elx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
-msgid "lang_enm"
+msgid "lang_eng"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
-msgid "lang_epo"
+msgid "lang_enm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
-msgid "lang_est"
+msgid "lang_epo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
-msgid "lang_ewe"
+msgid "lang_est"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
-msgid "lang_ewo"
+msgid "lang_ewe"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
-msgid "lang_fan"
+msgid "lang_ewo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
-msgid "lang_fao"
+msgid "lang_fan"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
-msgid "lang_fat"
+msgid "lang_fao"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
-msgid "lang_fij"
+msgid "lang_fat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
-msgid "lang_fil"
+msgid "lang_fij"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
-msgid "lang_fin"
+msgid "lang_fil"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
-msgid "lang_fiu"
+msgid "lang_fin"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
-msgid "lang_fon"
+msgid "lang_fiu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
-msgid "lang_fre"
+msgid "lang_fon"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
-msgid "lang_frm"
+msgid "lang_fre"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
-msgid "lang_fro"
+msgid "lang_frm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
-msgid "lang_frr"
+msgid "lang_fro"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
-msgid "lang_frs"
+msgid "lang_frr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
-msgid "lang_fry"
+msgid "lang_frs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
-msgid "lang_ful"
+msgid "lang_fry"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
-msgid "lang_fur"
+msgid "lang_ful"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
-msgid "lang_gaa"
+msgid "lang_fur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
-msgid "lang_gay"
+msgid "lang_gaa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
-msgid "lang_gba"
+msgid "lang_gay"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
-msgid "lang_gem"
+msgid "lang_gba"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
-msgid "lang_geo"
+msgid "lang_gem"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
-msgid "lang_ger"
+msgid "lang_geo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
-msgid "lang_gez"
+msgid "lang_ger"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
-msgid "lang_gil"
+msgid "lang_gez"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
-msgid "lang_gla"
+msgid "lang_gil"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
-msgid "lang_gle"
+msgid "lang_gla"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
-msgid "lang_glg"
+msgid "lang_gle"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
-msgid "lang_glv"
+msgid "lang_glg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
-msgid "lang_gmh"
+msgid "lang_glv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
-msgid "lang_goh"
+msgid "lang_gmh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
-msgid "lang_gon"
+msgid "lang_goh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
-msgid "lang_gor"
+msgid "lang_gon"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
-msgid "lang_got"
+msgid "lang_gor"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
-msgid "lang_grb"
+msgid "lang_got"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
-msgid "lang_grc"
+msgid "lang_grb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
-msgid "lang_gre"
+msgid "lang_grc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
-msgid "lang_grn"
+msgid "lang_gre"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
-msgid "lang_gsw"
+msgid "lang_grn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
-msgid "lang_guj"
+msgid "lang_gsw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
-msgid "lang_gwi"
+msgid "lang_guj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
-msgid "lang_hai"
+msgid "lang_gwi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
-msgid "lang_hat"
+msgid "lang_hai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
-msgid "lang_hau"
+msgid "lang_hat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
-msgid "lang_haw"
+msgid "lang_hau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
-msgid "lang_heb"
+msgid "lang_haw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
-msgid "lang_her"
+msgid "lang_heb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
-msgid "lang_hil"
+msgid "lang_her"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
-msgid "lang_him"
+msgid "lang_hil"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
-msgid "lang_hin"
+msgid "lang_him"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
-msgid "lang_hit"
+msgid "lang_hin"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
-msgid "lang_hmn"
+msgid "lang_hit"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
-msgid "lang_hmo"
+msgid "lang_hmn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
-msgid "lang_hrv"
+msgid "lang_hmo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
-msgid "lang_hsb"
+msgid "lang_hrv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
-msgid "lang_hun"
+msgid "lang_hsb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
-msgid "lang_hup"
+msgid "lang_hun"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
-msgid "lang_iba"
+msgid "lang_hup"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
-msgid "lang_ibo"
+msgid "lang_iba"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
-msgid "lang_ice"
+msgid "lang_ibo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
-msgid "lang_ido"
+msgid "lang_ice"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
-msgid "lang_iii"
+msgid "lang_ido"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
-msgid "lang_ijo"
+msgid "lang_iii"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
-msgid "lang_iku"
+msgid "lang_ijo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
-msgid "lang_ile"
+msgid "lang_iku"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
-msgid "lang_ilo"
+msgid "lang_ile"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
-msgid "lang_ina"
+msgid "lang_ilo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
-msgid "lang_inc"
+msgid "lang_ina"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
-msgid "lang_ind"
+msgid "lang_inc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
-msgid "lang_ine"
+msgid "lang_ind"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
-msgid "lang_inh"
+msgid "lang_ine"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
-msgid "lang_ipk"
+msgid "lang_inh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
-msgid "lang_ira"
+msgid "lang_ipk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
-msgid "lang_iro"
+msgid "lang_ira"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
-msgid "lang_ita"
+msgid "lang_iro"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
-msgid "lang_jav"
+msgid "lang_ita"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
-msgid "lang_jbo"
+msgid "lang_jav"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
-msgid "lang_jpn"
+msgid "lang_jbo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
-msgid "lang_jpr"
+msgid "lang_jpn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
-msgid "lang_jrb"
+msgid "lang_jpr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
-msgid "lang_kaa"
+msgid "lang_jrb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
-msgid "lang_kab"
+msgid "lang_kaa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
-msgid "lang_kac"
+msgid "lang_kab"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
-msgid "lang_kal"
+msgid "lang_kac"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
-msgid "lang_kam"
+msgid "lang_kal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
-msgid "lang_kan"
+msgid "lang_kam"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
-msgid "lang_kar"
+msgid "lang_kan"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
-msgid "lang_kas"
+msgid "lang_kar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
-msgid "lang_kau"
+msgid "lang_kas"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
-msgid "lang_kaw"
+msgid "lang_kau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
-msgid "lang_kaz"
+msgid "lang_kaw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
-msgid "lang_kbd"
+msgid "lang_kaz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
-msgid "lang_kha"
+msgid "lang_kbd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
-msgid "lang_khi"
+msgid "lang_kha"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
-msgid "lang_khm"
+msgid "lang_khi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
-msgid "lang_kho"
+msgid "lang_khm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
-msgid "lang_kik"
+msgid "lang_kho"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
-msgid "lang_kin"
+msgid "lang_kik"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
-msgid "lang_kir"
+msgid "lang_kin"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
-msgid "lang_kmb"
+msgid "lang_kir"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
-msgid "lang_kok"
+msgid "lang_kmb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
-msgid "lang_kom"
+msgid "lang_kok"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
-msgid "lang_kon"
+msgid "lang_kom"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
-msgid "lang_kor"
+msgid "lang_kon"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
-msgid "lang_kos"
+msgid "lang_kor"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
-msgid "lang_kpe"
+msgid "lang_kos"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
-msgid "lang_krc"
+msgid "lang_kpe"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
-msgid "lang_krl"
+msgid "lang_krc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
-msgid "lang_kro"
+msgid "lang_krl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
-msgid "lang_kru"
+msgid "lang_kro"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
-msgid "lang_kua"
+msgid "lang_kru"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
-msgid "lang_kum"
+msgid "lang_kua"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
-msgid "lang_kur"
+msgid "lang_kum"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
-msgid "lang_kut"
+msgid "lang_kur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
-msgid "lang_lad"
+msgid "lang_kut"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
-msgid "lang_lah"
+msgid "lang_lad"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
-msgid "lang_lam"
+msgid "lang_lah"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
-msgid "lang_lao"
+msgid "lang_lam"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
-msgid "lang_lat"
+msgid "lang_lao"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
-msgid "lang_lav"
+msgid "lang_lat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
-msgid "lang_lez"
+msgid "lang_lav"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
-msgid "lang_lim"
+msgid "lang_lez"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
-msgid "lang_lin"
+msgid "lang_lim"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
-msgid "lang_lit"
+msgid "lang_lin"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
-msgid "lang_lol"
+msgid "lang_lit"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
-msgid "lang_loz"
+msgid "lang_lol"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
-msgid "lang_ltz"
+msgid "lang_loz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
-msgid "lang_lua"
+msgid "lang_ltz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
-msgid "lang_lub"
+msgid "lang_lua"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
-msgid "lang_lug"
+msgid "lang_lub"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
-msgid "lang_lui"
+msgid "lang_lug"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
-msgid "lang_lun"
+msgid "lang_lui"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
-msgid "lang_luo"
+msgid "lang_lun"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
-msgid "lang_lus"
+msgid "lang_luo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
-msgid "lang_mac"
+msgid "lang_lus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
-msgid "lang_mad"
+msgid "lang_mac"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
-msgid "lang_mag"
+msgid "lang_mad"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
-msgid "lang_mah"
+msgid "lang_mag"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
-msgid "lang_mai"
+msgid "lang_mah"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
-msgid "lang_mak"
+msgid "lang_mai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
-msgid "lang_mal"
+msgid "lang_mak"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
-msgid "lang_man"
+msgid "lang_mal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
-msgid "lang_mao"
+msgid "lang_man"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
-msgid "lang_map"
+msgid "lang_mao"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
-msgid "lang_mar"
+msgid "lang_map"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
-msgid "lang_mas"
+msgid "lang_mar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
-msgid "lang_may"
+msgid "lang_mas"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
-msgid "lang_mdf"
+msgid "lang_may"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
-msgid "lang_mdr"
+msgid "lang_mdf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
-msgid "lang_men"
+msgid "lang_mdr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
-msgid "lang_mga"
+msgid "lang_men"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
-msgid "lang_mic"
+msgid "lang_mga"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
-msgid "lang_min"
+msgid "lang_mic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
-msgid "lang_mis"
+msgid "lang_min"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
-msgid "lang_mkh"
+msgid "lang_mis"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
-msgid "lang_mlg"
+msgid "lang_mkh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
-msgid "lang_mlt"
+msgid "lang_mlg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
-msgid "lang_mnc"
+msgid "lang_mlt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
-msgid "lang_mni"
+msgid "lang_mnc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
-msgid "lang_mno"
+msgid "lang_mni"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
-msgid "lang_moh"
+msgid "lang_mno"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
-msgid "lang_mon"
+msgid "lang_moh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
-msgid "lang_mos"
+msgid "lang_mon"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
-msgid "lang_mul"
+msgid "lang_mos"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
-msgid "lang_mun"
+msgid "lang_mul"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
-msgid "lang_mus"
+msgid "lang_mun"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
-msgid "lang_mwl"
+msgid "lang_mus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
-msgid "lang_mwr"
+msgid "lang_mwl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
-msgid "lang_myn"
+msgid "lang_mwr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
-msgid "lang_myv"
+msgid "lang_myn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
-msgid "lang_nah"
+msgid "lang_myv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
-msgid "lang_nai"
+msgid "lang_nah"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
-msgid "lang_nap"
+msgid "lang_nai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
-msgid "lang_nau"
+msgid "lang_nap"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
-msgid "lang_nav"
+msgid "lang_nau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
-msgid "lang_nbl"
+msgid "lang_nav"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
-msgid "lang_nde"
+msgid "lang_nbl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
-msgid "lang_ndo"
+msgid "lang_nde"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
-msgid "lang_nds"
+msgid "lang_ndo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
-msgid "lang_nep"
+msgid "lang_nds"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
-msgid "lang_new"
+msgid "lang_nep"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
-msgid "lang_nia"
+msgid "lang_new"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
-msgid "lang_nic"
+msgid "lang_nia"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
-msgid "lang_niu"
+msgid "lang_nic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
-msgid "lang_nno"
+msgid "lang_niu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
-msgid "lang_nob"
+msgid "lang_nno"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
-msgid "lang_nog"
+msgid "lang_nob"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
-msgid "lang_non"
+msgid "lang_nog"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
-msgid "lang_nor"
+msgid "lang_non"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
-msgid "lang_nqo"
+msgid "lang_nor"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
-msgid "lang_nso"
+msgid "lang_nqo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
-msgid "lang_nub"
+msgid "lang_nso"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
-msgid "lang_nwc"
+msgid "lang_nub"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
-msgid "lang_nya"
+msgid "lang_nwc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
-msgid "lang_nym"
+msgid "lang_nya"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
-msgid "lang_nyn"
+msgid "lang_nym"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
-msgid "lang_nyo"
+msgid "lang_nyn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
-msgid "lang_nzi"
+msgid "lang_nyo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
-msgid "lang_oci"
+msgid "lang_nzi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
-msgid "lang_oji"
+msgid "lang_oci"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
-msgid "lang_ori"
+msgid "lang_oji"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
-msgid "lang_orm"
+msgid "lang_ori"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
-msgid "lang_osa"
+msgid "lang_orm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
-msgid "lang_oss"
+msgid "lang_osa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
-msgid "lang_ota"
+msgid "lang_oss"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
-msgid "lang_oto"
+msgid "lang_ota"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
-msgid "lang_paa"
+msgid "lang_oto"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
-msgid "lang_pag"
+msgid "lang_paa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
-msgid "lang_pal"
+msgid "lang_pag"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
-msgid "lang_pam"
+msgid "lang_pal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
-msgid "lang_pan"
+msgid "lang_pam"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
-msgid "lang_pap"
+msgid "lang_pan"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
-msgid "lang_pau"
+msgid "lang_pap"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
-msgid "lang_peo"
+msgid "lang_pau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
-msgid "lang_per"
+msgid "lang_peo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
-msgid "lang_phi"
+msgid "lang_per"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
-msgid "lang_phn"
+msgid "lang_phi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
-msgid "lang_pli"
+msgid "lang_phn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
-msgid "lang_pol"
+msgid "lang_pli"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
-msgid "lang_pon"
+msgid "lang_pol"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
-msgid "lang_por"
+msgid "lang_pon"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
-msgid "lang_pra"
+msgid "lang_por"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
-msgid "lang_pro"
+msgid "lang_pra"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
-msgid "lang_pus"
+msgid "lang_pro"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
-msgid "lang_que"
+msgid "lang_pus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
-msgid "lang_raj"
+msgid "lang_que"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
-msgid "lang_rap"
+msgid "lang_raj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
-msgid "lang_rar"
+msgid "lang_rap"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
-msgid "lang_roa"
+msgid "lang_rar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
-msgid "lang_roh"
+msgid "lang_roa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
-msgid "lang_rom"
+msgid "lang_roh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
-msgid "lang_rum"
+msgid "lang_rom"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
-msgid "lang_run"
+msgid "lang_rum"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
-msgid "lang_rup"
+msgid "lang_run"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
-msgid "lang_rus"
+msgid "lang_rup"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
-msgid "lang_sad"
+msgid "lang_rus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
-msgid "lang_sag"
+msgid "lang_sad"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
-msgid "lang_sah"
+msgid "lang_sag"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
-msgid "lang_sai"
+msgid "lang_sah"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
-msgid "lang_sal"
+msgid "lang_sai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
-msgid "lang_sam"
+msgid "lang_sal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
-msgid "lang_san"
+msgid "lang_sam"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
-msgid "lang_sas"
+msgid "lang_san"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
-msgid "lang_sat"
+msgid "lang_sas"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
-msgid "lang_scn"
+msgid "lang_sat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
-msgid "lang_sco"
+msgid "lang_scn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
-msgid "lang_sel"
+msgid "lang_sco"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
-msgid "lang_sem"
+msgid "lang_sel"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
-msgid "lang_sga"
+msgid "lang_sem"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
-msgid "lang_sgn"
+msgid "lang_sga"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
-msgid "lang_shn"
+msgid "lang_sgn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
-msgid "lang_sid"
+msgid "lang_shn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
-msgid "lang_sin"
+msgid "lang_sid"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
-msgid "lang_sio"
+msgid "lang_sin"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
-msgid "lang_sit"
+msgid "lang_sio"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
-msgid "lang_sla"
+msgid "lang_sit"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
-msgid "lang_slo"
+msgid "lang_sla"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
-msgid "lang_slv"
+msgid "lang_slo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
-msgid "lang_sma"
+msgid "lang_slv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
-msgid "lang_sme"
+msgid "lang_sma"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
-msgid "lang_smi"
+msgid "lang_sme"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
-msgid "lang_smj"
+msgid "lang_smi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
-msgid "lang_smn"
+msgid "lang_smj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
-msgid "lang_smo"
+msgid "lang_smn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
-msgid "lang_sms"
+msgid "lang_smo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
-msgid "lang_sna"
+msgid "lang_sms"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
-msgid "lang_snd"
+msgid "lang_sna"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
-msgid "lang_snk"
+msgid "lang_snd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
-msgid "lang_sog"
+msgid "lang_snk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
-msgid "lang_som"
+msgid "lang_sog"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
-msgid "lang_son"
+msgid "lang_som"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
-msgid "lang_sot"
+msgid "lang_son"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
-msgid "lang_spa"
+msgid "lang_sot"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
-msgid "lang_srd"
+msgid "lang_spa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
-msgid "lang_srn"
+msgid "lang_srd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
-msgid "lang_srp"
+msgid "lang_srn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
-msgid "lang_srr"
+msgid "lang_srp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
-msgid "lang_ssa"
+msgid "lang_srr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
-msgid "lang_ssw"
+msgid "lang_ssa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
-msgid "lang_suk"
+msgid "lang_ssw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
-msgid "lang_sun"
+msgid "lang_suk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
-msgid "lang_sus"
+msgid "lang_sun"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
-msgid "lang_sux"
+msgid "lang_sus"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
-msgid "lang_swa"
+msgid "lang_sux"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
-msgid "lang_swe"
+msgid "lang_swa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
-msgid "lang_syc"
+msgid "lang_swe"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
-msgid "lang_syr"
+msgid "lang_syc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
-msgid "lang_tah"
+msgid "lang_syr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
-msgid "lang_tai"
+msgid "lang_tah"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
-msgid "lang_tam"
+msgid "lang_tai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
-msgid "lang_tat"
+msgid "lang_tam"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
-msgid "lang_tel"
+msgid "lang_tat"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
-msgid "lang_tem"
+msgid "lang_tel"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
-msgid "lang_ter"
+msgid "lang_tem"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
-msgid "lang_tet"
+msgid "lang_ter"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
-msgid "lang_tgk"
+msgid "lang_tet"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
-msgid "lang_tgl"
+msgid "lang_tgk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
-msgid "lang_tha"
+msgid "lang_tgl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
-msgid "lang_tib"
+msgid "lang_tha"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
-msgid "lang_tig"
+msgid "lang_tib"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
-msgid "lang_tir"
+msgid "lang_tig"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
-msgid "lang_tiv"
+msgid "lang_tir"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
-msgid "lang_tkl"
+msgid "lang_tiv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
-msgid "lang_tlh"
+msgid "lang_tkl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
-msgid "lang_tli"
+msgid "lang_tlh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
-msgid "lang_tmh"
+msgid "lang_tli"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
-msgid "lang_tog"
+msgid "lang_tmh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
-msgid "lang_ton"
+msgid "lang_tog"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
-msgid "lang_tpi"
+msgid "lang_ton"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
-msgid "lang_tsi"
+msgid "lang_tpi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
-msgid "lang_tsn"
+msgid "lang_tsi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
-msgid "lang_tso"
+msgid "lang_tsn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
-msgid "lang_tuk"
+msgid "lang_tso"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
-msgid "lang_tum"
+msgid "lang_tuk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
-msgid "lang_tup"
+msgid "lang_tum"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
-msgid "lang_tur"
+msgid "lang_tup"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
-msgid "lang_tut"
+msgid "lang_tur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
-msgid "lang_tvl"
+msgid "lang_tut"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
-msgid "lang_twi"
+msgid "lang_tvl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
-msgid "lang_tyv"
+msgid "lang_twi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
-msgid "lang_udm"
+msgid "lang_tyv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
-msgid "lang_uga"
+msgid "lang_udm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
-msgid "lang_uig"
+msgid "lang_uga"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
-msgid "lang_ukr"
+msgid "lang_uig"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
-msgid "lang_umb"
+msgid "lang_ukr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
-msgid "lang_und"
+msgid "lang_umb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
-msgid "lang_urd"
+msgid "lang_und"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
-msgid "lang_uzb"
+msgid "lang_urd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
-msgid "lang_vai"
+msgid "lang_uzb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
-msgid "lang_ven"
+msgid "lang_vai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
-msgid "lang_vie"
+msgid "lang_ven"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
-msgid "lang_vol"
+msgid "lang_vie"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
-msgid "lang_vot"
+msgid "lang_vol"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
-msgid "lang_wak"
+msgid "lang_vot"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
-msgid "lang_wal"
+msgid "lang_wak"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
-msgid "lang_war"
+msgid "lang_wal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
-msgid "lang_was"
+msgid "lang_war"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
-msgid "lang_wel"
+msgid "lang_was"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
-msgid "lang_wen"
+msgid "lang_wel"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
-msgid "lang_wln"
+msgid "lang_wen"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
-msgid "lang_wol"
+msgid "lang_wln"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
-msgid "lang_xal"
+msgid "lang_wol"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
-msgid "lang_xho"
+msgid "lang_xal"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
-msgid "lang_yao"
+msgid "lang_xho"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
-msgid "lang_yap"
+msgid "lang_yao"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
-msgid "lang_yid"
+msgid "lang_yap"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
-msgid "lang_yor"
+msgid "lang_yid"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
-msgid "lang_ypk"
+msgid "lang_yor"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
-msgid "lang_zap"
+msgid "lang_ypk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
-msgid "lang_zbl"
+msgid "lang_zap"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
-msgid "lang_zen"
+msgid "lang_zbl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
-msgid "lang_zha"
+msgid "lang_zen"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
-msgid "lang_znd"
+msgid "lang_zha"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
-msgid "lang_zul"
+msgid "lang_znd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
-msgid "lang_zun"
+msgid "lang_zul"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
-msgid "lang_zxx"
+msgid "lang_zun"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+msgid "lang_zxx"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
-msgid "country_aa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
-msgid "country_abc"
+msgid "country_aa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
-msgid "country_ac"
+msgid "country_abc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
-msgid "country_aca"
+msgid "country_ac"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
-msgid "country_ae"
+msgid "country_aca"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
-msgid "country_af"
+msgid "country_ae"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
-msgid "country_ag"
+msgid "country_af"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
-msgid "country_ai"
+msgid "country_ag"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
-msgid "country_air"
+msgid "country_ai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
-msgid "country_aj"
+msgid "country_air"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
-msgid "country_ajr"
+msgid "country_aj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
-msgid "country_aku"
+msgid "country_ajr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
-msgid "country_alu"
+msgid "country_aku"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
-msgid "country_am"
+msgid "country_alu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
-msgid "country_an"
+msgid "country_am"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
-msgid "country_ao"
+msgid "country_an"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
-msgid "country_aq"
+msgid "country_ao"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
-msgid "country_aru"
+msgid "country_aq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
-msgid "country_as"
+msgid "country_aru"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
-msgid "country_at"
+msgid "country_as"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
-msgid "country_au"
+msgid "country_at"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
-msgid "country_aw"
+msgid "country_au"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
-msgid "country_ay"
+msgid "country_aw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
-msgid "country_azu"
+msgid "country_ay"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
-msgid "country_ba"
+msgid "country_azu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
-msgid "country_bb"
+msgid "country_ba"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
-msgid "country_bcc"
+msgid "country_bb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
-msgid "country_bd"
+msgid "country_bcc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
-msgid "country_be"
+msgid "country_bd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
-msgid "country_bf"
+msgid "country_be"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
-msgid "country_bg"
+msgid "country_bf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
-msgid "country_bh"
+msgid "country_bg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
-msgid "country_bi"
+msgid "country_bh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
-msgid "country_bl"
+msgid "country_bi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
-msgid "country_bm"
+msgid "country_bl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
-msgid "country_bn"
+msgid "country_bm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
-msgid "country_bo"
+msgid "country_bn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
-msgid "country_bp"
+msgid "country_bo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
-msgid "country_br"
+msgid "country_bp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
-msgid "country_bs"
+msgid "country_br"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
-msgid "country_bt"
+msgid "country_bs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
-msgid "country_bu"
+msgid "country_bt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
-msgid "country_bv"
+msgid "country_bu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
-msgid "country_bw"
+msgid "country_bv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
-msgid "country_bwr"
+msgid "country_bw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
-msgid "country_bx"
+msgid "country_bwr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
-msgid "country_ca"
+msgid "country_bx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
-msgid "country_cau"
+msgid "country_ca"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
-msgid "country_cb"
+msgid "country_cau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
-msgid "country_cc"
+msgid "country_cb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
-msgid "country_cd"
+msgid "country_cc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
-msgid "country_ce"
+msgid "country_cd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
-msgid "country_cf"
+msgid "country_ce"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
-msgid "country_cg"
+msgid "country_cf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
-msgid "country_ch"
+msgid "country_cg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
-msgid "country_ci"
+msgid "country_ch"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
-msgid "country_cj"
+msgid "country_ci"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
-msgid "country_ck"
+msgid "country_cj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
-msgid "country_cl"
+msgid "country_ck"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
-msgid "country_cm"
+msgid "country_cl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
-msgid "country_cn"
+msgid "country_cm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
-msgid "country_co"
+msgid "country_cn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
-msgid "country_cou"
+msgid "country_co"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
-msgid "country_cp"
+msgid "country_cou"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
-msgid "country_cq"
+msgid "country_cp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
-msgid "country_cr"
+msgid "country_cq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
-msgid "country_cs"
+msgid "country_cr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
-msgid "country_ctu"
+msgid "country_cs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
-msgid "country_cu"
+msgid "country_ctu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
-msgid "country_cv"
+msgid "country_cu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
-msgid "country_cw"
+msgid "country_cv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
-msgid "country_cx"
+msgid "country_cw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
-msgid "country_cy"
+msgid "country_cx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
-msgid "country_cz"
+msgid "country_cy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
-msgid "country_dcu"
+msgid "country_cz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
-msgid "country_deu"
+msgid "country_dcu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
-msgid "country_dk"
+msgid "country_deu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
-msgid "country_dm"
+msgid "country_dk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
-msgid "country_dq"
+msgid "country_dm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
-msgid "country_dr"
+msgid "country_dq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
-msgid "country_ea"
+msgid "country_dr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
-msgid "country_ec"
+msgid "country_ea"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
-msgid "country_eg"
+msgid "country_ec"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
-msgid "country_em"
+msgid "country_eg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
-msgid "country_enk"
+msgid "country_em"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
-msgid "country_er"
+msgid "country_enk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
-msgid "country_err"
+msgid "country_er"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
-msgid "country_es"
+msgid "country_err"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
-msgid "country_et"
+msgid "country_es"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
-msgid "country_fa"
+msgid "country_et"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
-msgid "country_fg"
+msgid "country_fa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
-msgid "country_fi"
+msgid "country_fg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
-msgid "country_fj"
+msgid "country_fi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
-msgid "country_fk"
+msgid "country_fj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
-msgid "country_flu"
+msgid "country_fk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
-msgid "country_fm"
+msgid "country_flu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
-msgid "country_fp"
+msgid "country_fm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
-msgid "country_fr"
+msgid "country_fp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
-msgid "country_fs"
+msgid "country_fr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
-msgid "country_ft"
+msgid "country_fs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
-msgid "country_gau"
+msgid "country_ft"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
-msgid "country_gb"
+msgid "country_gau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
-msgid "country_gd"
+msgid "country_gb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
-msgid "country_ge"
+msgid "country_gd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
-msgid "country_gg"
+msgid "country_ge"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
-msgid "country_gh"
+msgid "country_gg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
-msgid "country_gi"
+msgid "country_gh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
-msgid "country_gl"
+msgid "country_gi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
-msgid "country_gm"
+msgid "country_gl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
-msgid "country_gn"
+msgid "country_gm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
-msgid "country_go"
+msgid "country_gn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
-msgid "country_gp"
+msgid "country_go"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
-msgid "country_gr"
+msgid "country_gp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
-msgid "country_gs"
+msgid "country_gr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
-msgid "country_gsr"
+msgid "country_gs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
-msgid "country_gt"
+msgid "country_gsr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
-msgid "country_gu"
+msgid "country_gt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
-msgid "country_gv"
+msgid "country_gu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
-msgid "country_gw"
+msgid "country_gv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
-msgid "country_gy"
+msgid "country_gw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
-msgid "country_gz"
+msgid "country_gy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
-msgid "country_hiu"
+msgid "country_gz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
-msgid "country_hk"
+msgid "country_hiu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
-msgid "country_hm"
+msgid "country_hk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
-msgid "country_ho"
+msgid "country_hm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
-msgid "country_ht"
+msgid "country_ho"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
-msgid "country_hu"
+msgid "country_ht"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
-msgid "country_iau"
+msgid "country_hu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
-msgid "country_ic"
+msgid "country_iau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
-msgid "country_idu"
+msgid "country_ic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
-msgid "country_ie"
+msgid "country_idu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
-msgid "country_ii"
+msgid "country_ie"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
-msgid "country_ilu"
+msgid "country_ii"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
-msgid "country_im"
+msgid "country_ilu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
-msgid "country_inu"
+msgid "country_im"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
-msgid "country_io"
+msgid "country_inu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
-msgid "country_iq"
+msgid "country_io"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
-msgid "country_ir"
+msgid "country_iq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
-msgid "country_is"
+msgid "country_ir"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
-msgid "country_it"
+msgid "country_is"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
-msgid "country_iu"
+msgid "country_it"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
-msgid "country_iv"
+msgid "country_iu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
-msgid "country_iw"
+msgid "country_iv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
-msgid "country_iy"
+msgid "country_iw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
-msgid "country_ja"
+msgid "country_iy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
-msgid "country_je"
+msgid "country_ja"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
-msgid "country_ji"
+msgid "country_je"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
-msgid "country_jm"
+msgid "country_ji"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
-msgid "country_jn"
+msgid "country_jm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
-msgid "country_jo"
+msgid "country_jn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
-msgid "country_ke"
+msgid "country_jo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
-msgid "country_kg"
+msgid "country_ke"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
-msgid "country_kgr"
+msgid "country_kg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
-msgid "country_kn"
+msgid "country_kgr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
-msgid "country_ko"
+msgid "country_kn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
-msgid "country_ksu"
+msgid "country_ko"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
-msgid "country_ku"
+msgid "country_ksu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
-msgid "country_kv"
+msgid "country_ku"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
-msgid "country_kyu"
+msgid "country_kv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
-msgid "country_kz"
+msgid "country_kyu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
-msgid "country_kzr"
+msgid "country_kz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
-msgid "country_lau"
+msgid "country_kzr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
-msgid "country_lb"
+msgid "country_lau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
-msgid "country_le"
+msgid "country_lb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
-msgid "country_lh"
+msgid "country_le"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
-msgid "country_li"
+msgid "country_lh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
-msgid "country_lir"
+msgid "country_li"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
-msgid "country_ln"
+msgid "country_lir"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
-msgid "country_lo"
+msgid "country_ln"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
-msgid "country_ls"
+msgid "country_lo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
-msgid "country_lu"
+msgid "country_ls"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
-msgid "country_lv"
+msgid "country_lu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
-msgid "country_lvr"
+msgid "country_lv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
-msgid "country_ly"
+msgid "country_lvr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
-msgid "country_mau"
+msgid "country_ly"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
-msgid "country_mbc"
+msgid "country_mau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
-msgid "country_mc"
+msgid "country_mbc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
-msgid "country_mdu"
+msgid "country_mc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
-msgid "country_meu"
+msgid "country_mdu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
-msgid "country_mf"
+msgid "country_meu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
-msgid "country_mg"
+msgid "country_mf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
-msgid "country_mh"
+msgid "country_mg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
-msgid "country_miu"
+msgid "country_mh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
-msgid "country_mj"
+msgid "country_miu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
-msgid "country_mk"
+msgid "country_mj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
-msgid "country_ml"
+msgid "country_mk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
-msgid "country_mm"
+msgid "country_ml"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
-msgid "country_mnu"
+msgid "country_mm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
-msgid "country_mo"
+msgid "country_mnu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
-msgid "country_mou"
+msgid "country_mo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
-msgid "country_mp"
+msgid "country_mou"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
-msgid "country_mq"
+msgid "country_mp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
-msgid "country_mr"
+msgid "country_mq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
-msgid "country_msu"
+msgid "country_mr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
-msgid "country_mtu"
+msgid "country_msu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
-msgid "country_mu"
+msgid "country_mtu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
-msgid "country_mv"
+msgid "country_mu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
-msgid "country_mvr"
+msgid "country_mv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
-msgid "country_mw"
+msgid "country_mvr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
-msgid "country_mx"
+msgid "country_mw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
-msgid "country_my"
+msgid "country_mx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
-msgid "country_mz"
+msgid "country_my"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
-msgid "country_na"
+msgid "country_mz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
-msgid "country_nbu"
+msgid "country_na"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
-msgid "country_ncu"
+msgid "country_nbu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
-msgid "country_ndu"
+msgid "country_ncu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
-msgid "country_ne"
+msgid "country_ndu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
-msgid "country_nfc"
+msgid "country_ne"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
-msgid "country_ng"
+msgid "country_nfc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
-msgid "country_nhu"
+msgid "country_ng"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
-msgid "country_nik"
+msgid "country_nhu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
-msgid "country_nju"
+msgid "country_nik"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
-msgid "country_nkc"
+msgid "country_nju"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
-msgid "country_nl"
+msgid "country_nkc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
-msgid "country_nm"
+msgid "country_nl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
-msgid "country_nmu"
+msgid "country_nm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
-msgid "country_nn"
+msgid "country_nmu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
-msgid "country_no"
+msgid "country_nn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
-msgid "country_np"
+msgid "country_no"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
-msgid "country_nq"
+msgid "country_np"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
-msgid "country_nr"
+msgid "country_nq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
-msgid "country_nsc"
+msgid "country_nr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
-msgid "country_ntc"
+msgid "country_nsc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
-msgid "country_nu"
+msgid "country_ntc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
-msgid "country_nuc"
+msgid "country_nu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
-msgid "country_nvu"
+msgid "country_nuc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
-msgid "country_nw"
+msgid "country_nvu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
-msgid "country_nx"
+msgid "country_nw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
-msgid "country_nyu"
+msgid "country_nx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
-msgid "country_nz"
+msgid "country_nyu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
-msgid "country_ohu"
+msgid "country_nz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
-msgid "country_oku"
+msgid "country_ohu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
-msgid "country_onc"
+msgid "country_oku"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
-msgid "country_oru"
+msgid "country_onc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
-msgid "country_ot"
+msgid "country_oru"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
-msgid "country_pau"
+msgid "country_ot"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
-msgid "country_pc"
+msgid "country_pau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
-msgid "country_pe"
+msgid "country_pc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
-msgid "country_pf"
+msgid "country_pe"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
-msgid "country_pg"
+msgid "country_pf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
-msgid "country_ph"
+msgid "country_pg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
-msgid "country_pic"
+msgid "country_ph"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
-msgid "country_pk"
+msgid "country_pic"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
-msgid "country_pl"
+msgid "country_pk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
-msgid "country_pn"
+msgid "country_pl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
-msgid "country_po"
+msgid "country_pn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
-msgid "country_pp"
+msgid "country_po"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
-msgid "country_pr"
+msgid "country_pp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
-msgid "country_pt"
+msgid "country_pr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
-msgid "country_pw"
+msgid "country_pt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
-msgid "country_py"
+msgid "country_pw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
-msgid "country_qa"
+msgid "country_py"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
-msgid "country_qea"
+msgid "country_qa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
-msgid "country_quc"
+msgid "country_qea"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
-msgid "country_rb"
+msgid "country_quc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
-msgid "country_re"
+msgid "country_rb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
-msgid "country_rh"
+msgid "country_re"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
-msgid "country_riu"
+msgid "country_rh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
-msgid "country_rm"
+msgid "country_riu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
-msgid "country_ru"
+msgid "country_rm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
-msgid "country_rur"
+msgid "country_ru"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
-msgid "country_rw"
+msgid "country_rur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
-msgid "country_ry"
+msgid "country_rw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
-msgid "country_sa"
+msgid "country_ry"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
-msgid "country_sb"
+msgid "country_sa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
-msgid "country_sc"
+msgid "country_sb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
-msgid "country_scu"
+msgid "country_sc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
-msgid "country_sd"
+msgid "country_scu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
-msgid "country_sdu"
+msgid "country_sd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
-msgid "country_se"
+msgid "country_sdu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
-msgid "country_sf"
+msgid "country_se"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
-msgid "country_sg"
+msgid "country_sf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
-msgid "country_sh"
+msgid "country_sg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
-msgid "country_si"
+msgid "country_sh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
-msgid "country_sj"
+msgid "country_si"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
-msgid "country_sk"
+msgid "country_sj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
-msgid "country_sl"
+msgid "country_sk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
-msgid "country_sm"
+msgid "country_sl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
-msgid "country_sn"
+msgid "country_sm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
-msgid "country_snc"
+msgid "country_sn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
-msgid "country_so"
+msgid "country_snc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
-msgid "country_sp"
+msgid "country_so"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
-msgid "country_sq"
+msgid "country_sp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
-msgid "country_sr"
+msgid "country_sq"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
-msgid "country_ss"
+msgid "country_sr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
-msgid "country_st"
+msgid "country_ss"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
-msgid "country_stk"
+msgid "country_st"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
-msgid "country_su"
+msgid "country_stk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
-msgid "country_sv"
+msgid "country_su"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
-msgid "country_sw"
+msgid "country_sv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
-msgid "country_sx"
+msgid "country_sw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
-msgid "country_sy"
+msgid "country_sx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
-msgid "country_sz"
+msgid "country_sy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
-msgid "country_ta"
+msgid "country_sz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
-msgid "country_tar"
+msgid "country_ta"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
-msgid "country_tc"
+msgid "country_tar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
-msgid "country_tg"
+msgid "country_tc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
-msgid "country_th"
+msgid "country_tg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
-msgid "country_ti"
+msgid "country_th"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
-msgid "country_tk"
+msgid "country_ti"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
-msgid "country_tkr"
+msgid "country_tk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
-msgid "country_tl"
+msgid "country_tkr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
-msgid "country_tma"
+msgid "country_tl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
-msgid "country_tnu"
+msgid "country_tma"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
-msgid "country_to"
+msgid "country_tnu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
-msgid "country_tr"
+msgid "country_to"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
-msgid "country_ts"
+msgid "country_tr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
-msgid "country_tt"
+msgid "country_ts"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
-msgid "country_tu"
+msgid "country_tt"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
-msgid "country_tv"
+msgid "country_tu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
-msgid "country_txu"
+msgid "country_tv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
-msgid "country_tz"
+msgid "country_txu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
-msgid "country_ua"
+msgid "country_tz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
-msgid "country_uc"
+msgid "country_ua"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
-msgid "country_ug"
+msgid "country_uc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
-msgid "country_ui"
+msgid "country_ug"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
-msgid "country_uik"
+msgid "country_ui"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
-msgid "country_uk"
+msgid "country_uik"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
-msgid "country_un"
+msgid "country_uk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
-msgid "country_unr"
+msgid "country_un"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
-msgid "country_up"
+msgid "country_unr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
-msgid "country_ur"
+msgid "country_up"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
-msgid "country_us"
+msgid "country_ur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
-msgid "country_utu"
+msgid "country_us"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
-msgid "country_uv"
+msgid "country_utu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
-msgid "country_uy"
+msgid "country_uv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
-msgid "country_uz"
+msgid "country_uy"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
-msgid "country_uzr"
+msgid "country_uz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
-msgid "country_vau"
+msgid "country_uzr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
-msgid "country_vb"
+msgid "country_vau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
-msgid "country_vc"
+msgid "country_vb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
-msgid "country_ve"
+msgid "country_vc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
-msgid "country_vi"
+msgid "country_ve"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
-msgid "country_vm"
+msgid "country_vi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
-msgid "country_vn"
+msgid "country_vm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
-msgid "country_vp"
+msgid "country_vn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
-msgid "country_vra"
+msgid "country_vp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
-msgid "country_vs"
+msgid "country_vra"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
-msgid "country_vtu"
+msgid "country_vs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
-msgid "country_wau"
+msgid "country_vtu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
-msgid "country_wb"
+msgid "country_wau"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
-msgid "country_wea"
+msgid "country_wb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
-msgid "country_wf"
+msgid "country_wea"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
-msgid "country_wiu"
+msgid "country_wf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
-msgid "country_wj"
+msgid "country_wiu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
-msgid "country_wk"
+msgid "country_wj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
-msgid "country_wlk"
+msgid "country_wk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
-msgid "country_ws"
+msgid "country_wlk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
-msgid "country_wvu"
+msgid "country_ws"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
-msgid "country_wyu"
+msgid "country_wvu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
-msgid "country_xa"
+msgid "country_wyu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
-msgid "country_xb"
+msgid "country_xa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
-msgid "country_xc"
+msgid "country_xb"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
-msgid "country_xd"
+msgid "country_xc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
-msgid "country_xe"
+msgid "country_xd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
-msgid "country_xf"
+msgid "country_xe"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
-msgid "country_xga"
+msgid "country_xf"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
-msgid "country_xh"
+msgid "country_xga"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
-msgid "country_xi"
+msgid "country_xh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
-msgid "country_xj"
+msgid "country_xi"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
-msgid "country_xk"
+msgid "country_xj"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
-msgid "country_xl"
+msgid "country_xk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
-msgid "country_xm"
+msgid "country_xl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
-msgid "country_xn"
+msgid "country_xm"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
-msgid "country_xna"
+msgid "country_xn"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
-msgid "country_xo"
+msgid "country_xna"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
-msgid "country_xoa"
+msgid "country_xo"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
-msgid "country_xp"
+msgid "country_xoa"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
-msgid "country_xr"
+msgid "country_xp"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
-msgid "country_xra"
+msgid "country_xr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
-msgid "country_xs"
+msgid "country_xra"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
-msgid "country_xv"
+msgid "country_xs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
-msgid "country_xx"
+msgid "country_xv"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
-msgid "country_xxc"
+msgid "country_xx"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
-msgid "country_xxk"
+msgid "country_xxc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
-msgid "country_xxr"
+msgid "country_xxk"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
-msgid "country_xxu"
+msgid "country_xxr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
-msgid "country_ye"
+msgid "country_xxu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
-msgid "country_ykc"
+msgid "country_ye"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
-msgid "country_ys"
+msgid "country_ykc"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
-msgid "country_yu"
+msgid "country_ys"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+msgid "country_yu"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
-msgstr ""
-
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
-msgid "canton_ag"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
-msgid "canton_ai"
+msgid "canton_ag"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
-msgid "canton_ar"
+msgid "canton_ai"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
-msgid "canton_be"
+msgid "canton_ar"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
-msgid "canton_bl"
+msgid "canton_be"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
-msgid "canton_bs"
+msgid "canton_bl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
-msgid "canton_fr"
+msgid "canton_bs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
-msgid "canton_ge"
+msgid "canton_fr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
-msgid "canton_gl"
+msgid "canton_ge"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
-msgid "canton_gr"
+msgid "canton_gl"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
-msgid "canton_ju"
+msgid "canton_gr"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
-msgid "canton_lu"
+msgid "canton_ju"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
-msgid "canton_ne"
+msgid "canton_lu"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
-msgid "canton_nw"
+msgid "canton_ne"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
-msgid "canton_ow"
+msgid "canton_nw"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
-msgid "canton_sg"
+msgid "canton_ow"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
-msgid "canton_sh"
+msgid "canton_sg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
-msgid "canton_so"
+msgid "canton_sh"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
-msgid "canton_sz"
+msgid "canton_so"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
-msgid "canton_tg"
+msgid "canton_sz"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
-msgid "canton_ti"
+msgid "canton_tg"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
-msgid "canton_ur"
+msgid "canton_ti"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
-msgid "canton_vd"
+msgid "canton_ur"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
-msgid "canton_vs"
+msgid "canton_vd"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
-msgid "canton_zg"
+msgid "canton_vs"
 msgstr ""
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+msgid "canton_zg"
+msgstr ""
+
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr ""
 
@@ -6687,6 +6692,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr ""
@@ -6808,7 +6817,6 @@ msgid "Barcode"
 msgstr ""
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr ""
 
@@ -6833,7 +6841,7 @@ msgid "Name of the ItemType."
 msgstr ""
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
+msgid "The item type name is already taken."
 msgstr ""
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
@@ -6846,6 +6854,10 @@ msgstr ""
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
+msgstr ""
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
 msgstr ""
 
 #: rero_ils/modules/items/views.py:113
@@ -6887,7 +6899,8 @@ msgid "Item ID"
 msgstr ""
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
 msgstr ""
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
@@ -6937,7 +6950,7 @@ msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr ""
 
@@ -6950,7 +6963,7 @@ msgid "Name of the library."
 msgstr ""
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr ""
 
@@ -6962,7 +6975,7 @@ msgstr ""
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr ""
 
@@ -7180,6 +7193,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7265,39 +7285,38 @@ msgid "Organisation ID"
 msgstr ""
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr ""
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr ""
 
@@ -7499,6 +7518,10 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr ""
@@ -7529,20 +7552,26 @@ msgstr ""
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr ""
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7564,10 +7593,6 @@ msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
-msgstr ""
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
 msgstr ""
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
@@ -7816,7 +7841,7 @@ msgid "Vendor ID"
 msgstr ""
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
+msgid "The vendor name is already taken."
 msgstr ""
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
@@ -7851,15 +7876,11 @@ msgstr ""
 msgid "Name of the vendor contact person."
 msgstr ""
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr ""
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr ""
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr ""
 

--- a/rero_ils/translations/nl/LC_MESSAGES/messages.po
+++ b/rero_ils/translations/nl/LC_MESSAGES/messages.po
@@ -7,12 +7,11 @@
 # bibsys UCL <bibsys@uclouvain.be>, 2020
 # iGor milhit <igor.milhit@rero.ch>, 2020
 # ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020
-
 msgid ""
 msgstr ""
 "Project-Id-Version: rero-ils 0.8.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-05-28 10:58+0200\n"
+"POT-Creation-Date: 2020-06-03 17:10+0200\n"
 "PO-Revision-Date: 2018-09-03 13:16+0000\n"
 "Last-Translator: ManaDeweerdt <anne-marie.deweerdt@uclouvain.be>, 2020\n"
 "Language: nl\n"
@@ -79,8 +78,8 @@ msgid "author__it"
 msgstr "Auteurs"
 
 #: rero_ils/config.py:1200
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3887
 msgid "language"
 msgstr "taal"
 
@@ -367,8 +366,8 @@ msgid "The amount allocated for the acquisition account."
 msgstr "Het toegekende bedrag voor de account."
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:65
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:283
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:282
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:202
 #: rero_ils/modules/holdings/templates/rero_ils/detailed_view_holdings.html:49
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:4
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:126
@@ -379,8 +378,8 @@ msgid "Library"
 msgstr "Bibliotheek"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:69
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:287
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:286
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:206
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:122
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:130
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:66
@@ -389,10 +388,10 @@ msgid "Library URI"
 msgstr "URI van de bibliotheek"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:76
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:294
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:293
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:165
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:214
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:93
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:213
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:91
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:39
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:377
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:398
@@ -405,15 +404,15 @@ msgstr "URI van de bibliotheek"
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:4
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:84
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:56
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:249
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:248
 msgid "Organisation"
 msgstr "Organisatie"
 
 #: rero_ils/modules/acq_accounts/jsonschemas/acq_accounts/acq_account-v0.0.1.json:80
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:298
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:297
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:169
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:218
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:97
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:217
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:95
 #: rero_ils/modules/circ_policies/jsonschemas/circ_policies/circ_policy-v0.0.1.json:43
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:97
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:169
@@ -421,7 +420,7 @@ msgstr "Organisatie"
 #: rero_ils/modules/loans/jsonschemas/loans/loan-ils-v0.0.1.json:85
 #: rero_ils/modules/patron_transactions/jsonschemas/patron_transactions/patron_transaction-v0.0.1.json:88
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:60
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:256
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:255
 msgid "Organisation URI"
 msgstr "URI van de organisatie"
 
@@ -473,7 +472,7 @@ msgid "Price per unit"
 msgstr "Prijs per unit"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:78
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:241
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:240
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:92
 msgid "Discount amount"
 msgstr "Kortingsbedrag"
@@ -495,8 +494,8 @@ msgid "Invoice number"
 msgstr "Factuurnummer"
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:116
-msgid "The invoice number is already taken"
-msgstr "De factuurnummer is al bezet"
+msgid "The invoice number is already taken."
+msgstr "De factuurnummer is al bezet."
 
 #: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:122
 msgid "Invoice price"
@@ -528,81 +527,81 @@ msgstr "Verwijderd"
 msgid "Date"
 msgstr "Datum"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:156
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:158
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:56
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:74
-msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
-msgstr "Moet in het volgende formaat zijn: 2022-12-31 (JJJJ-MM-DD)."
-
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:159
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:161
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:158
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:160
 msgid "Select a date"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:171
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:164
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:166
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:63
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:80
+msgid "Should be in the following format: 2022-12-31 (YYYY-MM-DD)."
+msgstr "Moet in het volgende formaat zijn: 2022-12-31 (JJJJ-MM-DD)."
+
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:170
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:904
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:922
 msgid "Notes"
 msgstr "Notas"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:180
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:179
 msgid "Taxes"
 msgstr "Belastingen"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:188
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:187
 msgid "Type of taxe"
 msgstr "Type van belastingen"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:199
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:198
 msgid "Shipping and handling"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:203
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:202
 msgid "State taxes"
 msgstr "Staatsbelastingen"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:207
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:206
 msgid "Miscellaneous"
 msgstr "Diversen"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:213
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:237
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:212
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:236
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:86
 #: rero_ils/modules/patron_transaction_events/jsonschemas/patron_transaction_events/patron_transaction_event-v0.0.1.json:44
 #: rero_ils/modules/patron_types/jsonschemas/patron_types/patron_type-v0.0.1.json:67
 msgid "Amount"
 msgstr "Bedrag"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:222
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:221
 msgid "Discount"
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:225
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:224
 msgid "Percentage"
 msgstr "Percentage"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:229
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:228
 msgid "Discount percentage."
 msgstr ""
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:254
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:253
 msgid "List of invoice lines"
 msgstr "Lijst van factuurlijnen"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:259
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:179
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:258
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:178
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:4
 msgid "Vendor"
 msgstr "Verkoper"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:266
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:186
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:265
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:185
 msgid "Vendor URI"
 msgstr "Verkoper URI"
 
-#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:274
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:194
+#: rero_ils/modules/acq_invoices/jsonschemas/acq_invoices/acq_invoice-v0.0.1.json:273
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:193
 msgid "Choose a vendor"
 msgstr "Kies een verkoper"
 
@@ -658,7 +657,7 @@ msgid "Quantity"
 msgstr "Hoeveelheid"
 
 #: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:98
-#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:173
+#: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:172
 msgid "Total amount"
 msgstr "Totaalbedrag"
 
@@ -691,6 +690,12 @@ msgstr "Order"
 msgid "Acquisition order URI"
 msgstr "Order URI"
 
+#: rero_ils/modules/acq_order_lines/jsonschemas/acq_order_lines/acq_order_line-v0.0.1.json:157
+msgid ""
+"Should be in the following format: "
+"https://ils.rero.ch/api/documents/<PID>."
+msgstr ""
+
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:4
 msgid "Acquisition order"
 msgstr "Order"
@@ -708,8 +713,8 @@ msgid "AcqOrder ID"
 msgstr "Order ID"
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:51
-msgid "The order number is already taken"
-msgstr "De ordernummer is al bezet"
+msgid "The order number is already taken."
+msgstr "De ordernummer is al bezet."
 
 #: rero_ils/modules/acq_orders/jsonschemas/acq_orders/acq_order-v0.0.1.json:57
 msgid "Order type"
@@ -772,18 +777,18 @@ msgid "Name of the budget."
 msgstr "Begrotingsnaam."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:46
-msgid "The budget name is already taken"
+msgid "The budget name is already taken."
 msgstr "Het bergrotingsnaam is al genomen."
 
 #: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:54
 msgid "Start date"
 msgstr "Datum 1"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:72
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:71
 msgid "End date"
 msgstr "Datum 2"
 
-#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:89
+#: rero_ils/modules/budgets/jsonschemas/budgets/budget-v0.0.1.json:87
 msgid "Active"
 msgstr "Actief"
 
@@ -994,9 +999,9 @@ msgid "Sound"
 msgstr "Geluid"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:91
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1402
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:95
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1418
 msgid "Video"
 msgstr "Video"
 
@@ -1277,11 +1282,11 @@ msgid "type"
 msgstr "type"
 
 #: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:548
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3969
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3973
 #: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:552
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3990
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:140
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:202
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:201
 msgid "Country"
 msgstr "Land"
 
@@ -1808,4753 +1813,4753 @@ msgstr "Status"
 msgid "Status of the ISBN/ISSN identifier."
 msgstr "Status van de ISBN/ISSN-identificatiecode."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1164
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1180
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "De ISBN/ISSN-status moet in de onderstaande lijst worden geselecteerd."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1195
 msgid "Subjects"
 msgstr "Onderwerpen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1176
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
 msgid "Subject of the resource."
 msgstr "Onderwerp van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1180
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1184
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1200
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1192
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1196
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1212
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:88
 msgid "Electronic locations"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1193
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1209
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1197
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1213
 msgid "Information needed to locate and access an electronic resource."
 msgstr ""
 "Informatie die nodig is om een elektronische bron te lokaliseren en te "
 "benaderen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1214
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1218
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:93
 msgid "Electronic location"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1231
 msgid "URL"
 msgstr "URL"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1212
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1216
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1232
 msgid "Record a unique URL here."
 msgstr "Neem hier een unieke URL op."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1213
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1229
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1217
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1233
 msgid "Example: https://www.rero.ch/"
 msgstr "Voorbeeld: https://www.rero.ch/"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1239
 msgid "Type of link"
 msgstr "Soort link"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
 msgid "Resource"
 msgstr "Bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
 msgid "Version of resource"
 msgstr "Versie van de bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:127
 msgid "Related resource"
 msgstr "Verbonden bron"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
 msgid "Hidden URL"
 msgstr "Verborgen Url"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1267
 msgid "No info"
 msgstr "Geen informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1270
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1274
 msgid "Content type"
 msgstr "Soort inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1275
 msgid "Is displayed as the text of the link."
 msgstr "Wordt weergegeven als de tekst van de link."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
 msgid "Poster"
 msgstr "Affiche"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
 msgid "Audio"
 msgstr "Audio"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
 msgid "Postcard"
 msgstr "Postkaart"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
 msgid "Addition"
 msgstr "Aanvulling"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
 msgid "Debriefing"
 msgstr "Debriefing"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
 msgid "Exhibition documentation"
 msgstr "Tentoonstellingsdocumentatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
 msgid "Erratum"
 msgstr "Erratum"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
 msgid "Bookplate"
 msgstr "Boekmerk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
 msgid "Extract"
 msgstr "Extract"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
 msgid "Educational sheet"
 msgstr "Onderwijsformulier"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
 #: rero_ils/modules/documents/templates/rero_ils/_documents_description.html:79
 msgid "Illustrations"
 msgstr "Illustraties"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
 msgid "Cover image"
 msgstr "Omslagafbeelding"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
 msgid "Delivery information"
 msgstr "Leveringsinformatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
 #: rero_ils/modules/persons/templates/rero_ils/_person_by_source_data.html:26
 #: rero_ils/modules/persons/templates/rero_ils/_person_unified.html:29
 msgid "Biographical information"
 msgstr "Biografische informatie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
 msgid "Introduction/preface"
 msgstr "Introductie/voorwoord"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
 msgid "Class reading"
 msgstr "Class reading"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
 msgid "Teacher's kit"
 msgstr "Educatief pakket"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
 msgid "Publisher's note"
 msgstr "uitgave opmerking"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
 msgid "Note on content"
 msgstr "Opmerking over de inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
 msgid "Title page"
 msgstr "titelpagina"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
 msgid "Photography"
 msgstr "Fotografie"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
 msgid "Summarization"
 msgstr "Samenvatting"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
 msgid "Online resource via RERO DOC"
 msgstr "Online bron via RERO DOC"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
 msgid "Press review"
 msgstr "Persoverzicht"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1402
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
 msgid "Web site"
 msgstr "Website"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1406
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
 msgid "Table of contents"
 msgstr "Inhoudsopgave"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1414
 msgid "Full text"
 msgstr "Integrale tekst"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1405
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1421
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1409
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1425
 msgid "Public note"
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1422
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1426
 msgid "Is displayed next to the link, as additional information."
 msgstr ""
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1412
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1429
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1416
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1433
 msgid "Example: Access only from the library"
 msgstr "Voorbeeld: Toegang alleen vanuit de bibliotheek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1444
 msgid "Harvested"
 msgstr "Geoogst"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1424
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1441
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1428
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1445
 msgid "Document is harvested or not, will disable record edition or similar."
 msgstr ""
 "Document is geoogst of niet, zal de record editie of iets dergelijks "
 "uitschakelen."
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1452
 msgid "Language value"
 msgstr "Taalwaarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
 msgid "lang_aar"
 msgstr "Afar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
 msgid "lang_abk"
 msgstr "Abchazisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
 msgid "lang_ace"
 msgstr "Atjehs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
 msgid "lang_ach"
 msgstr "Akoli"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
 msgid "lang_ady"
 msgstr "Adygees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
 msgid "lang_afa"
 msgstr "Afro-Aziatische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
 msgid "lang_ain"
 msgstr "Aino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
 msgid "lang_aka"
 msgstr "Akan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
 msgid "lang_alb"
 msgstr "Albanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
 msgid "lang_ale"
 msgstr "Aleoetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:1996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
 msgid "lang_alg"
 msgstr "Algonkische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
 msgid "lang_alt"
 msgstr "Zuid-Altaïsch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
 msgid "lang_amh"
 msgstr "Amhaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
 msgid "lang_ang"
 msgstr "Oudengels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
 msgid "lang_anp"
 msgstr "Angika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:1999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
 msgid "lang_apa"
 msgstr "Na-Denétalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
 msgid "lang_arc"
 msgstr "Aramees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
 msgid "lang_arg"
 msgstr "Aragonees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
 msgid "lang_arm"
 msgstr "Armeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
 msgid "lang_art"
 msgstr "Kunsttalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
 msgid "lang_asm"
 msgstr "Assamees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
 msgid "lang_ath"
 msgstr "Athabaskische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
 msgid "lang_aus"
 msgstr "Australische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
 msgid "lang_ava"
 msgstr "Avarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
 msgid "lang_aze"
 msgstr "Azerbeidzjaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
 msgid "lang_bad"
 msgstr "Bandatalen (Centraal-Afrika)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
 msgid "lang_bai"
 msgstr "Bamileke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
 msgid "lang_bak"
 msgstr "Basjkiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
 msgid "lang_bal"
 msgstr "Beloetsji"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
 msgid "lang_ban"
 msgstr "Balinees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
 msgid "lang_bas"
 msgstr "Basa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
 msgid "lang_bat"
 msgstr "Baltische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
 msgid "lang_bej"
 msgstr "Beja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
 msgid "lang_bel"
 msgstr "Wit-Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
 msgid "lang_ben"
 msgstr "Bengaals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
 msgid "lang_ber"
 msgstr "Berber"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
 msgid "lang_bin"
 msgstr "Bini"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
 msgid "lang_bnt"
 msgstr "Bantoetalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
 msgid "lang_bra"
 msgstr "Braj"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
 msgid "lang_bre"
 msgstr "Bretons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
 msgid "lang_btk"
 msgstr "Bataktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
 msgid "lang_bua"
 msgstr "Boerjatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
 msgid "lang_bug"
 msgstr "Buginees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
 msgid "lang_bul"
 msgstr "Bulgaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
 msgid "lang_bur"
 msgstr "Birmaans, Birmees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
 msgid "lang_byn"
 msgstr "Blin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
 msgid "lang_cai"
 msgstr "Midden-Amerikaanse Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
 msgid "lang_car"
 msgstr "Caribisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
 msgid "lang_cat"
 msgstr "Catalaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
 msgid "lang_cau"
 msgstr "[California] (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
 msgid "lang_cel"
 msgstr "Keltische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
 msgid "lang_che"
 msgstr "Tsjetsjeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
 msgid "lang_chi"
 msgstr "Chinees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
 msgid "lang_chk"
 msgstr "Chuukees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
 msgid "lang_chm"
 msgstr "Mari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
 msgid "lang_chn"
 msgstr "Chinook Jargon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
 msgid "lang_chu"
 msgstr "Kerkslavisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
 msgid "lang_chv"
 msgstr "Tsjoevasjisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
 msgid "lang_cmc"
 msgstr "Chamische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
 msgid "lang_cnr"
 msgstr "Montenegrijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
 msgid "lang_cos"
 msgstr "Corsicaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
 msgid "lang_cpe"
 msgstr "Engelse creoolse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
 msgid "lang_cpf"
 msgstr "Franse creoolse talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
 msgid "lang_cpp"
 msgstr "Portugese creoolse talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
 msgid "lang_cre"
 msgstr "Cree"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
 msgid "lang_crh"
 msgstr "Krim-Tataars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
 msgid "lang_crp"
 msgstr "Creools en Pidgin (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
 msgid "lang_csb"
 msgstr "Kasjoebisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
 msgid "lang_cus"
 msgstr "Koesjitische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
 msgid "lang_cze"
 msgstr "Tsjechisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
 msgid "lang_dan"
 msgstr "Deens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
 msgid "lang_day"
 msgstr "Dajaktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
 msgid "lang_del"
 msgstr "Delaware"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
 msgid "lang_den"
 msgstr "Slavey"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
 msgid "lang_din"
 msgstr "Dinka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
 msgid "lang_div"
 msgstr "Divehi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
 msgid "lang_dra"
 msgstr "Dravidische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
 msgid "lang_dsb"
 msgstr "Nedersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
 msgid "lang_dua"
 msgstr "Duala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
 msgid "lang_dum"
 msgstr "Middelnederlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
 msgid "lang_dut"
 msgstr "Nederlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
 msgid "lang_efi"
 msgstr "Efik"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
 msgid "lang_egy"
 msgstr "Oudegyptisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
 msgid "lang_elx"
 msgstr "Elamitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
 msgid "lang_eng"
 msgstr "Engels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
 msgid "lang_enm"
 msgstr "Middelengels"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
 msgid "lang_est"
 msgstr "Estisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
 msgid "lang_fan"
 msgstr "Fang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
 msgid "lang_fao"
 msgstr "Faeröers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
 msgid "lang_fij"
 msgstr "Fijisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
 msgid "lang_fil"
 msgstr "Filipijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
 msgid "lang_fin"
 msgstr "Fins"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
 msgid "lang_fiu"
 msgstr "Fins-Oegrische talen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
 msgid "lang_fon"
 msgstr "Fon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
 msgid "lang_fre"
 msgstr "Frans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
 msgid "lang_frm"
 msgstr "Middelfrans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
 msgid "lang_fro"
 msgstr "Oudfrans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
 msgid "lang_frr"
 msgstr "Noord-Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
 msgid "lang_frs"
 msgstr "Oost-Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
 msgid "lang_fry"
 msgstr "Fries"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
 msgid "lang_ful"
 msgstr "Fulah"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
 msgid "lang_fur"
 msgstr "Friulisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
 msgid "lang_gem"
 msgstr "Germaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
 msgid "lang_ger"
 msgstr "Duits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
 msgid "lang_gez"
 msgstr "Ge’ez"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
 msgid "lang_gil"
 msgstr "Gilbertees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
 msgid "lang_gla"
 msgstr "Schots-Gaelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
 msgid "lang_gle"
 msgstr "Iers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
 msgid "lang_glv"
 msgstr "Manx"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
 msgid "lang_gmh"
 msgstr "Middelhoogduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
 msgid "lang_goh"
 msgstr "Oudhoogduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
 msgid "lang_got"
 msgstr "Gothisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
 msgid "lang_grc"
 msgstr "Oudgrieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
 msgid "lang_gre"
 msgstr "Grieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
 msgid "lang_grn"
 msgstr "Guaraní"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
 msgid "lang_gsw"
 msgstr "Zwitserduits"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
 msgid "lang_gwi"
 msgstr "Gwichʼin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
 msgid "lang_hai"
 msgstr "Haida"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
 msgid "lang_hat"
 msgstr "Haïtiaans Creools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
 msgid "lang_haw"
 msgstr "Hawaïaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
 msgid "lang_heb"
 msgstr "Hebreeuws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
 msgid "lang_her"
 msgstr "Herero"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
 msgid "lang_him"
 msgstr "Himachali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
 msgid "lang_hit"
 msgstr "Hettitisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
 msgid "lang_hsb"
 msgstr "Oppersorbisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
 msgid "lang_hun"
 msgstr "Hongaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
 msgid "lang_iba"
 msgstr "Iban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
 msgid "lang_ice"
 msgstr "Ijslands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
 msgid "lang_ido"
 msgstr "Ido"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
 msgid "lang_iii"
 msgstr "Yi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
 msgid "lang_ijo"
 msgstr "Ijawtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
 msgid "lang_inc"
 msgstr "Indo-Arische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
 msgid "lang_ine"
 msgstr "Indo-Europese talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
 msgid "lang_inh"
 msgstr "Ingoesjetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
 msgid "lang_ira"
 msgstr "Iraanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
 msgid "lang_iro"
 msgstr "Irokese talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
 msgid "lang_ita"
 msgstr "Italiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
 msgid "lang_jav"
 msgstr "Javaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
 msgid "lang_jpn"
 msgstr "Japans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
 msgid "lang_jpr"
 msgstr "Judeo-Perzisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
 msgid "lang_jrb"
 msgstr "Judeo-Arabisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
 msgid "lang_kaa"
 msgstr "Karakalpaks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
 msgid "lang_kal"
 msgstr "Groenlands"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
 msgid "lang_kar"
 msgstr "Karen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
 msgid "lang_kas"
 msgstr "Kasjmiri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
 msgid "lang_kaz"
 msgstr "Kazachs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
 msgid "lang_kbd"
 msgstr "Kabardisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
 msgid "lang_khi"
 msgstr "Khoisantalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
 msgid "lang_kho"
 msgstr "Khotanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
 msgid "lang_kik"
 msgstr "Gikuyu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
 msgid "lang_kir"
 msgstr "Kirgizisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
 msgid "lang_kom"
 msgstr "Komi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
 msgid "lang_kor"
 msgstr "Koreaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
 msgid "lang_kos"
 msgstr "Kosraeaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
 msgid "lang_krc"
 msgstr "Karatsjaj-Balkarisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2863
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2880
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2867
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2884
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
 msgid "lang_kro"
 msgstr "Krutalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2871
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2888
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2875
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2892
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2879
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2896
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
 msgid "lang_kum"
 msgstr "Koemuks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2883
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2900
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
 msgid "lang_kur"
 msgstr "Koerdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2887
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2904
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
 msgid "lang_kut"
 msgstr "Kutenai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2891
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2908
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2895
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2912
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2899
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2916
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2903
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2920
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
 msgid "lang_lao"
 msgstr "Laotiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2907
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2924
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
 msgid "lang_lat"
 msgstr "Latijn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2911
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
 msgid "lang_lav"
 msgstr "Lets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2915
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2932
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
 msgid "lang_lez"
 msgstr "Lezgisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2919
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2936
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
 msgid "lang_lim"
 msgstr "Limburgs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2923
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2940
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2927
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2944
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
 msgid "lang_lit"
 msgstr "Litouws"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2931
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2948
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
 msgid "lang_lol"
 msgstr "Mongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2935
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2952
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2939
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2956
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
 msgid "lang_ltz"
 msgstr "Luxemburgs"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2943
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2960
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2947
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2964
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2951
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2968
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2955
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2972
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
 msgid "lang_lui"
 msgstr "Luiseno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2959
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2976
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2963
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2980
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
 msgid "lang_luo"
 msgstr "Luo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2967
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2984
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2971
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2988
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
 msgid "lang_mac"
 msgstr "Macedonisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2975
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2992
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
 msgid "lang_mad"
 msgstr "Madoerees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2979
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:2996
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2983
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3000
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
 msgid "lang_mah"
 msgstr "Marshallees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2987
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3004
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2991
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3008
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
 msgid "lang_mak"
 msgstr "Makassaars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2995
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3012
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:2999
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3016
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3003
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3020
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
 msgid "lang_mao"
 msgstr "Maori"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3007
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3024
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
 msgid "lang_map"
 msgstr "Austronesische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3011
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3028
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3015
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3032
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
 msgid "lang_mas"
 msgstr "Maa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3019
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3036
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
 msgid "lang_may"
 msgstr "Maleis"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3023
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3040
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
 msgid "lang_mdf"
 msgstr "Moksja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3027
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3044
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3031
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3048
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
 msgid "lang_men"
 msgstr "Mende"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3035
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3052
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
 msgid "lang_mga"
 msgstr "Middeliers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3039
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3056
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
 msgid "lang_mic"
 msgstr "Mi’kmaq"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3043
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3060
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3047
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3064
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
 msgid "lang_mis"
 msgstr "niet gecodeerde talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3051
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3068
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
 msgid "lang_mkh"
 msgstr "Mon-Khmertalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3055
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3072
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
 msgid "lang_mlg"
 msgstr "Malagassisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3059
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3076
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
 msgid "lang_mlt"
 msgstr "Maltees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3063
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3080
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
 msgid "lang_mnc"
 msgstr "Mantsjoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3067
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3084
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
 msgid "lang_mni"
 msgstr "Meitei"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3071
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3088
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
 msgid "lang_mno"
 msgstr "Manobotalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3075
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3092
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3079
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3096
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
 msgid "lang_mon"
 msgstr "Mongools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3083
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3100
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
 msgid "lang_mos"
 msgstr "Mossi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3087
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3104
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
 msgid "lang_mul"
 msgstr "Meerdere talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3091
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3108
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
 msgid "lang_mun"
 msgstr "Mundatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3095
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3112
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
 msgid "lang_mus"
 msgstr "Creek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3099
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3116
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
 msgid "lang_mwl"
 msgstr "Mirandees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3103
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3120
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3107
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3124
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
 msgid "lang_myn"
 msgstr "Mayatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3111
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3128
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
 msgid "lang_myv"
 msgstr "Erzja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3115
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3132
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3119
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3136
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
 msgid "lang_nai"
 msgstr "Noord-Amerikaans Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3123
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3140
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
 msgid "lang_nap"
 msgstr "Napolitaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3127
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3144
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
 msgid "lang_nau"
 msgstr "Nauruaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3131
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3148
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3135
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3152
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
 msgid "lang_nbl"
 msgstr "Zuid-Ndbele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3139
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3156
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
 msgid "lang_nde"
 msgstr "Noord-Ndebele"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3143
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3160
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3147
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3164
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
 msgid "lang_nds"
 msgstr "Nedersaksisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3151
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3168
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
 msgid "lang_nep"
 msgstr "Nepalees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3155
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3172
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
 msgid "lang_new"
 msgstr "Newari"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3159
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3176
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
 msgid "lang_nia"
 msgstr "Nias"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3163
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3180
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
 msgid "lang_nic"
 msgstr "Niger-Congotalen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3167
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3184
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
 msgid "lang_niu"
 msgstr "Niueaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3171
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3188
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
 msgid "lang_nno"
 msgstr "Noors - Nynorsk"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3175
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3192
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
 msgid "lang_nob"
 msgstr "Noors - Bokmål"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3179
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3196
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3183
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3200
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
 msgid "lang_non"
 msgstr "Oudnoors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3187
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3204
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
 msgid "lang_nor"
 msgstr "Noors"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3191
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3208
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3195
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3212
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
 msgid "lang_nso"
 msgstr "Noord-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3199
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3216
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
 msgid "lang_nub"
 msgstr "Nubisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3203
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3220
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
 msgid "lang_nwc"
 msgstr "Klassiek Nepalbhasa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3207
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3224
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3211
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3228
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3215
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3232
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3219
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3236
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3223
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3240
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3227
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3244
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
 msgid "lang_oci"
 msgstr "Occitaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3231
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3248
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3235
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3252
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
 msgid "lang_ori"
 msgstr "Odia"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3239
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3256
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
 msgid "lang_orm"
 msgstr "Afaan Oromo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3243
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3260
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
 msgid "lang_osa"
 msgstr "Osage"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3247
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3264
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3251
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3268
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
 msgid "lang_ota"
 msgstr "Ottomaans-Turks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3255
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3272
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
 msgid "lang_oto"
 msgstr "Otomi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3259
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3276
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
 msgid "lang_paa"
 msgstr "Papoeatalen (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3263
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3280
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3267
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3284
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3271
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3288
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3275
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3292
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
 msgid "lang_pan"
 msgstr "Punjabi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3279
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3296
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
 msgid "lang_pap"
 msgstr "Papiaments"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3283
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3300
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
 msgid "lang_pau"
 msgstr "[Pennsylvania] (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3287
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3304
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
 msgid "lang_peo"
 msgstr "Oudperzisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3291
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3308
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
 msgid "lang_per"
 msgstr "Perzisch (Farsi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3295
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3312
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
 msgid "lang_phi"
 msgstr "Filipijns (overige)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3299
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3316
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
 msgid "lang_phn"
 msgstr "Foenicisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3303
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3320
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
 msgid "lang_pli"
 msgstr "Pali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3307
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3324
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
 msgid "lang_pol"
 msgstr "Pools"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3311
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3328
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
 msgid "lang_pon"
 msgstr "Pohnpeiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3315
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3332
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
 msgid "lang_por"
 msgstr "Portugees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3319
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3336
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3323
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3340
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
 msgid "lang_pro"
 msgstr "Oudprovençaals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3327
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3344
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
 msgid "lang_pus"
 msgstr "Pasjtoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3331
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3348
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
 msgid "lang_que"
 msgstr "Quechua"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3335
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3352
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3339
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3356
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3343
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3360
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3347
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3364
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
 msgid "lang_roa"
 msgstr "Romaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3351
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3368
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
 msgid "lang_roh"
 msgstr "Reto-Romaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3355
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3372
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
 msgid "lang_rom"
 msgstr "Romani"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3359
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3376
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
 msgid "lang_rum"
 msgstr "Roemeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3363
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3380
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3367
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3384
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
 msgid "lang_rup"
 msgstr "Aroemeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3371
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3388
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3375
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3392
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3379
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3396
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
 msgid "lang_sag"
 msgstr "Sango"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3383
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3400
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
 msgid "lang_sah"
 msgstr "Jakoets"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3387
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3404
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
 msgid "lang_sai"
 msgstr "Zuid-Amerikaanse Indiaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3391
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3408
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
 msgid "lang_sal"
 msgstr "Salishtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3395
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3412
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
 msgid "lang_sam"
 msgstr "Samaritaans-Aramees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3399
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3416
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
 msgid "lang_san"
 msgstr "Sanskriet"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3403
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3420
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3407
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3424
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
 msgid "lang_sat"
 msgstr "Santali"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3411
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3428
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
 msgid "lang_scn"
 msgstr "Siciliaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3415
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3432
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
 msgid "lang_sco"
 msgstr "Schots"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3419
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3436
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
 msgid "lang_sel"
 msgstr "Selkoeps"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3423
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3440
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
 msgid "lang_sem"
 msgstr "Semitische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3427
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3444
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
 msgid "lang_sga"
 msgstr "Oudiers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3431
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3448
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
 msgid "lang_sgn"
 msgstr "Gebarentalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3435
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3452
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
 msgid "lang_shn"
 msgstr "Shan"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3439
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3456
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3443
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3460
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
 msgid "lang_sin"
 msgstr "Singalees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3447
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3464
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
 msgid "lang_sio"
 msgstr "Sioux-Catawbatalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3451
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3468
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
 msgid "lang_sit"
 msgstr "Sino-Tibetaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3455
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3472
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
 msgid "lang_sla"
 msgstr "Slavische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3459
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3476
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
 msgid "lang_slo"
 msgstr "Slowaaks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3463
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3480
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
 msgid "lang_slv"
 msgstr "Sloveens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3467
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3484
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
 msgid "lang_sma"
 msgstr "Zuid-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3471
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3488
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
 msgid "lang_sme"
 msgstr "Noord-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3475
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3492
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
 msgid "lang_smi"
 msgstr "Samisch (Laps)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3479
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3496
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
 msgid "lang_smj"
 msgstr "Lule-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3483
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3500
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
 msgid "lang_smn"
 msgstr "Inari-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3487
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3504
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
 msgid "lang_smo"
 msgstr "Samoaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3491
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3508
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
 msgid "lang_sms"
 msgstr "Skolt-Samisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3495
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3512
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
 msgid "lang_sna"
 msgstr "Shona"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3499
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3516
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3503
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3520
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3507
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3524
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3511
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3528
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
 msgid "lang_som"
 msgstr "Somalisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3515
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3532
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
 msgid "lang_son"
 msgstr "Songhai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3519
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3536
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
 msgid "lang_sot"
 msgstr "Zuid-Sotho"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3523
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3540
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
 msgid "lang_spa"
 msgstr "Spaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3527
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3544
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
 msgid "lang_srd"
 msgstr "Sardijns"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3531
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3548
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3535
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3552
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
 msgid "lang_srp"
 msgstr "Servisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3539
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3556
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
 msgid "lang_srr"
 msgstr "Serer"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3543
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3560
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
 msgid "lang_ssa"
 msgstr "Nilo-Saharaanse talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3547
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3564
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3551
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3568
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3555
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3572
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
 msgid "lang_sun"
 msgstr "Soendanees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3559
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3576
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
 msgid "lang_sus"
 msgstr "Soesoe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3563
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3580
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
 msgid "lang_sux"
 msgstr "Soemerisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3567
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3584
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3571
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3588
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
 msgid "lang_swe"
 msgstr "Zweeds"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3575
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3592
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
 msgid "lang_syc"
 msgstr "Klassiek Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3579
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3596
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
 msgid "lang_syr"
 msgstr "Syrisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3583
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3600
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
 msgid "lang_tah"
 msgstr "Tahitiaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3587
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3604
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
 msgid "lang_tai"
 msgstr "Taitalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3591
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3608
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3595
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3612
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
 msgid "lang_tat"
 msgstr "Tataars"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3599
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3616
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3603
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3620
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
 msgid "lang_tem"
 msgstr "Timne"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3607
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3624
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
 msgid "lang_ter"
 msgstr "Tereno"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3611
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3628
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
 msgid "lang_tet"
 msgstr "Tetun"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3615
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3632
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
 msgid "lang_tgk"
 msgstr "Tadzjieks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3619
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3636
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3623
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3640
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
 msgid "lang_tha"
 msgstr "Thai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3627
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3644
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
 msgid "lang_tib"
 msgstr "Tibetaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3631
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3648
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3635
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3652
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3639
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3656
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3643
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3660
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
 msgid "lang_tkl"
 msgstr "Tokelaus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3647
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3664
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
 msgid "lang_tlh"
 msgstr "Klingon"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3651
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3668
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3655
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3672
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3659
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3676
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
 msgid "lang_tog"
 msgstr "Nyasa Tonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3663
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3680
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
 msgid "lang_ton"
 msgstr "Tongaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3667
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3684
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3671
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3688
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3675
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3692
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3679
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3696
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3683
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3700
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
 msgid "lang_tuk"
 msgstr "Turkmeens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3687
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3704
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
 msgid "lang_tum"
 msgstr "Toemboeka"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3691
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3708
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
 msgid "lang_tup"
 msgstr "Tupi-talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3695
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3712
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
 msgid "lang_tur"
 msgstr "Turks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3699
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3716
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
 msgid "lang_tut"
 msgstr "Altaïsche talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3703
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3720
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
 msgid "lang_tvl"
 msgstr "Tuvaluaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3707
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3724
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
 msgid "lang_twi"
 msgstr "Twi"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3711
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3728
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
 msgid "lang_tyv"
 msgstr "Toevaans"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3715
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3732
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
 msgid "lang_udm"
 msgstr "Oedmoerts"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3719
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3736
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
 msgid "lang_uga"
 msgstr "Oegaritisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3723
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3740
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
 msgid "lang_uig"
 msgstr "Oeigoers"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3727
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3744
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
 msgid "lang_ukr"
 msgstr "Oekraïens"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3731
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3748
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3735
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3752
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
 msgid "lang_und"
 msgstr "onbekende taal"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3739
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3756
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3743
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3760
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
 msgid "lang_uzb"
 msgstr "Oezbeeks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3747
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3764
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
 msgid "lang_vai"
 msgstr "Vai"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3751
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3768
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
 msgid "lang_ven"
 msgstr "Venda"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3755
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3772
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
 msgid "lang_vie"
 msgstr "Vietnamees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3759
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3776
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3763
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3780
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
 msgid "lang_vot"
 msgstr "Votisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3767
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3784
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
 msgid "lang_wak"
 msgstr "Wakashtalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3771
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3788
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3775
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3792
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
 msgid "lang_war"
 msgstr "Waray"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3779
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3796
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
 msgid "lang_was"
 msgstr "Washo"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3783
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3800
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3787
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3804
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
 msgid "lang_wen"
 msgstr "Sorbische talen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3791
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3808
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
 msgid "lang_wln"
 msgstr "Waals"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3795
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3812
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3799
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3816
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
 msgid "lang_xal"
 msgstr "Kalmuks"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3803
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3820
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3807
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3824
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
 msgid "lang_yao"
 msgstr "Yao"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3811
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3828
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
 msgid "lang_yap"
 msgstr "Yapees"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3815
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3832
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3819
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3836
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3823
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3840
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
 msgid "lang_ypk"
 msgstr "Yupiktalen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3827
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3844
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3831
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3848
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
 msgid "lang_zbl"
 msgstr "Blissymbolen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3835
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3852
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3839
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3856
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3843
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3860
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
 msgid "lang_znd"
 msgstr "Zande"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3847
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3864
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
 msgid "lang_zul"
 msgstr "Zoeloe"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3851
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3868
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3855
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3872
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
 msgid "lang_zxx"
 msgstr "geen linguïstische inhoud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3859
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3876
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3863
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3880
 msgid "lang_zza"
 msgstr "Zaza"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3924
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3945
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3941
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3962
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3928
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3949
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3945
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3966
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:276
 msgid "Values"
 msgstr "Waarden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3935
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3956
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3952
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3973
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:3960
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3956
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:3977
 msgid "value"
 msgstr "Waarde"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
 msgid "country_aa"
 msgstr "Albanië (aa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
 msgid "country_abc"
 msgstr "Alberta (abc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
 msgid "country_ac"
 msgstr "Ashmore- en Cartier-eilanden (ac)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
 msgid "country_aca"
 msgstr "Australian Capital Territory (aca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
 msgid "country_ae"
 msgstr "Algerije (ae)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
 msgid "country_af"
 msgstr "Afghanistan (af)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
 msgid "country_ag"
 msgstr "Argentinië (ag)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
 msgid "country_ai"
 msgstr "Armenië (Republiek) (ai)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
 msgid "country_air"
 msgstr "Armeense S.S.R. (air)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
 msgid "country_aj"
 msgstr "Azerbeidzjan (aj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
 msgid "country_ajr"
 msgstr "Azerbeidzjan S.S.R. (ajr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
 msgid "country_aku"
 msgstr "Alaska (aku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
 msgid "country_alu"
 msgstr "Alabama (alu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
 msgid "country_am"
 msgstr "Anguilla (am)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
 msgid "country_an"
 msgstr "Andorra (an)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
 msgid "country_ao"
 msgstr "Angola (ao)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
 msgid "country_aq"
 msgstr "Antigua en Barbuda (aq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
 msgid "country_aru"
 msgstr "Arkansas (aru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
 msgid "country_as"
 msgstr "Amerikaans-Samoa (as)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
 msgid "country_at"
 msgstr "Australië (at)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
 msgid "country_au"
 msgstr "Oostenrijk (au)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
 msgid "country_aw"
 msgstr "Aruba (aw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
 msgid "country_ay"
 msgstr "Antarctica (ay)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
 msgid "country_azu"
 msgstr "Arizona (azu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
 msgid "country_ba"
 msgstr "Bahrein (ba)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
 msgid "country_bb"
 msgstr "Barbados (bb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
 msgid "country_bcc"
 msgstr "British Columbia (bcc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
 msgid "country_bd"
 msgstr "Burundi (bd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
 msgid "country_be"
 msgstr "België (be)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
 msgid "country_bf"
 msgstr "Bahama’s (bf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
 msgid "country_bg"
 msgstr "Bangladesh (bg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
 msgid "country_bh"
 msgstr "Belize (bh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
 msgid "country_bi"
 msgstr "Brits Indische Oceaanterritorium (bi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
 msgid "country_bl"
 msgstr "Brazilië (bl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
 msgid "country_bm"
 msgstr "Bermuda Islands (bm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
 msgid "country_bn"
 msgstr "Bosnië en Herzegovina (bn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
 msgid "country_bo"
 msgstr "Bolivia (bo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
 msgid "country_bp"
 msgstr "Salomonseilanden (bp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
 msgid "country_br"
 msgstr "Burma (br)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
 msgid "country_bs"
 msgstr "Botswana (bs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
 msgid "country_bt"
 msgstr "Bhutan (bt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
 msgid "country_bu"
 msgstr "Bulgarije (bu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
 msgid "country_bv"
 msgstr "Bouveteiland (bv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
 msgid "country_bw"
 msgstr "Belarus (bw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
 msgid "country_bwr"
 msgstr "Wit-Russische S.S.R. (-bwr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
 msgid "country_bx"
 msgstr "Brunei (bx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
 msgid "country_ca"
 msgstr "Caribisch Nederland (ca)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
 msgid "country_cau"
 msgstr "Californië (cau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
 msgid "country_cb"
 msgstr "Cambodja (cb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
 msgid "country_cc"
 msgstr "China (cc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
 msgid "country_cd"
 msgstr "Tsjaad (cd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
 msgid "country_ce"
 msgstr "Sri Lanka (ce)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
 msgid "country_cf"
 msgstr "Congo (Brazzaville) (cf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
 msgid "country_cg"
 msgstr "Congo (Democratische Republiek) (cg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
 msgid "country_ch"
 msgstr "China (Republiek: 1949-) (ch)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
 msgid "country_ci"
 msgstr "Kroatië (ci)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
 msgid "country_cj"
 msgstr "Kaaimaneilanden (cj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
 msgid "country_ck"
 msgstr "Colombia (ck)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
 msgid "country_cl"
 msgstr "Chili (cl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
 msgid "country_cm"
 msgstr "Kameroen (cm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
 msgid "country_cn"
 msgstr "Canada (cn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
 msgid "country_co"
 msgstr "Curaçao (co)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
 msgid "country_cou"
 msgstr "Colorado (cou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
 msgid "country_cp"
 msgstr "Canton en Enderbury Islands (cp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
 msgid "country_cq"
 msgstr "Comoren (cq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
 msgid "country_cr"
 msgstr "Costa Rica (cr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
 msgid "country_cs"
 msgstr "Tsjecho-Slowakije (cs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
 msgid "country_ctu"
 msgstr "Connecticut (ctu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
 msgid "country_cu"
 msgstr "Cuba (cu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
 msgid "country_cv"
 msgstr "Kaapverdië (cv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
 msgid "country_cw"
 msgstr "Cookeilanden (cw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
 msgid "country_cx"
 msgstr "Centraal-Afrikaanse Republiek (cx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
 msgid "country_cy"
 msgstr "Cyprus (cy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
 msgid "country_cz"
 msgstr "[Canal Zone] (cz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
 msgid "country_dcu"
 msgstr "District of Columbia (dcu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
 msgid "country_deu"
 msgstr "Delaware (deu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
 msgid "country_dk"
 msgstr "Denemarken (dk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
 msgid "country_dm"
 msgstr "Benin (dm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
 msgid "country_dq"
 msgstr "Dominica (dq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
 msgid "country_dr"
 msgstr "Dominicaanse Republiek (dr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
 msgid "country_ea"
 msgstr "Eritrea (ea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
 msgid "country_ec"
 msgstr "Ecuador (ec)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
 msgid "country_eg"
 msgstr "Equatoriaal-Guinea (eg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
 msgid "country_em"
 msgstr "Oost-Timor (em)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
 msgid "country_enk"
 msgstr "[England] (enk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
 msgid "country_er"
 msgstr "Estland (er)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
 msgid "country_err"
 msgstr "Estland (err)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
 msgid "country_es"
 msgstr "El Salvador (es)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
 msgid "country_et"
 msgstr "Ethiopië (et)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
 msgid "country_fa"
 msgstr "Faeröer (fa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
 msgid "country_fg"
 msgstr "Frans-Guyana (fg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
 msgid "country_fi"
 msgstr "Finland (fi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
 msgid "country_fj"
 msgstr "Fiji (fj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
 msgid "country_fk"
 msgstr "Falkland Islands (fk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
 msgid "country_flu"
 msgstr "Florida (flu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
 msgid "country_fm"
 msgstr "Micronesië (Federale Staten) (fm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
 msgid "country_fp"
 msgstr "Frans-Polynesië (fp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
 msgid "country_fr"
 msgstr "Frankrijk (fr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
 msgid "country_fs"
 msgstr "Terres australes et antarctiques françaises (fs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
 msgid "country_ft"
 msgstr "Djibouti (ft)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
 msgid "country_gau"
 msgstr "Georgië (gau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
 msgid "country_gb"
 msgstr "Kiribati (gb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
 msgid "country_gd"
 msgstr "Grenada (gd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
 msgid "country_ge"
 msgstr "Duitsland (Oost) (ge)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
 msgid "country_gg"
 msgstr "Guernsey (gg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
 msgid "country_gh"
 msgstr "Ghana (gh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
 msgid "country_gi"
 msgstr "Gibraltar (gi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
 msgid "country_gl"
 msgstr "Groenland (gl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
 msgid "country_gm"
 msgstr "Gambia (gm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
 msgid "country_gn"
 msgstr "Gilbert and Ellice Islands (gn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
 msgid "country_go"
 msgstr "Gabon (go)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
 msgid "country_gp"
 msgstr "Guadeloupe (gp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
 msgid "country_gr"
 msgstr "Griekenland (gr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
 msgid "country_gs"
 msgstr "Georgië (Republiek) (gs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
 msgid "country_gsr"
 msgstr "Georgian S.S.R. (gsr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
 msgid "country_gt"
 msgstr "Guatemala (gt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
 msgid "country_gu"
 msgstr "Guam (gu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
 msgid "country_gv"
 msgstr "Guinee (gv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
 msgid "country_gw"
 msgstr "Duitsland (gw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
 msgid "country_gy"
 msgstr "Guyana (gy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
 msgid "country_gz"
 msgstr "Gaza Strip (gz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
 msgid "country_hiu"
 msgstr "Hawaii (hiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
 msgid "country_hk"
 msgstr "Hongkong SAR van China (hk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
 msgid "country_hm"
 msgstr "Heard and McDonald Islands (hm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
 msgid "country_ho"
 msgstr "Honduras (ho)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
 msgid "country_ht"
 msgstr "Haïti (ht)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
 msgid "country_hu"
 msgstr "Hongarije (hu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
 msgid "country_iau"
 msgstr "Iowa (iau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
 msgid "country_ic"
 msgstr "IJsland (ic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
 msgid "country_idu"
 msgstr "Idaho (idu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
 msgid "country_ie"
 msgstr "Ierland (ie)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
 msgid "country_ii"
 msgstr "India (ii)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4886
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4903
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
 msgid "country_ilu"
 msgstr "Illinois (ilu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4890
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4907
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
 msgid "country_im"
 msgstr "Isle of Man (im)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4894
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4911
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
 msgid "country_inu"
 msgstr "Indiana (inu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4898
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4915
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
 msgid "country_io"
 msgstr "Indonesië (io)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4902
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4919
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
 msgid "country_iq"
 msgstr "Irak (iq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4906
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4923
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
 msgid "country_ir"
 msgstr "Iran (ir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4910
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4927
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
 msgid "country_is"
 msgstr "Israël (is)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4914
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4931
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
 msgid "country_it"
 msgstr "Italië (it)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4918
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4935
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
 msgid "country_iu"
 msgstr "Gedemilitariseerde zones Israël-Syrië (iu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
 msgid "country_iv"
 msgstr "Ivoorkust (iv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
 msgid "country_iw"
 msgstr "Gedemilitariseerde zones Israël-Jordanië (iw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
 msgid "country_iy"
 msgstr "Irak-Saoedi-Arabië Neutrale zone (iy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
 msgid "country_ja"
 msgstr "Japan (ja)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
 msgid "country_je"
 msgstr "Jersey (je)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
 msgid "country_ji"
 msgstr "Johnston Atoll (ji)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
 msgid "country_jm"
 msgstr "Jamaica (jm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
 msgid "country_jn"
 msgstr "Jan Mayen (jn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
 msgid "country_jo"
 msgstr "Jordanië (jo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
 msgid "country_ke"
 msgstr "Kenia (ke)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
 msgid "country_kg"
 msgstr "Kirgizië (kg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
 msgid "country_kgr"
 msgstr "Kirghiz S.S.R. (kgr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
 msgid "country_kn"
 msgstr "Korea (Noord) (kn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
 msgid "country_ko"
 msgstr "Zuid Korea (ko)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
 msgid "country_ksu"
 msgstr "Kansas (ksu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:4999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
 msgid "country_ku"
 msgstr "Koeweit (ku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
 msgid "country_kv"
 msgstr "Kosovo (kv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
 msgid "country_kyu"
 msgstr "Kentucky (kyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
 msgid "country_kz"
 msgstr "Kazachstan (kz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:4998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
 msgid "country_kzr"
 msgstr "Kazakh S.S.R. (kzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
 msgid "country_lau"
 msgstr "Louisiana (lau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
 msgid "country_lb"
 msgstr "Liberia (lb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
 msgid "country_le"
 msgstr "Libanon (le)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
 msgid "country_lh"
 msgstr "Liechtenstein (lh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
 msgid "country_li"
 msgstr "Litouwen (li)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
 msgid "country_lir"
 msgstr "Litouwen (lir)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5026
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5043
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
 msgid "country_ln"
 msgstr "Central and Southern Line Islands (ln)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5030
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5047
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
 msgid "country_lo"
 msgstr "Lesotho (lo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5034
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5051
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
 msgid "country_ls"
 msgstr "Laos (ls)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5038
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5055
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
 msgid "country_lu"
 msgstr "Luxemburg (lu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5042
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5059
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
 msgid "country_lv"
 msgstr "Letland (lv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5046
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5063
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
 msgid "country_lvr"
 msgstr "Letland (lvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5050
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5067
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
 msgid "country_ly"
 msgstr "Libië (ly)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5054
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5071
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
 msgid "country_mau"
 msgstr "Massachusetts (mau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5058
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5075
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
 msgid "country_mbc"
 msgstr "Manitoba (mbc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5062
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5079
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
 msgid "country_mc"
 msgstr "Monaco (mc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5066
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5083
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
 msgid "country_mdu"
 msgstr "Maryland (mdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5070
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5087
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
 msgid "country_meu"
 msgstr "Maine (meu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5074
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5091
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
 msgid "country_mf"
 msgstr "Mauritius (mf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5078
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5095
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
 msgid "country_mg"
 msgstr "Madagaskar (mg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5082
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5099
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
 msgid "country_mh"
 msgstr "Macau SAR van China (mh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5086
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5103
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
 msgid "country_miu"
 msgstr "Michigan (miu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5090
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5107
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
 msgid "country_mj"
 msgstr "Montserrat (mj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5094
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5111
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
 msgid "country_mk"
 msgstr "Oman (mk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5098
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5115
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
 msgid "country_ml"
 msgstr "Mali (ml)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5102
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5119
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
 msgid "country_mm"
 msgstr "Malta (mm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5106
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5123
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
 msgid "country_mnu"
 msgstr "Minnesota (mnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5110
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5127
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
 msgid "country_mo"
 msgstr "Montenegro (mo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5114
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5131
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
 msgid "country_mou"
 msgstr "Missouri (mou)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5118
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5135
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
 msgid "country_mp"
 msgstr "Mongolië (mp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5122
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5139
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
 msgid "country_mq"
 msgstr "Martinique (mq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5126
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5143
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
 msgid "country_mr"
 msgstr "Marokko (mr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5130
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5147
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
 msgid "country_msu"
 msgstr "Mississippi (msu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5134
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5151
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
 msgid "country_mtu"
 msgstr "Montana (mtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5138
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5155
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
 msgid "country_mu"
 msgstr "Mauritanië (mu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5142
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5159
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
 msgid "country_mv"
 msgstr "Moldavië (mv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5146
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5163
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
 msgid "country_mvr"
 msgstr "Moldavian S.S.R. (mvr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5150
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5167
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
 msgid "country_mw"
 msgstr "Malawi (mw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5154
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5171
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
 msgid "country_mx"
 msgstr "Mexico (mx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5158
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5175
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
 msgid "country_my"
 msgstr "Maleisië (my)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5162
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5179
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
 msgid "country_mz"
 msgstr "Mozambique (mz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5166
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5183
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
 msgid "country_na"
 msgstr "Nederlandse Antillen (na)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5170
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5187
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
 msgid "country_nbu"
 msgstr "Nebraska (nbu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5174
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5191
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
 msgid "country_ncu"
 msgstr "North Carolina (ncu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5178
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5195
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
 msgid "country_ndu"
 msgstr "North Dakota (ndu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5182
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5199
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
 msgid "country_ne"
 msgstr "Nederland (ne)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5186
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5203
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
 msgid "country_nfc"
 msgstr "Newfoundland and Labrador (nfc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5190
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5207
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
 msgid "country_ng"
 msgstr "Niger (ng)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5194
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5211
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
 msgid "country_nhu"
 msgstr "New Hampshire (nhu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5198
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5215
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
 msgid "country_nik"
 msgstr "Noord-Ierland (nik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5202
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5219
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
 msgid "country_nju"
 msgstr "New Jersey (nju)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5206
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5223
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
 msgid "country_nkc"
 msgstr "New Brunswick (nkc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5210
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5227
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
 msgid "country_nl"
 msgstr "Nieuw-Caledonië (nl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5214
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5231
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
 msgid "country_nm"
 msgstr "Noordelijke Marianen (nm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5218
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5235
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
 msgid "country_nmu"
 msgstr "New Mexico (nmu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5222
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5239
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
 msgid "country_nn"
 msgstr "Vanuatu (nn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5226
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5243
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
 msgid "country_no"
 msgstr "Noorwegen (no)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5230
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5247
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
 msgid "country_np"
 msgstr "Nepal (np)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5234
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5251
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
 msgid "country_nq"
 msgstr "Nicaragua (nq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5238
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5255
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
 msgid "country_nr"
 msgstr "Nigeria (nr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5242
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5259
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
 msgid "country_nsc"
 msgstr "Nova Scotia (nsc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5246
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5263
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
 msgid "country_ntc"
 msgstr "Northwest Territories (ntc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5250
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5267
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
 msgid "country_nu"
 msgstr "Nauru (nu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5254
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5271
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
 msgid "country_nuc"
 msgstr "Nunavut (nuc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5258
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5275
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
 msgid "country_nvu"
 msgstr "Nevada (nvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5262
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5279
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
 msgid "country_nw"
 msgstr "Noordelijke Marianen (nw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5266
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5283
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
 msgid "country_nx"
 msgstr "Norfolk (nx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5270
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5287
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
 msgid "country_nyu"
 msgstr "New York (Staat) (nyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5274
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5291
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
 msgid "country_nz"
 msgstr "Nieuw-Zeeland (nz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5278
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5295
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
 msgid "country_ohu"
 msgstr "Ohio (ohu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5282
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5299
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
 msgid "country_oku"
 msgstr "Oklahoma (oku)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5286
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5303
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
 msgid "country_onc"
 msgstr "Ontario (onc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5290
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5307
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
 msgid "country_oru"
 msgstr "Oregon (oru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5294
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5311
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
 msgid "country_ot"
 msgstr "Mayotte (ot)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5298
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5315
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
 msgid "country_pau"
 msgstr "Pennsylvania (pau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5302
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5319
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
 msgid "country_pc"
 msgstr "Pitcairn Island (pc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5306
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5323
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
 msgid "country_pe"
 msgstr "Peru (pe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5310
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5327
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
 msgid "country_pf"
 msgstr "Paracel Islands (pf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5314
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5331
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
 msgid "country_pg"
 msgstr "Guinee-Bissau (pg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5318
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5335
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
 msgid "country_ph"
 msgstr "Filipijnen (ph)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5322
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5339
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
 msgid "country_pic"
 msgstr "Prince Edward Island (pic)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5326
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5343
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
 msgid "country_pk"
 msgstr "Pakistan (pk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5330
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5347
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
 msgid "country_pl"
 msgstr "Polen (pl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5334
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5351
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
 msgid "country_pn"
 msgstr "Panama (pn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5338
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5355
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
 msgid "country_po"
 msgstr "Portugal (po)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5342
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5359
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
 msgid "country_pp"
 msgstr "Papoea-Nieuw-Guinea (pp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5346
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5363
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
 msgid "country_pr"
 msgstr "Puerto Rico (pr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5350
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5367
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
 msgid "country_pt"
 msgstr "Portugees Timor (pt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5354
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5371
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
 msgid "country_pw"
 msgstr "Palau (pw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5358
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5375
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
 msgid "country_py"
 msgstr "Paraguay (py)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5362
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5379
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
 msgid "country_qa"
 msgstr "Qatar (qa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5366
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5383
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
 msgid "country_qea"
 msgstr "Queensland (qea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5370
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5387
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
 msgid "country_quc"
 msgstr "Québec (Province) (quc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5374
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5391
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
 msgid "country_rb"
 msgstr "Servië (rb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5378
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5395
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
 msgid "country_re"
 msgstr "Réunion (re)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5382
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5399
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
 msgid "country_rh"
 msgstr "Zimbabwe (rh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5386
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5403
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
 msgid "country_riu"
 msgstr "Rhode Island (riu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5390
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5407
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
 msgid "country_rm"
 msgstr "Roemenië (rm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5394
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5411
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
 msgid "country_ru"
 msgstr "Rusland (Federatie) (ru)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5398
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5415
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
 msgid "country_rur"
 msgstr "Russische S.F.S.R. (rur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5402
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5419
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
 msgid "country_rw"
 msgstr "Rwanda (rw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5406
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5423
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
 msgid "country_ry"
 msgstr "Ryukyu Islands, Southern (ry)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5410
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5427
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
 msgid "country_sa"
 msgstr "Zuid-Afrika (sa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5414
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5431
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
 msgid "country_sb"
 msgstr "Svalbard (sb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5418
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5435
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
 msgid "country_sc"
 msgstr "Saint-Barthélemy (sc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5422
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5439
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
 msgid "country_scu"
 msgstr "South Carolina (scu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5426
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5443
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
 msgid "country_sd"
 msgstr "Zuid-Soedan (sd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5430
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5447
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
 msgid "country_sdu"
 msgstr "South Dakota (sdu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5434
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5451
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
 msgid "country_se"
 msgstr "Seychellen (se)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5438
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5455
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
 msgid "country_sf"
 msgstr "Sao Tomé en Principe (sf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5442
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5459
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
 msgid "country_sg"
 msgstr "Senegal (sg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5446
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5463
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
 msgid "country_sh"
 msgstr "Spaans Noord-Afrika (sh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5450
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5467
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
 msgid "country_si"
 msgstr "Singapore (si)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5454
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5471
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
 msgid "country_sj"
 msgstr "Soedan (sj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5458
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5475
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
 msgid "country_sk"
 msgstr "Sikkim (sk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5462
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5479
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
 msgid "country_sl"
 msgstr "Sierra Leone (sl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5466
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5483
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
 msgid "country_sm"
 msgstr "San Marino (sm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5470
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5487
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
 msgid "country_sn"
 msgstr "Sint Maarten (sn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5474
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5491
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
 msgid "country_snc"
 msgstr "Saskatchewan (snc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5478
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5495
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
 msgid "country_so"
 msgstr "Somalië (so)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5482
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5499
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
 msgid "country_sp"
 msgstr "Spanje (sp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5486
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5503
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
 msgid "country_sq"
 msgstr "eSwatini (sq)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5490
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5507
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
 msgid "country_sr"
 msgstr "Surinam (sr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5494
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5511
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
 msgid "country_ss"
 msgstr "Westelijke Sahara (ss)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5498
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5515
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
 msgid "country_st"
 msgstr "Saint-Martin (st)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5502
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5519
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
 msgid "country_stk"
 msgstr "Schotland (stk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5506
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5523
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
 msgid "country_su"
 msgstr "Saoedi-Arabië (su)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5510
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5527
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
 msgid "country_sv"
 msgstr "Swan Islands (sv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5514
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5531
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
 msgid "country_sw"
 msgstr "Zweden (sw)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5518
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5535
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
 msgid "country_sx"
 msgstr "Namibië (sx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5522
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5539
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
 msgid "country_sy"
 msgstr "[Syria] (sy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5526
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5543
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
 msgid "country_sz"
 msgstr "Zwitserland (sz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5530
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5547
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
 msgid "country_ta"
 msgstr "Tadzjikistan (ta)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5534
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5551
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
 msgid "country_tar"
 msgstr "Tajik S.S.R. (tar)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5538
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5555
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
 msgid "country_tc"
 msgstr "Turks- en Caicoseilanden (tc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5542
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5559
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
 msgid "country_tg"
 msgstr "Togo (tg)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5546
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5563
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
 msgid "country_th"
 msgstr "Thailand (th)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5550
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5567
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
 msgid "country_ti"
 msgstr "Tunesië (ti)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5554
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5571
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
 msgid "country_tk"
 msgstr "Turkmenistan (tk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5558
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5575
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
 msgid "country_tkr"
 msgstr "Turkmen S.S.R. (tkr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5562
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5579
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
 msgid "country_tl"
 msgstr "Tokelau (tl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5566
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5583
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
 msgid "country_tma"
 msgstr "Tasmania (tma)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5570
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5587
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
 msgid "country_tnu"
 msgstr "Tennessee (tnu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5574
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5591
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
 msgid "country_to"
 msgstr "Tonga (to)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5578
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5595
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
 msgid "country_tr"
 msgstr "Trinidad en Tobago (tr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5582
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5599
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
 msgid "country_ts"
 msgstr "Verenigde Arabische Emiraten (ts)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5586
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5603
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
 msgid "country_tt"
 msgstr "Trust Territory of the Pacific Islands (tt)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5590
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5607
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
 msgid "country_tu"
 msgstr "Turkije (tu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5594
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5611
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
 msgid "country_tv"
 msgstr "Tuvalu (tv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5598
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5615
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
 msgid "country_txu"
 msgstr "Texas (txu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5602
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5619
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
 msgid "country_tz"
 msgstr "Tanzania (tz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5606
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5623
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
 msgid "country_ua"
 msgstr "Egypte (ua)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5610
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5627
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
 msgid "country_uc"
 msgstr "Verenigde Staten Misc. Caribbean Islands (uc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5614
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5631
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
 msgid "country_ug"
 msgstr "Oeganda (ug)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5618
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5635
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
 msgid "country_ui"
 msgstr "Verenigd Koninkrijk Misc. Islands (ui)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5622
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5639
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
 msgid "country_uik"
 msgstr "Verenigd Koninkrijk Misc. Islands (uik)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5626
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5643
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
 msgid "country_uk"
 msgstr "Verenigd Koninkrijk (uk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5630
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5647
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
 msgid "country_un"
 msgstr "Oekraïne (un)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5634
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5651
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
 msgid "country_unr"
 msgstr "Oekraïne (unr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5638
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5655
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
 msgid "country_up"
 msgstr "Verenigde Staten Misc. Pacific Islands (up)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5642
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5659
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
 msgid "country_ur"
 msgstr "Sovjet-Unie (ur)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5646
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5663
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
 msgid "country_us"
 msgstr "Verenigde Staten (us)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5650
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5667
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
 msgid "country_utu"
 msgstr "Utah (utu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5654
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5671
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
 msgid "country_uv"
 msgstr "Burkina Faso (uv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5658
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5675
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
 msgid "country_uy"
 msgstr "Uruguay (uy)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5662
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5679
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
 msgid "country_uz"
 msgstr "Oezbekistan (uz)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5666
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5683
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
 msgid "country_uzr"
 msgstr "Uzbek S.S.R. (uzr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5670
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5687
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
 msgid "country_vau"
 msgstr "Virginia (vau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5674
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5691
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
 msgid "country_vb"
 msgstr "Britse Maagdeneilanden (vb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5678
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5695
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
 msgid "country_vc"
 msgstr "Vaticaanstad (vc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5682
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5699
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
 msgid "country_ve"
 msgstr "Venezuela (ve)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5686
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5703
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
 msgid "country_vi"
 msgstr "Amerikaanse Maagdeneilanden (vi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5690
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5707
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
 msgid "country_vm"
 msgstr "Vietnam (vm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5694
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5711
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
 msgid "country_vn"
 msgstr "Vietnam, Noord (vn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5698
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5715
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
 msgid "country_vp"
 msgstr "[Verschillende plaatsen] (vp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5702
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5719
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
 msgid "country_vra"
 msgstr "Victoria (vra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5706
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5723
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
 msgid "country_vs"
 msgstr "Vietnam, Zuid (vs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5710
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5727
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
 msgid "country_vtu"
 msgstr "Vermont (vtu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5714
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5731
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
 msgid "country_wau"
 msgstr "Washington (Staat) (wau)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5718
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5735
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
 msgid "country_wb"
 msgstr "West Berlijn (wb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5722
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5739
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
 msgid "country_wea"
 msgstr "Western Australia (wea)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5726
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5743
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
 msgid "country_wf"
 msgstr "Wallis en Futuna (wf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5730
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5747
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
 msgid "country_wiu"
 msgstr "Wisconsin (wiu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5734
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5751
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
 msgid "country_wj"
 msgstr "Westelijke Jordaanoever (wj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5738
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5755
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
 msgid "country_wk"
 msgstr "Wake Island (wk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5742
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5759
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
 msgid "country_wlk"
 msgstr "Wales (wlk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5746
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5763
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
 msgid "country_ws"
 msgstr "Samoa (ws)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5750
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5767
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
 msgid "country_wvu"
 msgstr "West Virginia (wvu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5754
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5771
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
 msgid "country_wyu"
 msgstr "Wyoming (wyu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5758
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5775
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
 msgid "country_xa"
 msgstr "Christmas Island (Indian Ocean) (xa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5762
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5779
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
 msgid "country_xb"
 msgstr "Cocoseilanden (xb)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5766
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5783
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
 msgid "country_xc"
 msgstr "Maldiven (xc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5770
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5787
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
 msgid "country_xd"
 msgstr "Saint Kitts-Nevis (xd)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5774
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5791
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
 msgid "country_xe"
 msgstr "Marshalleilanden (xe)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5778
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5795
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
 msgid "country_xf"
 msgstr "Midway Islands (xf)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5782
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5799
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
 msgid "country_xga"
 msgstr "Coral Sea Islands Territory (xga)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5786
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5803
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
 msgid "country_xh"
 msgstr "Niue (xh)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5790
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5807
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
 msgid "country_xi"
 msgstr "Saint Kitts-Nevis-Anguilla (xi)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5794
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5811
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
 msgid "country_xj"
 msgstr "Saint Helena (xj)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5798
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5815
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
 msgid "country_xk"
 msgstr "Saint Lucia (xk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5802
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5819
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
 msgid "country_xl"
 msgstr "Saint-Pierre en Miquelon (xl)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5806
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5823
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
 msgid "country_xm"
 msgstr "Saint Vincent en de Grenadines (xm)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5810
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5827
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
 msgid "country_xn"
 msgstr "Noord-Macedonië (xn)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5814
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5831
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
 msgid "country_xna"
 msgstr "New South Wales (xna)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5818
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5835
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
 msgid "country_xo"
 msgstr "Slowakije (xo)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5822
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5839
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
 msgid "country_xoa"
 msgstr "Northern Territory (xoa)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5826
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5843
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
 msgid "country_xp"
 msgstr "Spratly Island (xp)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5830
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5847
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
 msgid "country_xr"
 msgstr "Tsjechië (xr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5834
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5851
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
 msgid "country_xra"
 msgstr "Zuid Australië (xra)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5838
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5855
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
 msgid "country_xs"
 msgstr "Zuid-Georgia en Zuidelijke Sandwicheilanden (xs)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5842
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5859
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
 msgid "country_xv"
 msgstr "Slovenië (xv)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5846
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5863
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
 msgid "country_xx"
 msgstr "Geen plaats, onbekend of onbepaald (xx)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5850
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5867
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
 msgid "country_xxc"
 msgstr "Canada (xxc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5854
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5871
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
 msgid "country_xxk"
 msgstr "Verenigd Koninkrijk (xxk)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5858
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5875
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
 msgid "country_xxr"
 msgstr "Sovjet-Unie (xxr)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5862
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5879
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
 msgid "country_xxu"
 msgstr "Verenigde Staten (xxu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5866
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5883
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
 msgid "country_ye"
 msgstr "Jemen (ye)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5870
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5887
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
 msgid "country_ykc"
 msgstr "Yukon-gebied (ykc)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5874
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5891
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
 msgid "country_ys"
 msgstr "Jemen (Democratische Volksrepubliek) (ys)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5878
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5895
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
 msgid "country_yu"
 msgstr "Servië en Montenegro (yu)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5882
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5899
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5886
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5903
 msgid "country_za"
 msgstr "Zambia (za)"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5889
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5906
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5893
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5910
 msgid "Cantons"
 msgstr "Kantons"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5922
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5939
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
 msgid "canton_ag"
 msgstr "Aargau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5926
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5943
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
 msgid "canton_ai"
 msgstr "Appenzell Innerrhoden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5930
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5947
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
 msgid "canton_ar"
 msgstr "Appenzell Ausserrhoden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5934
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5951
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
 msgid "canton_be"
 msgstr "Bern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5938
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5955
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
 msgid "canton_bl"
 msgstr "Basel-Landschaft"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5942
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5959
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
 msgid "canton_bs"
 msgstr "Basel-Stadt"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5946
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5963
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
 msgid "canton_fr"
 msgstr "Fribourg"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5950
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5967
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
 msgid "canton_ge"
 msgstr "Genève"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5954
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5971
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
 msgid "canton_gl"
 msgstr "Glarus"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5958
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5975
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
 msgid "canton_gr"
 msgstr "Graubünden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5962
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5979
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
 msgid "canton_ju"
 msgstr "Jura"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5966
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5983
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
 msgid "canton_lu"
 msgstr "Luzern"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5970
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5987
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
 msgid "canton_ne"
 msgstr "Neuchâtel"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5974
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5991
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
 msgid "canton_nw"
 msgstr "Nidwalden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5978
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5995
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
 msgid "canton_ow"
 msgstr "Obwalden"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5982
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:5999
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
 msgid "canton_sg"
 msgstr "Sankt Gallen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5986
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6003
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
 msgid "canton_sh"
 msgstr "Schaffhausen"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5990
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6007
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
 msgid "canton_so"
 msgstr "Solothurn"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5994
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6011
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
 msgid "canton_sz"
 msgstr "Schwyz"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:5998
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6015
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
 msgid "canton_tg"
 msgstr "Thurgau"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6002
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6019
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
 msgid "canton_ti"
 msgstr "Ticino"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6006
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6023
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
 msgid "canton_ur"
 msgstr "Uri"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6010
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6027
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
 msgid "canton_vd"
 msgstr "Vaud"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6014
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6031
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
 msgid "canton_vs"
 msgstr "Valais"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6018
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6035
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
 msgid "canton_zg"
 msgstr "Zug"
 
-#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6022
-#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6039
+#: rero_ils/modules/documents/jsonschemas/documents/document-minimal-v0.0.1_src.json:6026
+#: rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1_src.json:6043
 msgid "canton_zh"
 msgstr "Zürich"
 
@@ -6716,6 +6721,10 @@ msgstr ""
 msgid "Vol. {{numbering.vol}}, {{chronology.year}}"
 msgstr ""
 
+#: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:149
+msgid "Should contains at least one variable between {{ }}."
+msgstr ""
+
 #: rero_ils/modules/holdings/jsonschemas/holdings/holding-v0.0.1.json:155
 msgid "Prediction patterns"
 msgstr ""
@@ -6837,7 +6846,6 @@ msgid "Barcode"
 msgstr "Barcode"
 
 #: rero_ils/modules/item_types/api.py:73
-#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
 msgid "Another online item type exists in this organisation"
 msgstr "Een ander online type van exemplaar bestaat in deze organisatie "
 
@@ -6862,7 +6870,7 @@ msgid "Name of the ItemType."
 msgstr "Naam van de type van de exemplaar"
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:46
-msgid "The item type name is already taken"
+msgid "The item type name is already taken."
 msgstr "De naam van de type van exemplaar is al genomen."
 
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:53
@@ -6876,6 +6884,10 @@ msgstr "Type van de circulatie categorie"
 #: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:70
 msgid "Standard"
 msgstr "Standaard"
+
+#: rero_ils/modules/item_types/jsonschemas/item_types/item_type-v0.0.1.json:87
+msgid "Another online item type exists in this organisation."
+msgstr "Een ander online type van exemplaar bestaat in deze organisatie."
 
 #: rero_ils/modules/items/views.py:113
 #, python-format
@@ -6916,7 +6928,8 @@ msgid "Item ID"
 msgstr "Kopie ID"
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:47
-msgid "The barcode is already taken"
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
+msgid "The barcode is already taken."
 msgstr "De barcode is al bezet."
 
 #: rero_ils/modules/items/jsonschemas/items/item-v0.0.1.json:90
@@ -6966,7 +6979,7 @@ msgstr "Bibliotheek ID"
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:38
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:39
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:39
 msgid "Code"
 msgstr "Code"
 
@@ -6979,7 +6992,7 @@ msgid "Name of the library."
 msgstr "Naam van de bibliotheek."
 
 #: rero_ils/modules/libraries/jsonschemas/libraries/library-v0.0.1.json:49
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:33
 msgid "Address"
 msgstr "Adres"
 
@@ -6991,7 +7004,7 @@ msgstr "Adres van de bibliotheek."
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:74
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:31
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:150
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:213
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:212
 msgid "Email"
 msgstr "E-mail"
 
@@ -7213,6 +7226,13 @@ msgstr ""
 msgid "Specify a generic email address used for notification."
 msgstr ""
 
+#: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:173
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:88
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:158
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:220
+msgid "Email should have at least one <code>@</code> and one <code>.</code>."
+msgstr ""
+
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:179
 #: rero_ils/modules/locations/jsonschemas/locations/location-v0.0.1.json:209
 msgid "Restrict pickup to"
@@ -7298,39 +7318,38 @@ msgid "Organisation ID"
 msgstr "Organisatie ID"
 
 #: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:28
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:29
 msgid "Required. Name of the organisation."
 msgstr "Verplicht. Naam van de organisatie."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:35
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:34
 msgid "Address of the organisation."
 msgstr "Adres van de organisatie."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:41
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:40
 msgid "Code of the organisation."
 msgstr "Code van de organisatie."
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:45
 msgid "Current ID of the budget"
 msgstr "Huidige ID van de begroting"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:47
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:46
 msgid "The ID of the current budget of the organisation"
 msgstr "ID van de huidige begroting van de organisatie"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:50
 msgid "Default currency"
 msgstr "Standaardvaluta"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:52
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:51
 msgid "The default currency of the organisation"
 msgstr "De standaardvaluta van de organisatie"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:56
 msgid "Online harvested source"
 msgstr "Online geoogste bron"
 
-#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:58
+#: rero_ils/modules/organisations/jsonschemas/organisations/organisation-v0.0.1.json:57
 msgid "Online harvested source as configured in ebooks server."
 msgstr "Online geoogste bron zoals geconfigureerd in de ebookserver."
 
@@ -7532,6 +7551,10 @@ msgstr "Achternaam"
 msgid "Date of birth"
 msgstr "Geboortedatum"
 
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:67
+msgid "Should be in the ISO 8601, YYYY-MM-DD."
+msgstr ""
+
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:70
 msgid "Example: 1985-12-29"
 msgstr "Voorbeeld: 1985-12-29"
@@ -7562,20 +7585,26 @@ msgstr "Postcode"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:106
 #: rero_ils/modules/patrons/templates/rero_ils/_patron_profile_personal.html:27
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:135
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:197
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:196
 msgid "City"
 msgstr "Stad"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:111
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:145
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:206
 msgid "Phone number"
 msgstr "Telefoonnummer"
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:112
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:146
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:208
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:207
 msgid "Phone number with the international prefix, without spaces."
+msgstr "Telefoonnummer met internationaal kengetal, zonder spaties."
+
+#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:118
+msgid ""
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr "Telefoonnummer met internationaal kengetal, zonder spaties."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:121
@@ -7598,10 +7627,6 @@ msgstr "Lezerstype URI"
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:151
 msgid "Patron's barcode or card number"
 msgstr "Barcode of kaartnummer van de lezer"
-
-#: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:164
-msgid "The barcode is already taken."
-msgstr "De barcode is al bezet."
 
 #: rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json:171
 msgid "Library affiliation."
@@ -7849,7 +7874,7 @@ msgid "Vendor ID"
 msgstr "Verkoper ID"
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:50
-msgid "The vendor name is already taken"
+msgid "The vendor name is already taken."
 msgstr "De verkopersnaam is al genomen."
 
 #: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:56
@@ -7884,15 +7909,11 @@ msgstr "Contactnaam"
 msgid "Name of the vendor contact person."
 msgstr ""
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:194
-msgid "A valid postal code with a min of 4 characters."
-msgstr "Een geldige postcode met minimaal 4 karakters."
-
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:229
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:228
 msgid "Currency"
 msgstr "Valuta"
 
-#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:243
+#: rero_ils/modules/vendors/jsonschemas/vendors/vendor-v0.0.1.json:242
 msgid "VAT rate"
 msgstr "btw tarief"
 
@@ -8068,4 +8089,10 @@ msgstr "Klik hier om uw wachtwoord opnieuw in te stellen"
 
 #~ msgid "requested"
 #~ msgstr "gereserveerd"
+
+#~ msgid "The barcode is already taken"
+#~ msgstr "De barcode is al bezet."
+
+#~ msgid "A valid postal code with a min of 4 characters."
+#~ msgstr "Een geldige postcode met minimaal 4 karakters."
 

--- a/rero_ils/views.py
+++ b/rero_ils/views.py
@@ -36,7 +36,6 @@ from rero_ils.modules.organisations.api import Organisation
 from rero_ils.modules.patrons.api import current_patron
 from rero_ils.permissions import can_access_professional_view
 
-from .modules.babel_extractors import translate
 from .version import __version__
 
 blueprint = Blueprint(
@@ -282,15 +281,7 @@ def prepare_jsonschema(schema):
     if schema.get('$schema'):
         del schema['$schema']
     schema['required'].remove('pid')
-    keys = current_app.config['RERO_ILS_BABEL_TRANSLATE_JSON_KEYS']
-    return translate(schema, keys=keys)
-
-
-def prepare_form_option(form_option):
-    """Option prep."""
-    form_option = copy.deepcopy(form_option)
-    keys = current_app.config['RERO_ILS_BABEL_TRANSLATE_JSON_KEYS']
-    return translate(form_option, keys=keys)
+    return schema
 
 
 @blueprint.route('/schemaform/<document_type>')
@@ -310,12 +301,6 @@ def schemaform(document_type):
     except JSONSchemaNotFound:
         abort(404)
 
-    # try:
-    #     form = current_jsonschemas.get_schema(
-    #         'form_{}/{}-v0.0.1.json'.format(document_type, doc_type))
-    #     data['layout'] = prepare_form_option(form)
-    # except JSONSchemaNotFound as error:
-    #     raise(error)
     return jsonify(data)
 
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -125,7 +125,7 @@ fi
 # install assets utils
 virtualenv_path=`poetry env info -p`
 info_msg "Install npm assets utils in: ${virtualenv_path}"
-npm i npm@latest -g --prefix "${virtualenv_path}" && npm install --prefix "${virtualenv_path}" --silent -g node-sass@4.9.0 clean-css@3.4.19 uglify-js@2.7.3 requirejs@2.2.0 @angular/cli@7.0.4 yarn
+npm i npm@latest -g --prefix "${virtualenv_path}" && npm install --prefix "${virtualenv_path}" --silent -g  node-sass@4.14.1 clean-css-cli@4.3.0 uglify-js@3.9.4 requirejs@2.3.6
 
 # collect static files and compile html/css assets
 # ------------------------------------------------

--- a/tests/data/babel_extraction.json
+++ b/tests/data/babel_extraction.json
@@ -24,7 +24,6 @@
     "name": {
       "title": "Name",
       "description": "Required. Name of the organisation.",
-      "validationMessage": "Required. Name of the organisation.",
       "type": "string",
       "minLength": 1
     }


### PR DESCRIPTION
* Removes JSONSchema backend on the fly translations.
* Removes legacy `validationMessage` JSONSchema` property.
* Adds suffix to the validation messages keys.
* Fixes missing punctuation in the validation messages.
* Cleans babel configuration.
* Removes legacy schema form code.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- FixesL https://tree.taiga.io/project/rero21-reroils/task/1456?kanban-status=1224894

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* https://github.com/rero/ng-core/pull/187
* https://github.com/rero/rero-ils-ui/pull/277

## How to test?

- Go to the professionnal interface
  - the language menu should have the same behaviour than the public interface
  - test the editor with several resources, switch the language, the label, the description the placeholder and the validation should be translated.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
