### PR TITLE
documents: add public notes in document detail view 

### DIFF
--- a/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
+++ b/rero_ils/modules/documents/templates/rero_ils/_documents_get.html
@@ -126,10 +126,7 @@
         {% if record.harvested %}
           {% for elocation in holding.electronic_location %}
             <div class="row my-2">
-              <div class="col-1">
-                &nbsp;
-              </div>
-              <div class="col-10">
+              <div class="offset-1 col-10">
                 <a href="{{ elocation.uri }}" target="_blank">{{ _(elocation.source) }}</a>
               </div>
             </div>
@@ -139,10 +136,7 @@
         {% if number_items > 0 %}
         {% for item in items %}
         <div class="row my-2">
-          <div class="col-1">
-            &nbsp;
-          </div>
-          <div class="col-10">
+          <div class="offset-1 col-10">
             <div class="row">
               <div class="col-sm-4">
                 {{ item.barcode }}
@@ -180,6 +174,17 @@
             </div>
           </div>
         </div>
+        {% if item|get_note('public_note') %}
+        <div class="row">
+          <div class="offset-1 col-sm-1 text-right pr-2">
+            <i class="fa fa-level-up fa-rotate-90"></i>
+            <i class="fa fa-sticky-note-o text-warning pl-1"></i>
+          </div>
+          <div class="col">
+            {{ item|get_note('public_note') }}
+          </div>
+        </div>
+        {% endif %}
         {% endfor %}
         {% endif %}
       </div>

--- a/rero_ils/modules/documents/views.py
+++ b/rero_ils/modules/documents/views.py
@@ -208,6 +208,12 @@ def can_request(item):
 
 
 @blueprint.app_template_filter()
+def get_note(item, note_type):
+    """Get the public note corresponding to an item."""
+    return item.get_note(note_type)
+
+
+@blueprint.app_template_filter()
 def authors_format(pid, language, viewcode):
     """Format authors for template in given language."""
     doc = Document.get_record_by_pid(pid)

--- a/tests/ui/documents/test_documents_filter.py
+++ b/tests/ui/documents/test_documents_filter.py
@@ -19,8 +19,15 @@
 
 
 from rero_ils.modules.documents.api import Document
-from rero_ils.modules.documents.views import authors_format, \
+from rero_ils.modules.documents.views import authors_format, get_note, \
     identifiedby_format, language_format, series_format
+from rero_ils.modules.items.models import ItemNoteTypes
+
+
+def test_get_note(item_lib_martigny):
+    """Test get_note function."""
+    assert get_note(item_lib_martigny, ItemNoteTypes.STAFF) is not None
+    assert get_note(item_lib_martigny, ItemNoteTypes.CHECKIN) is None
 
 
 def test_authors_format(db, document_data):


### PR DESCRIPTION
If an item has an attached public note, it will be displayed in the
document detail view, just below the item detail row


## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/us/1351?milestone=266303

## How to test?

- Use the professional interface to add a public notes on an item.
- Go into the public interface on the related document detail view.
- See the public note under the item detail

![image](https://user-images.githubusercontent.com/10031585/83878877-12e40b00-a73d-11ea-9a47-4be2ba21b316.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
