### PR TITLE
circulation: implement cancel item request action

### DIFF
--- a/doc/circulation/actions.md
+++ b/doc/circulation/actions.md
@@ -110,26 +110,38 @@
 
 ## Cancel request
 
-1. __CANCEL_REQUEST_1__: item on_shelf (no current loan)
-	1. __CANCEL_REQUEST_1_1__: PENDING loan does not exist →  (cancel not possible)
-	1. __CANCEL_REQUEST_1_2__: PENDING loan exists →  (cancel loan, item is: on_shelf)
-1. __CANCEL_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK)
-	1. __CANCEL_REQUEST_2_1__: loan to cancel = current loan →  (cancel denied) *Future: make it possible and give an alert to the library that the item should not stayed at desk*
-	1. __CANCEL_REQUEST_2_2__: loan to cancel != current loan →  (cancel loan, item is: at desk)
-1. __CANCEL_REQUEST_3__: item on_loan (ITEM_ON_LOAN)
-	1. __CANCEL_REQUEST_3_1__: loan to cancel = current loan →  (cancel not possible)
-	1. __CANCEL_REQUEST_3_2__: loan to cancel != current loan →  (cancel loan, item is: on_loan (ITEM_ON_LOAN))
-1. __CANCEL_REQUEST_4__: item in_transit (IN_TRANSIT_FOR_PICKUP)
-	1. loan to cancel = current loan
-		1. __CANCEL_REQUEST_4_1_1__: PENDING loan does not exist →  (cancel loan?, item is: in_transit (IN_TRANSIT_TO_HOUSE)) *[FIND A SOLUTION]*
-		1. __CANCEL_REQUEST_4_1_2__: PENDING loan exists →  (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
-	1. __CANCEL_REQUEST_4_2__: loan to cancel != current loan →  (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))
-1. __CANCEL_REQUEST_5__: item in_transit (IN_TRANSIT_TO_HOUSE)
-	1. :white_check_mark: __CANCEL_REQUEST_5_1__: loan to cancel = current loan →  (cancel loan, item is: in_transit (IN_TRANSIT_TO_HOUSE))
-	1. loan to cancel = 1st pending loan
-        1. __CANCEL_REQUEST_5_2_1__: pickup location of 2nd pending loan = item library →  (cancel loan, item is: in_transit (IN_TRANSIT_TO_HOUSE))
-        1. __CANCEL_REQUEST_5_2_2__: pickup location of 2nd pending loan != item library →  (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate 2nd pending loan]
-    1. __CANCEL_REQUEST_5_3__: loan to cancel != (current loan OR 1rst pending loan) →  (cancel loan)
+
+1. :100: __CANCEL_REQUEST_1__: item on_shelf (no current loan)
+	1. __CANCEL_REQUEST_1_1__: PENDING loan does not exist → (cancel not possible)
+	1. __CANCEL_REQUEST_1_2__: PENDING loan exists → (cancel loan, item is: on_shelf)
+
+1. :100: __CANCEL_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK)
+	1. __CANCEL_REQUEST_2_1__: loan to cancel = current loan
+		1. __CANCEL_REQUEST_2_1_1__: PENDING loan does not exist Make it impossible to cancel loan from public interface. Future: make it possible and give an alert to the library that the item should not stayed at desk
+			1. __CANCEL_REQUEST_2_1_1_1__: item library != pickup location of current loan → (update loan to IN_TRANSIT_TO_HOUSE, item is: in_transit)
+			1. __CANCEL_REQUEST_2_1_1_2__: item library = pickup location of current loan → (cancel loan, item is: on_shelf)
+		1. __CANCEL_REQUEST_2_1_2__: PENDING loan exists
+			1. __CANCEL_REQUEST_2_1_2_1__: pickup location of 1st pending loan != pickup location of current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
+			1. __CANCEL_REQUEST_2_1_2_2__: pickup location of 1st pending loan = pickup location of current loan → (cancel loan, item is: at_desk (ITEM_AT_DESK))[automatic validate next PENDING loan]
+	1. __CANCEL_REQUEST_2_2__: loan to cancel != current loan → (cancel loan, item is: at desk)
+
+1. :100: __CANCEL_REQUEST_3__: item on_loan (ITEM_ON_LOAN)
+	1. __CANCEL_REQUEST_3_1__: loan to cancel = current loan → (cancel not possible)
+	1. __CANCEL_REQUEST_3_2__: loan to cancel != current loan → (cancel loan, item is: on_loan (ITEM_ON_LOAN))
+
+1. :100: __CANCEL_REQUEST_4__: item in_transit (IN_TRANSIT_FOR_PICKUP)
+	1. __CANCEL_REQUEST_4_1__: loan to cancel = current loan
+		1. __CANCEL_REQUEST_4_1_1__: PENDING loan does not exist → (update loan, item is: in_transit (IN_TRANSIT_TO_HOUSE))
+		1. __CANCEL_REQUEST_4_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate logic is applied next PENDING loan] 
+		
+	1. __CANCEL_REQUEST_4_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))
+
+1. :100: __CANCEL_REQUEST_5__: item in_transit (IN_TRANSIT_TO_HOUSE)
+	1. __CANCEL_REQUEST_5_1__: loan to cancel = current loan
+		1. __CANCEL_REQUEST_5_1_1__: PENDING loan does not exist → (checkin the IN_TRANSIT_TO_HOUSE loan, item will  go on shelf  and the loan is cancelled).
+		1. __CANCEL_REQUEST_5_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
+	1. __CANCEL_REQUEST_5_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_TO_HOUSE)) This use case should in principle never happen.
+
 
 ## Change request pickup location
 

--- a/rero_ils/modules/items/api/circulation.py
+++ b/rero_ils/modules/items/api/circulation.py
@@ -441,6 +441,110 @@ class ItemCirculation(IlsRecord):
             LoanAction.CANCEL: loan
         }
 
+    def cancel_item_request(self, pid, **kwargs):
+        """A smart cancel request for an item. Some actions are performed.
+
+        during the cancelling process and according to the loan state.
+        :param pid: the loan pid for the request to cancel.
+        :return: the item record and list of actions performed.
+        """
+        actions = {}
+        loan = Loan.get_record_by_pid(pid)
+        # decide  which actions need to be executed according to loan state.
+        actions_to_execute = self.checks_before_a_cancel_item_request(
+            loan, **kwargs)
+        # execute the actions
+        if actions_to_execute.get('cancel_loan'):
+            item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
+        elif actions_to_execute.get('loan_update', {}).get('state'):
+            loan['state'] = actions_to_execute['loan_update']['state']
+            loan.update(loan, dbcommit=True, reindex=True)
+            self.status_update(dbcommit=True, reindex=True, forceindex=True)
+            actions.update({LoanAction.UPDATE: loan})
+            item = self
+        elif actions_to_execute.get('validate_first_pending'):
+            pending = self.get_first_loan_by_state(state=LoanState.PENDING)
+            item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
+            item, validate_actions = self.validate_request(
+                pid=pending.pid, **kwargs)
+            actions.update({LoanAction.VALIDATE: validate_actions})
+
+        return item, actions
+
+    def checks_before_a_cancel_item_request(self, loan, **kwargs):
+        """Actions tobe executed before a cancel item request.
+
+        :param loan : the current loan to cancel
+        :param kwargs : all others named arguments
+        :return:  the item record and list of actions performed
+        """
+        actions_to_execute = {
+            'cancel_loan': False,
+            'loan_update': {},
+            'validate_first_pending': False
+
+        }
+        libraries = self.compare_item_pickup_transaction_libraries(**kwargs)
+        # List all loan states attached to this item except the loan to cancel.
+        loans_list = self.get_loans_states_by_item_pid_exclude_loan_pid(
+            self.pid, loan.pid)
+        if not loans_list:
+            if loan['state'] in \
+                    [LoanState.PENDING, LoanState.ITEM_IN_TRANSIT_TO_HOUSE]:
+                # CANCEL_REQUEST_1_2, CANCEL_REQUEST_5_1_1:
+                # cancel the current loan is the only action
+                actions_to_execute['cancel_loan'] = True
+                # item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
+            elif loan['state'] == LoanState.ITEM_ON_LOAN:
+                # CANCEL_REQUEST_3_1: no cancel action is possible on the loan
+                # of a checked-in item.
+                raise NoCirculationAction(
+                    'No circulation action is possible')
+            elif loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP:
+                # CANCEL_REQUEST_4_1_1: cancelling a ITEM_IN_TRANSIT_FOR_PICKUP
+                # loan with no pending request puts the item on in_transit
+                # and the loan becomes ITEM_IN_TRANSIT_TO_HOUSE.
+                actions_to_execute['loan_update']['state'] = \
+                    LoanState.ITEM_IN_TRANSIT_TO_HOUSE
+            elif loan['state'] == LoanState.ITEM_AT_DESK:
+                if not libraries['item_pickup_libraries']:
+                    # CANCEL_REQUEST_2_1_1_1: when item library and pickup
+                    # pickup library arent equal, update loan to go in_transit.
+                    actions_to_execute['loan_update']['state'] = \
+                        LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+                elif libraries['item_pickup_libraries']:
+                    # CANCEL_REQUEST_2_1_1_2: when item library and pickup
+                    # pickup library are equal, cancel loan to go on_shelf.
+                    # item, actions = self.cancel_loan(pid=loan.pid, **kwargs)
+                    actions_to_execute['cancel_loan'] = True
+        elif loan['state'] == LoanState.ITEM_AT_DESK and \
+                LoanState.PENDING in loans_list:
+            # CANCEL_REQUEST_2_1_2: when item at desk with pending loan, cancel
+            # the loan triggers an automatic validation of first pending loan.
+            actions_to_execute['validate_first_pending'] = True
+        elif loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP and \
+                LoanState.PENDING in loans_list:
+            # CANCEL_REQUEST_4_1_2: when item in_transit with pending loan,
+            # cancel the loan triggers an automatic validation of 1st loan.
+            actions_to_execute['validate_first_pending'] = True
+        elif loan['state'] == LoanState.ITEM_IN_TRANSIT_TO_HOUSE and \
+                LoanState.PENDING in loans_list:
+            # CANCEL_REQUEST_5_1_2: when item at desk with pending loan, cancel
+            # the loan triggers an automatic validation of first pending loan.
+            actions_to_execute['validate_first_pending'] = True
+        elif loan['state'] == LoanState.PENDING and (
+            LoanState.ITEM_AT_DESK in loans_list or
+            LoanState.ITEM_ON_LOAN in loans_list or
+            LoanState.ITEM_IN_TRANSIT_FOR_PICKUP in loans_list or
+            LoanState.ITEM_IN_TRANSIT_TO_HOUSE in loans_list
+        ):
+            # CANCEL_REQUEST_2_2, CANCEL_REQUEST_3_2, CANCEL_REQUEST_4_2,
+            # CANCEL_REQUEST_5_2:
+            # canceling a pending loan does not affect the other active loans.
+            actions_to_execute['cancel_loan'] = True
+
+        return actions_to_execute
+
     @add_loans_parameters_and_flush_indexes
     def validate_request(self, current_loan, **kwargs):
         """Validate item request."""

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -69,6 +69,7 @@ class LoanAction(object):
     CANCEL = 'cancel'
     LOSE = 'lose'
     NO = 'no'
+    UPDATE = 'update'
 
 
 class LoansSearch(IlsRecordsSearch):

--- a/tests/fixtures/circulation.py
+++ b/tests/fixtures/circulation.py
@@ -934,6 +934,106 @@ def item_at_desk_martigny_patron_and_loan_at_desk(
 
 
 @pytest.fixture(scope="module")
+def item2_at_desk_martigny_patron_and_loan_at_desk(
+        app,
+        librarian_martigny_no_email,
+        item_lib_martigny, loc_public_martigny,
+        patron_martigny_no_email, circulation_policies):
+    """Creates an item with a validated pending request.
+
+    :return item: the created or copied item.
+    :return patron: the patron placed the request.
+    :return loan: the validated pending loan.
+    """
+    params = {
+        'patron_pid': patron_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, loan = item_record_to_a_specific_loan_state(
+        item=item_lib_martigny,
+        loan_state=LoanState.ITEM_AT_DESK,
+        params=params, copy_item=True)
+    return item, patron_martigny_no_email, loan
+
+
+@pytest.fixture(scope="module")
+def item3_at_desk_martigny_patron_and_loan_at_desk(
+        app,
+        librarian_martigny_no_email,
+        item_lib_martigny, loc_public_martigny,
+        patron_martigny_no_email, circulation_policies):
+    """Creates an item with a validated pending request.
+
+    :return item: the created or copied item.
+    :return patron: the patron placed the request.
+    :return loan: the validated pending loan.
+    """
+    params = {
+        'patron_pid': patron_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, loan = item_record_to_a_specific_loan_state(
+        item=item_lib_martigny,
+        loan_state=LoanState.ITEM_AT_DESK,
+        params=params, copy_item=True)
+    return item, patron_martigny_no_email, loan
+
+
+@pytest.fixture(scope="module")
+def item4_at_desk_martigny_patron_and_loan_at_desk(
+        app,
+        librarian_martigny_no_email,
+        item_lib_martigny, loc_public_martigny,
+        patron_martigny_no_email, circulation_policies):
+    """Creates an item with a validated pending request.
+
+    :return item: the created or copied item.
+    :return patron: the patron placed the request.
+    :return loan: the validated pending loan.
+    """
+    params = {
+        'patron_pid': patron_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, loan = item_record_to_a_specific_loan_state(
+        item=item_lib_martigny,
+        loan_state=LoanState.ITEM_AT_DESK,
+        params=params, copy_item=True)
+    return item, patron_martigny_no_email, loan
+
+
+@pytest.fixture(scope="module")
+def item5_at_desk_martigny_patron_and_loan_at_desk(
+        app,
+        librarian_martigny_no_email,
+        item_lib_martigny, loc_public_martigny,
+        patron_martigny_no_email, circulation_policies):
+    """Creates an item with a validated pending request.
+
+    :return item: the created or copied item.
+    :return patron: the patron placed the request.
+    :return loan: the validated pending loan.
+    """
+    params = {
+        'patron_pid': patron_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, loan = item_record_to_a_specific_loan_state(
+        item=item_lib_martigny,
+        loan_state=LoanState.ITEM_AT_DESK,
+        params=params, copy_item=True)
+    return item, patron_martigny_no_email, loan
+
+
+@pytest.fixture(scope="module")
 def item_on_shelf_fully_patron_and_loan_pending(
         app,
         librarian_martigny_no_email,
@@ -1135,6 +1235,31 @@ def item_in_transit_martigny_patron_and_loan_for_pickup(
 
 @pytest.fixture(scope="module")
 def item2_in_transit_martigny_patron_and_loan_for_pickup(
+        app,
+        librarian_martigny_no_email, loc_public_fully,
+        item_lib_martigny, loc_public_martigny,
+        patron_martigny_no_email, circulation_policies):
+    """Creates an item in_transit for pickup.
+
+    :return item: the created or copied item.
+    :return patron: the patron requested the item.
+    :return loan: the ITEM_IN_TRANSIT_FOR_PICKUP loan.
+    """
+    params = {
+        'patron_pid': patron_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_fully.pid
+    }
+    item, loan = item_record_to_a_specific_loan_state(
+        item=item_lib_martigny,
+        loan_state=LoanState.ITEM_IN_TRANSIT_FOR_PICKUP,
+        params=params, copy_item=True)
+    return item, patron_martigny_no_email, loan
+
+
+@pytest.fixture(scope="module")
+def item3_in_transit_martigny_patron_and_loan_for_pickup(
         app,
         librarian_martigny_no_email, loc_public_fully,
         item_lib_martigny, loc_public_martigny,

--- a/tests/ui/circulation/test_actions_cancel_request.py
+++ b/tests/ui/circulation/test_actions_cancel_request.py
@@ -1,0 +1,441 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test item circulation cancel request actions."""
+
+
+import pytest
+from invenio_circulation.errors import MissingRequiredParameterError, \
+    RecordCannotBeRequestedError
+from utils import item_record_to_a_specific_loan_state
+
+from rero_ils.modules.errors import NoCirculationAction
+from rero_ils.modules.items.api import Item
+from rero_ils.modules.items.models import ItemStatus
+from rero_ils.modules.loans.api import Loan, LoanState
+
+
+def test_cancel_request_on_item_on_shelf(
+        item_lib_martigny, item_on_shelf_martigny_patron_and_loan_pending,
+        loc_public_martigny, librarian_martigny_no_email):
+    """Test cancel request on an on_shelf item."""
+    # the following tests the circulation action CANCEL_REQUEST_1_1
+    # on_shelf item with no pending requests, not possible to cancel a request.
+    # a loan pid is a required parameter and not given
+    with pytest.raises(TypeError):
+        item_lib_martigny.cancel_item_request()
+    assert item_lib_martigny.status == ItemStatus.ON_SHELF
+
+    # the following tests the circulation action CANCEL_REQUEST_1_2
+    # on_shelf item with pending requests, cancel a pending loan is possible.
+    # the item remains on_shelf
+    item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.ON_SHELF
+    assert loan['state'] == LoanState.CANCELLED
+
+
+def test_cancel_request_on_item_at_desk_no_requests_externally(
+        client, item_at_desk_martigny_patron_and_loan_at_desk,
+        loc_public_martigny, librarian_martigny_no_email,
+        loc_public_fully):
+    """Test cancel requests on an at_desk item externally."""
+    item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
+    # the following tests the circulation action CANCEL_REQUEST_2_1_1_1
+    # an item at_desk with no other pending loans.
+    # if the item library != pickup location, update the at_desk loan.
+    # loan ITEM_IN_TRANSIT_FOR_PICKUP and item is: in_transit
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_fully.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+
+
+def test_cancel_request_on_item_at_desk_no_requests_at_home(
+        client, item2_at_desk_martigny_patron_and_loan_at_desk,
+        loc_public_martigny, librarian_martigny_no_email):
+    """Test cancel requests on an at_desk item at home."""
+    item, patron, loan = item2_at_desk_martigny_patron_and_loan_at_desk
+    # the following tests the circulation action CANCEL_REQUEST_2_1_1_2
+    # an item at_desk with no other pending loans.
+    # if the item library = pickup location, cancels the
+    # loan and item is: on_shelf
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.ON_SHELF
+    assert loan['state'] == LoanState.CANCELLED
+
+
+def test_cancel_request_on_item_at_desk_with_requests_externally(
+        client, item3_at_desk_martigny_patron_and_loan_at_desk,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email, loc_public_fully):
+    """Test cancel requests on an at_desk item with requests at externally."""
+    item, patron, loan = item3_at_desk_martigny_patron_and_loan_at_desk
+    # the following tests the circulation action CANCEL_REQUEST_2_1_2_1
+    # an item at_desk with other pending loans.
+    # pickup location of 1st pending loan != pickup location of current loan
+    # cancel the current loan and item is: in_transit, automatic validation of
+    # firt pending loan
+
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_fully.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_fully.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert loan['state'] == LoanState.CANCELLED
+    assert requested_loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+
+
+def test_cancel_request_on_item_at_desk_with_requests_at_home(
+        client, item4_at_desk_martigny_patron_and_loan_at_desk,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel requests on an at_desk item with requests at home."""
+    item, patron, loan = item4_at_desk_martigny_patron_and_loan_at_desk
+    # the following tests the circulation action CANCEL_REQUEST_2_1_2_2
+    # an item at_desk with other pending loans.
+    # pickup location of 1st pending loan = pickup location of current loan
+    # cancel the current loan and item is: at_desk, automatic validation of
+    # firt pending loan
+
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.AT_DESK
+    assert loan['state'] == LoanState.CANCELLED
+    assert requested_loan['state'] == LoanState.ITEM_AT_DESK
+
+
+def test_cancel_pending_request_on_item_at_desk(
+        client, item5_at_desk_martigny_patron_and_loan_at_desk,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel requests on an at_desk item with requests at home."""
+    item, patron, loan = item5_at_desk_martigny_patron_and_loan_at_desk
+    # the following tests the circulation action CANCEL_REQUEST_2_2
+    # an item at_desk with other pending loans. when a librarian wants to
+    # cancel one of the pending loans. the item remains at_desk
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': requested_loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.AT_DESK
+    assert requested_loan['state'] == LoanState.CANCELLED
+    assert loan['state'] == LoanState.ITEM_AT_DESK
+
+
+def test_cancel_item_request_on_item_on_loan(
+        client, item_on_loan_martigny_patron_and_loan_on_loan,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel requests on an on_loan item."""
+    item, patron, loan = item_on_loan_martigny_patron_and_loan_on_loan
+    # the following tests the circulation action CANCEL_REQUEST_3_1
+    # an item on_loan with no other pending loans. when a librarian wants to
+    # cancel the on_loan loan. action is not permitted and item remain on_loan.
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    with pytest.raises(NoCirculationAction):
+        item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.ON_LOAN
+    assert loan['state'] == LoanState.ITEM_ON_LOAN
+
+    # the following tests the circulation action CANCEL_REQUEST_3_2
+    # an item on_loan with other pending loans. when a librarian wants to
+    # cancel the pending loan. action is permitted and item remains on_loan.
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': requested_loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.ON_LOAN
+    assert loan['state'] == LoanState.ITEM_ON_LOAN
+    assert requested_loan['state'] == LoanState.CANCELLED
+
+
+def test_cancel_item_request_on_item_in_transit_for_pickup(
+        client, item_in_transit_martigny_patron_and_loan_for_pickup,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel requests on an in_transit for pickup item."""
+    item, patron, loan = item_in_transit_martigny_patron_and_loan_for_pickup
+    # the following tests the circulation action CANCEL_REQUEST_4_1_1
+    # an item in_transit for pickup with no other pending loans. when a
+    # librarian wants to cancel the in_transit loan. action is permitted.
+    # update loan, item is: in_transit (IN_TRANSIT_TO_HOUSE).
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert loan['state'] == LoanState.ITEM_IN_TRANSIT_TO_HOUSE
+
+
+def test_cancel_item_request_on_item_in_transit_for_pickup_with_requests(
+        client, item2_in_transit_martigny_patron_and_loan_for_pickup,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel requests on an in_transit for pickup item with requests."""
+    item, patron, loan = item2_in_transit_martigny_patron_and_loan_for_pickup
+    # the following tests the circulation action CANCEL_REQUEST_4_1_2
+    # an item in_transit for pickup with other pending loans. when a
+    # librarian wants to cancel the in_transit loan. action is permitted.
+    # cancel loan, next pending loan is validated.
+
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.AT_DESK
+    assert loan['state'] == LoanState.CANCELLED
+    assert requested_loan['state'] == LoanState.ITEM_AT_DESK
+
+
+def test_cancel_pending_loan_on_item_in_transit_for_pickup_with_requests(
+        client, item3_in_transit_martigny_patron_and_loan_for_pickup,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel pending loan on an in_transit for pickup item."""
+    item, patron, loan = item3_in_transit_martigny_patron_and_loan_for_pickup
+    # the following tests the circulation action CANCEL_REQUEST_4_2
+    # an item in_transit for pickup with other pending loans. when a
+    # librarian wants to cancel the pending loan. action is permitted.
+    # item remains in_transit
+
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': requested_loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert loan['state'] == LoanState.ITEM_IN_TRANSIT_FOR_PICKUP
+    assert requested_loan['state'] == LoanState.CANCELLED
+
+
+def test_cancel_request_on_item_in_transit_to_house(
+        client, item_in_transit_martigny_patron_and_loan_to_house,
+        loc_public_martigny, librarian_martigny_no_email):
+    """Test cancel request loan on an in_transit to_house item."""
+    item, patron, loan = item_in_transit_martigny_patron_and_loan_to_house
+    # the following tests the circulation action CANCEL_REQUEST_5_1_1
+    # an item in_transit to house with no other loans. when a
+    # librarian wants to cancel the in_transit loan. action is permitted.
+    # the item will be checked in. at home, will go on_shelf
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    assert item.status == ItemStatus.ON_SHELF
+    assert loan['state'] == LoanState.CANCELLED
+
+
+def test_cancel_request_on_item_in_transit_to_house_with_requests(
+        client, item2_in_transit_martigny_patron_and_loan_to_house,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel request on an in_transit to_house item with requests."""
+    item, patron, loan = item2_in_transit_martigny_patron_and_loan_to_house
+    # the following tests the circulation action CANCEL_REQUEST_5_1_2
+    # an item in_transit to house with pending loans. when a
+    # librarian wants to cancel the in_transit loan. action is permitted.
+    # the loan will be cancelled. and first pending loan will be validated.
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.AT_DESK
+    assert loan['state'] == LoanState.CANCELLED
+    assert requested_loan['state'] == LoanState.ITEM_AT_DESK
+
+
+def test_cancel_pending_on_item_in_transit_to_house(
+        client, item3_in_transit_martigny_patron_and_loan_to_house,
+        loc_public_martigny, librarian_martigny_no_email,
+        patron2_martigny_no_email):
+    """Test cancel pending loan on an in_transit to_house item."""
+    item, patron, loan = item3_in_transit_martigny_patron_and_loan_to_house
+    # the following tests the circulation action CANCEL_REQUEST_5_2
+    # an item in_transit to house with pending loans. when a
+    # librarian wants to cancel the pending loan. action is permitted.
+    # the loan will be cancelled. and in_transit loan remains in transit.
+    params = {
+        'patron_pid': patron2_martigny_no_email.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid,
+        'pickup_location_pid': loc_public_martigny.pid
+    }
+    item, requested_loan = item_record_to_a_specific_loan_state(
+        item=item, loan_state=LoanState.PENDING,
+        params=params, copy_item=False)
+    assert requested_loan['state'] == LoanState.PENDING
+
+    params = {
+        'pid': requested_loan.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
+    }
+    item.cancel_item_request(**params)
+    item = Item.get_record_by_pid(item.pid)
+    loan = Loan.get_record_by_pid(loan.pid)
+    requested_loan = Loan.get_record_by_pid(requested_loan.pid)
+    assert item.status == ItemStatus.IN_TRANSIT
+    assert loan['state'] == LoanState.ITEM_IN_TRANSIT_TO_HOUSE
+    assert requested_loan['state'] == LoanState.CANCELLED


### PR DESCRIPTION
Takes part of the implementations of all actions after an effort
to modelize extensively all the circulation uses cases.

Implements all the `cancel item request` actions and use cases listed here:
https://github.com/rero/rero-ils/blob/dev/doc/circulation/actions.md

* Updates tests and fixtures accordingly.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1509?kanban-status=1224894

## Dependencies

`rero_ils.US1394-invenio-circulation`

## How to test?

code  review only

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
