### PR TITLE
authorization: create role management API

### DIFF
--- a/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
+++ b/rero_ils/modules/patrons/jsonschemas/patrons/patron-v0.0.1.json
@@ -189,7 +189,8 @@
         "hideExpression": "!field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))",
         "expressionProperties": {
           "templateOptions.required": "field.parent.model.roles.some(v => (v === 'librarian' || v === 'system_librarian'))"
-        }
+        },
+        "fieldMap": "library"
       }
     },
     "roles": {
@@ -225,6 +226,9 @@
             }
           ]
         }
+      },
+      "form": {
+        "fieldMap": "roles"
       }
     },
     "communication_channel": {

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -32,6 +32,7 @@ from invenio_i18n.ext import current_i18n
 from werkzeug.exceptions import NotFound
 
 from .api import Patron, PatronsSearch
+from .permissions import get_allowed_roles_management
 from .utils import user_has_patron
 from ..items.api import Item
 from ..libraries.api import Library
@@ -213,6 +214,15 @@ def profile(viewcode):
         viewcode=viewcode,
         tab=tab
     )
+
+
+@api_blueprint.route('/roles_management_permissions', methods=['GET'])
+@check_permission
+def get_roles_management_permissions():
+    """Get the roles that current logged user could manage."""
+    return jsonify({
+        'allowed_roles': get_allowed_roles_management()
+    })
 
 
 @blueprint.app_template_filter('get_patron_from_barcode')

--- a/tests/api/test_patrons_rest.py
+++ b/tests/api/test_patrons_rest.py
@@ -356,10 +356,9 @@ def test_patron_secure_api(client, json_header,
     # assert res.status_code == 403
 
 
-def test_patron_secure_api_create(client, json_header,
+def test_patron_secure_api_create(client,
                                   patron_martigny_data,
-                                  librarian_martigny_no_email,
-                                  librarian_sion_no_email):
+                                  librarian_martigny_no_email):
     """Test patron secure api create."""
     # Martigny
     login_user_via_session(client, librarian_martigny_no_email.user)
@@ -426,6 +425,12 @@ def test_patron_secure_api_delete(client, json_header,
 
     res = client.delete(record_url)
     assert res.status_code == 204
+
+    # try to delete itself
+    record_url = url_for('invenio_records_rest.ptrn_item',
+                         pid_value=librarian_martigny_no_email.pid)
+    res = client.delete(record_url)
+    assert res.status_code == 403
 
     # Sion
     # login_user_via_session(client, librarian_sion_no_email.user)

--- a/tests/api/test_permissions_librarian.py
+++ b/tests/api/test_permissions_librarian.py
@@ -70,6 +70,14 @@ def test_librarian_permissions(
     data = get_json(res)
     assert data['hits']['total'] == 3
 
+    # can manage all types of patron roles
+    role_url = url_for('api_patrons.get_roles_management_permissions')
+    res = client.get(role_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'librarian' in data['allowed_roles']
+    assert 'system_librarian' not in data['allowed_roles']
+
     # can create all type of users except system_librarians
     post_entrypoint = 'invenio_records_rest.ptrn_list'
     system_librarian = deepcopy(record)

--- a/tests/api/test_permissions_patron.py
+++ b/tests/api/test_permissions_patron.py
@@ -50,6 +50,11 @@ def test_patron_permissions(
     res = client.get(list_url)
     assert res.status_code == 403
 
+    # can not manage any types of patron roles
+    role_url = url_for('api_patrons.get_roles_management_permissions')
+    res = client.get(role_url)
+    assert res.status_code == 403
+
     # can not create any type of users.
     system_librarian = deepcopy(record)
     librarian = deepcopy(record)

--- a/tests/api/test_permissions_sys_librarian.py
+++ b/tests/api/test_permissions_sys_librarian.py
@@ -52,6 +52,13 @@ def test_system_librarian_permissions(
     data = get_json(res)
     assert data['hits']['total'] == 3
 
+    # can manage all types of patron roles
+    role_url = url_for('api_patrons.get_roles_management_permissions')
+    res = client.get(role_url)
+    assert res.status_code == 200
+    data = get_json(res)
+    assert 'system_librarian' in data['allowed_roles']
+
     # can create all type of users.
     system_librarian = deepcopy(record)
     librarian = deepcopy(record)

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -92,10 +92,11 @@ def test_patrons_permissions(
     librarian2_martigny_no_email,
     librarian_saxon_no_email,
     system_librarian_martigny_no_email,
+    system_librarian2_martigny_no_email,
     system_librarian_sion_no_email,
     librarian_sion_no_email
 ):
-    """Test serializers for patrons."""
+    """Test permissions for patrons."""
 
     # simple librarian -----------------------------------------------
     login_user(client, librarian_martigny_no_email)
@@ -130,8 +131,9 @@ def test_patrons_permissions(
     assert data['update']['can']
 
     # should update and delete a system librarian of the same organisation
+    # but not itself
     data = call_api_permissions(client, 'patrons',
-                                system_librarian_martigny_no_email.pid)
+                                system_librarian2_martigny_no_email.pid)
     assert data['delete']['can']
     assert data['update']['can']
 

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -2340,6 +2340,26 @@
     "blocked": true,
     "blocked_note": "Lost card"
   },
+  "ptrn12": {
+    "$schema": "https://ils.rero.ch/schemas/patrons/patron-v0.0.1.json",
+    "pid": "ptrn12",
+    "first_name": "Joella",
+    "last_name": "Dosimonta",
+    "street": "Grand place, 123",
+    "postal_code": "1920",
+    "city": "Martigny",
+    "birth_date": "1980-06-07",
+    "library": {
+      "$ref": "https://ils.rero.ch/api/libraries/lib1"
+    },
+    "email": "joellalibri07@gmail.com",
+    "phone": "+32324993585",
+    "roles": [
+      "system_librarian",
+      "librarian"
+    ],
+    "barcode": "sys_ptrn12"
+  },
   "dummy_notif": {
     "$schema": "https://ils.rero.ch/schemas/notifications/notification-v0.0.1.json",
     "pid": "notif1",

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -89,6 +89,51 @@ def system_librarian_martigny_no_email(
     return ptrn
 
 
+@pytest.fixture(scope="module")
+def system_librarian2_martigny_data(data):
+    """Load Martigny system librarian data."""
+    return deepcopy(data.get('ptrn12'))
+
+
+@pytest.fixture(scope="function")
+def system_librarian2_martigny_data_tmp(data):
+    """Load Martigny system librarian data scope function."""
+    return deepcopy(data.get('ptrn12'))
+
+
+@pytest.fixture(scope="module")
+def system_librarian2_martigny(
+        app,
+        roles,
+        lib_martigny,
+        system_librarian2_martigny_data):
+    """Create Martigny system librarian record."""
+    ptrn = Patron.create(
+        data=system_librarian2_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn
+
+
+@pytest.fixture(scope="module")
+@mock.patch('rero_ils.modules.patrons.api.send_reset_password_instructions')
+def system_librarian2_martigny_no_email(
+        app,
+        roles,
+        lib_martigny,
+        system_librarian2_martigny_data):
+    """Create Martigny system librarian without sending reset password."""
+    ptrn = Patron.create(
+        data=system_librarian2_martigny_data,
+        delete_pid=False,
+        dbcommit=True,
+        reindex=True)
+    flush_index(PatronsSearch.Meta.index)
+    return ptrn
+
+
 # ------------ Org: Martigny, Lib: Martigny, Librarian 1 ----------
 @pytest.fixture(scope="module")
 def librarian_martigny_data(data):

--- a/tests/ui/patrons/test_patrons_api.py
+++ b/tests/ui/patrons/test_patrons_api.py
@@ -175,3 +175,30 @@ def test_get_patron_blocked_field_absent(patron2_martigny_no_email):
     """Test patron blocked field retrieval."""
     patron = Patron.get_patron_by_email(patron2_martigny_no_email.get('email'))
     assert 'blocked' not in patron
+
+
+def test_get_reachable_roles():
+    """Test get roles covered by the given role."""
+    roles = Patron.get_reachable_roles(Patron.ROLE_SYSTEM_LIBRARIAN)
+    assert len(roles) == 2
+    assert Patron.ROLE_LIBRARIAN in roles
+    assert Patron.ROLE_SYSTEM_LIBRARIAN in roles
+
+    roles = Patron.get_reachable_roles('unknown_role')
+    assert not roles
+
+
+def test_get_all_roles_for_role():
+    """Test get roles covering by roles hierarchy."""
+    roles = Patron.get_all_roles_for_role(Patron.ROLE_PATRON)
+    assert len(roles) == 1
+    assert Patron.ROLE_PATRON in roles
+
+    roles = Patron.get_all_roles_for_role(Patron.ROLE_SYSTEM_LIBRARIAN)
+    assert len(roles) == 1
+    assert Patron.ROLE_SYSTEM_LIBRARIAN in roles
+
+    roles = Patron.get_all_roles_for_role(Patron.ROLE_LIBRARIAN)
+    assert len(roles) == 2
+    assert Patron.ROLE_LIBRARIAN in roles
+    assert Patron.ROLE_SYSTEM_LIBRARIAN in roles


### PR DESCRIPTION
Creates an API to expose which roles could be managed by the current
logged user.
This commit also introduces a restriction to disallow the current user
to delete itself.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/task/1523?kanban-status=1224894

## Dependencies

* rero/rero-ils-ui#<xx>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
