### PR TITLE
cli: correct wrong process bulk queue

### DIFF
--- a/rero_ils/modules/acq_accounts/api.py
+++ b/rero_ils/modules/acq_accounts/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -126,3 +127,11 @@ class AcqAccountsIndexer(IlsRecordsIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = AcqAccount
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(AcqAccountsIndexer, self).bulk_index(record_id_iterator,
+                                                   doc_type='acac')

--- a/rero_ils/modules/acq_invoices/api.py
+++ b/rero_ils/modules/acq_invoices/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -147,6 +148,14 @@ class AcquisitionInvoicesIndexer(IlsRecordsIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = AcquisitionInvoice
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(AcquisitionInvoicesIndexer, self).bulk_index(record_id_iterator,
+                                                           doc_type='acin')
 
 
 class InvoiceLine(object):

--- a/rero_ils/modules/acq_order_lines/api.py
+++ b/rero_ils/modules/acq_order_lines/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -161,3 +162,11 @@ class AcqOrderLinesIndexer(IlsRecordsIndexer):
         order = AcqOrder.get_record_by_pid(order_pid)
         order['total_amount'] = order.get_order_total_amount()
         order.update(order, dbcommit=True, reindex=True)
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(AcqOrderLinesIndexer, self).bulk_index(record_id_iterator,
+                                                     doc_type='acol')

--- a/rero_ils/modules/acq_orders/api.py
+++ b/rero_ils/modules/acq_orders/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -139,3 +140,11 @@ class AcqOrdersIndexer(IlsRecordsIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = AcqOrder
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(AcqOrdersIndexer, self).bulk_index(record_id_iterator,
+                                                 doc_type='acor')

--- a/rero_ils/modules/budgets/api.py
+++ b/rero_ils/modules/budgets/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -100,3 +101,11 @@ class BudgetsIndexer(IlsRecordsIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = Budget
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(BudgetsIndexer, self).bulk_index(record_id_iterator,
+                                               doc_type='budg')

--- a/rero_ils/modules/circ_policies/api.py
+++ b/rero_ils/modules/circ_policies/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -281,3 +282,11 @@ class CircPoliciesIndexer(IlsRecordsIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = CircPolicy
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(CircPoliciesIndexer, self).bulk_index(record_id_iterator,
+                                                    doc_type='cipo')

--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -234,3 +235,11 @@ class DocumentsIndexer(IlsRecordsIndexer):
         return_value = super(DocumentsIndexer, self).index(record)
         record.index_persons()
         return return_value
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(DocumentsIndexer, self).bulk_index(record_id_iterator,
+                                                 doc_type='doc')

--- a/rero_ils/modules/holdings/api.py
+++ b/rero_ils/modules/holdings/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -469,3 +470,11 @@ class HoldingsIndexer(IlsRecordsIndexer):
         return_value = super(HoldingsIndexer, self).index(record)
         # current_search.flush_and_refresh(HoldingsSearch.Meta.index)
         return return_value
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(HoldingsIndexer, self).bulk_index(record_id_iterator,
+                                                doc_type='hold')

--- a/rero_ils/modules/item_types/api.py
+++ b/rero_ils/modules/item_types/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -162,3 +163,11 @@ class ItemTypesIndexer(IlsRecordsIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = ItemType
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(ItemTypesIndexer, self).bulk_index(record_id_iterator,
+                                                 doc_type='itty')

--- a/rero_ils/modules/items/api/api.py
+++ b/rero_ils/modules/items/api/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -169,3 +170,11 @@ class ItemsIndexer(IlsRecordsIndexer):
                 pass
 
         return return_value
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(ItemsIndexer, self).bulk_index(record_id_iterator,
+                                             doc_type='item')

--- a/rero_ils/modules/libraries/api.py
+++ b/rero_ils/modules/libraries/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -325,3 +326,11 @@ class LibrariesIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Library
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(LibrariesIndexer, self).bulk_index(record_id_iterator,
+                                                 doc_type='lib')

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -399,3 +400,11 @@ class LoansIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Loan
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(LoansIndexer, self).bulk_index(record_id_iterator,
+                                             doc_type='loan')

--- a/rero_ils/modules/locations/api.py
+++ b/rero_ils/modules/locations/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -167,3 +168,11 @@ class LocationsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Location
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(LocationsIndexer, self).bulk_index(record_id_iterator,
+                                                 doc_type='loc')

--- a/rero_ils/modules/notifications/api.py
+++ b/rero_ils/modules/notifications/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -333,6 +334,14 @@ class NotificationsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Notification
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(NotificationsIndexer, self).bulk_index(record_id_iterator,
+                                                     doc_type='notif')
 
 
 def get_availability_notification(loan):

--- a/rero_ils/modules/organisations/api.py
+++ b/rero_ils/modules/organisations/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -155,3 +156,11 @@ class OrganisationsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Organisation
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(OrganisationsIndexer, self).bulk_index(record_id_iterator,
+                                                     doc_type='org')

--- a/rero_ils/modules/patron_transaction_events/api.py
+++ b/rero_ils/modules/patron_transaction_events/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -177,3 +178,12 @@ class PatronTransactionEventsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = PatronTransactionEvent
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(PatronTransactionEventsIndexer, self).bulk_index(
+            record_id_iterator,
+            doc_type='ptre')

--- a/rero_ils/modules/patron_transactions/api.py
+++ b/rero_ils/modules/patron_transactions/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -295,3 +296,11 @@ class PatronTransactionsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = PatronTransaction
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(PatronTransactionsIndexer, self).bulk_index(record_id_iterator,
+                                                          doc_type='pttr')

--- a/rero_ils/modules/patron_types/api.py
+++ b/rero_ils/modules/patron_types/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -153,3 +154,11 @@ class PatronTypesIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = PatronType
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(PatronTypesIndexer, self).bulk_index(record_id_iterator,
+                                                   doc_type='ptty')

--- a/rero_ils/modules/patrons/api.py
+++ b/rero_ils/modules/patrons/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -514,3 +515,11 @@ class PatronsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Patron
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(PatronsIndexer, self).bulk_index(record_id_iterator,
+                                               doc_type='ptrn')

--- a/rero_ils/modules/persons/api.py
+++ b/rero_ils/modules/persons/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -226,3 +227,11 @@ class PersonsIndexer(IlsRecordsIndexer):
     """Person indexing class."""
 
     record_cls = Person
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(PersonsIndexer, self).bulk_index(record_id_iterator,
+                                               doc_type='pers')

--- a/rero_ils/modules/tasks.py
+++ b/rero_ils/modules/tasks.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -23,16 +24,20 @@ from .api import IlsRecordsIndexer
 
 
 @shared_task(ignore_result=True)
-def process_bulk_queue(version_type=None, es_bulk_kwargs=None):
+def process_bulk_queue(version_type=None, es_bulk_kwargs=None,
+                       stats_only=True):
     """Process bulk indexing queue.
 
     :param str version_type: Elasticsearch version type.
     :param dict es_bulk_kwargs: Passed to
         :func:`elasticsearch:elasticsearch.helpers.bulk`.
+    :param boolean stats_only: if `True` only report number of
+            successful/failed operations instead of just number of
+            successful and a list of error responses.
     Note: You can start multiple versions of this task.
     """
-    IlsRecordsIndexer(version_type=version_type).process_bulk_queue(
-        es_bulk_kwargs=es_bulk_kwargs)
+    return IlsRecordsIndexer(version_type=version_type).process_bulk_queue(
+        es_bulk_kwargs=es_bulk_kwargs, stats_only=stats_only)
 
 
 @shared_task(ignore_result=True)

--- a/rero_ils/modules/vendors/api.py
+++ b/rero_ils/modules/vendors/api.py
@@ -2,6 +2,7 @@
 #
 # RERO ILS
 # Copyright (C) 2019 RERO
+# Copyright (C) 2020 UCLouvain
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -97,3 +98,11 @@ class VendorsIndexer(IlsRecordsIndexer):
     """Holdings indexing class."""
 
     record_cls = Vendor
+
+    def bulk_index(self, record_id_iterator):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        """
+        super(VendorsIndexer, self).bulk_index(record_id_iterator,
+                                               doc_type='vndr')


### PR DESCRIPTION
* Fixes CLI to use the correct process bulk indexing task.
* Improves IlsRecordsIndexer class to support `stats_only` option when processing bulk queue.
* Improves CLI tu support `with-stats` option on `runindex` command.
* Updates all Indexer class to use typed bulk indexing.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

When we start delayed bulk indexing, celery task use default invenio-indexer process bulk queue.
We need to use IlsRecordindexer class to process bulk indexing queue.

## How to test?

reindex resource persons using task:

- `poetry run invenio utils reindex -t pers --yes-i-know`
- `poetry run invenio utils runindex -d -c 2`

The MEF persons must be filtered by organisation on each view.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
