### PR TITLE
document: adapt the importation REST API to the UI

### DIFF
--- a/rero_ils/modules/documents/api.py
+++ b/rero_ils/modules/documents/api.py
@@ -154,9 +154,13 @@ class Document(IlsRecord):
             cannot_delete['others'] = dict(harvested=True)
         return cannot_delete
 
-    def dumps(self, **kwargs):
-        """Return pure Python dictionary with record metadata."""
-        dump = super(Document, self).dumps(**kwargs)
+    @classmethod
+    def post_process(cls, dump):
+        """Post process data after a dump.
+
+        :param dump: a dictionary of a resulting Record dumps
+        "return: a modified dictionary
+        """
         provision_activities = dump.get('provisionActivity', [])
         for provision_activity in provision_activities:
             provision_activity['_text'] = \
@@ -180,6 +184,10 @@ class Document(IlsRecord):
         if document_type == 'journal':
             dump['issuance'] = 'rdami:1003'
         return dump
+
+    def dumps(self, **kwargs):
+        """Return pure Python dictionary with record metadata."""
+        return self.post_process(super(Document, self).dumps(**kwargs))
 
     def index_persons(self, bulk=False):
         """Index all attached persons."""

--- a/tests/api/test_external_services.py
+++ b/tests/api/test_external_services.py
@@ -62,18 +62,6 @@ def test_documents_get(client, document):
     assert data['hits']['hits'][0]['metadata'] == \
         document.replace_refs().dumps()
 
-    res = client.get(url_for(
-        'api_imports.imports_search',
-        q='9782070541270:any:ean'
-    ))
-    assert res.status_code == 200
-    assert get_json(res) == {
-        'aggregations': {},
-        'hits': {
-            'hits': [],
-            'total': 0
-        }
-    }
     list_url = url_for('invenio_records_rest.doc_list', q="Vincent Berthe")
     res = client.get(list_url)
     assert res.status_code == 200
@@ -100,85 +88,9 @@ def test_documents_import_bnf_ean(client):
     ))
     assert res.status_code == 200
     data = get_json(res).get('hits').get('hits')[0].get('metadata')
-    data.update({
-        "$schema": "https://ils.rero.ch/schemas/documents/document-v0.0.1.json"
-    })
-    assert data == {
-        '$schema':
-            'https://ils.rero.ch/schemas/documents/document-v0.0.1.json',
-        'authors': [
-            {'date': '1965-', 'name': 'Rowling, J. K.', 'type': 'person'},
-            {
-                'date': '1948-',
-                'name': 'Ménard, Jean-François',
-                'qualifier': 'romancier pour la jeunesse',
-                'type': 'person'
-            }
-        ],
-        'extent': '232 p.',
-        'dimensions': ['24 cm'],
-        'colorContent': ['rdacc:1003'],
-        'identifiedBy': [
-            {
-                'source': 'BNF',
-                'type': 'bf:Local',
-                'value': 'ark:/12148/cb37090396w'
-            },
-            {
-                'type': 'bf:Ean',
-                'value': '9782070541270'
-            }
-        ],
-        'language': [{'type': 'bf:Language', 'value': 'fre'}],
-        'note': [{
-            'noteType': 'otherPhysicalDetails',
-            'label': 'couv. ill. en coul.'
-        }],
-        'provisionActivity': [{
-            'type': 'bf:Publication',
-            'place': [
-                {
-                    'country': 're',
-                    'type': 'bf:Place'
-                }
-            ],
-            'statement': [
-                {
-                    'label': [
-                        {'value': '[Paris]'}
-                    ],
-                    'type': 'bf:Place'
-                },
-                {
-                    'label': [
-                        {'value': 'Gallimard'}
-                    ],
-                    'type': 'bf:Agent'
-                },
-                {
-                    'label': [
-                        {'value': '1999'}
-                    ],
-                    'type': 'Date'
-                },
-            ],
-            'startDate': 1999,
-        }],
-        'series': [{'name': 'Harry Potter.', 'number': '1'}],
-        'subjects': ['JnRoman'],
-        'title': [{
-            'mainTitle': [{'value': "Harry Potter à l'école des sorciers"}],
-            'type': 'bf:Title'
-        }],
-        'responsibilityStatement': [
-            [{'value': 'J. K. Rowling'}],
-            [{'value': "trad. de l'anglais par Jean-François Ménard"}]
-        ],
-        'titlesProper': ['Harry Potter'],
-        'translatedFrom': ['eng'],
-        'type': 'book'
-    }
+    assert data['pid'] == 'FRBNF370903960000006'
     assert Document.create(data)
+
     res = client.get(url_for(
         'api_imports.imports_search',
         q='ean:any:9782072862014'
@@ -191,108 +103,79 @@ def test_documents_import_bnf_ean(client):
     })
     assert Document.create(data)
     marc21_link = res_j.get('hits').get('hits')[0].get('links').get('marc21')
+
     res = client.get(marc21_link)
     data = get_json(res)
-    assert data == [
-        ['leader', '     cam  22        450 '],
-        ['001', 'FRBNF457899220000009'],
-        ['003', 'http://catalogue.bnf.fr/ark:/12148/cb457899220'],
-        ['010 __', [
-            ['a', '978-2-07-286201-4'],
-            ['b', 'br.'],
-            ['d', '4,90 EUR']
-        ]],
-        ['020 __', [['a', 'FR'], ['b', '01952290']]],
-        ['073 _0', [['a', '9782072862014']]],
-        ['100 __', [['a', '20190823d2019    m  y0frey50      ba']]],
-        ['101 0_', [['a', 'fre']]],
-        ['102 __', [['a', 'FR']]],
-        ['105 __', [['a', '||||z   00|y|']]],
-        ['106 __', [['a', 'r']]],
-        ['181 _0', [['6', '01'], ['a', 'i '], ['b', 'xxxe  ']]],
-        ['181 __', [['6', '02'], ['c', 'txt'], ['2', 'rdacontent']]],
-        ['182 _0', [['6', '01'], ['a', 'n']]],
-        ['182 __', [['6', '02'], ['c', 'n'], ['2', 'rdamedia']]],
-        ['200 1_', [
-            ['a', 'Les contemplations'],
-            ['b', 'Texte imprimé'],
-            ['f', 'Victor Hugo'],
-            ['g', 'édition établie et annotée par Pierre Albouy...'],
-            ['g', '[préface] par Charles Baudelaire']
-        ]],
-        ['210 __', [
-            ['a', '[Paris]'],
-            ['c', 'Gallimard'],
-            ['d', 'DL 2019'],
-            ['e', 'impr. en Espagne']]],
-        ['214 _0', [
-            ['a', '[Paris]'],
-            ['c', 'Gallimard'],
-            ['d', 'DL 2019']]],
-        ['214 _3', [['a', 'impr. en Espagne']]],
-        ['215 __', [['a', '1 vol. (534 p.)'], ['d', '18 cm']]],
-        ['225 |_', [['a', 'Folio'], ['i', 'Classique']]],
-        ['308 __', [['a', '6678']]],
-        ['410 _0', [
-            ['0', '34284640'],
-            ['t', 'Collection Folio. Classique'],
-            ['x', '1258-0449'],
-            ['d', '2019']
-        ]],
-        ['410 _0', [
-            ['0', '34234540'],
-            ['t', 'Collection Folio'],
-            ['x', '0768-0732'],
-            ['v', '6678']
-        ]],
-        ['500 11', [
-            ['3', '12044981'],
-            ['a', 'Les contemplations'],
-            ['m', 'français'],
-            ['2', 'lien automatique']]],
-        ['686 __', [
-            ['a', '801'],
-            [
-                '2',
-                'Cadre de classement de la Bibliographie nationale française'
-            ]
-        ]],
-        ['700 _|', [
-            ['3', '11907966'],
-            ['o', 'ISNI0000000121200982'],
-            ['a', 'Hugo'],
-            ['b', 'Victor'],
-            ['f', '1802-1885'],
-            ['4', '070']
-        ]],
-        ['702 _|', [
-            ['3', '11888332'],
-            ['o', 'ISNI0000000117709487'],
-            ['a', 'Albouy'],
-            ['b', 'Pierre'],
-            ['f', '1920-1974'],
-            ['4', '340']
-        ]],
-        ['702 _|', [
-            ['3', '11890582'],
-            ['o', 'ISNI0000000121221863'],
-            ['a', 'Baudelaire'],
-            ['b', 'Charles'],
-            ['f', '1821-1867'],
-            ['4', '080']
-        ]],
-        ['801 _0', [
-            ['a', 'FR'],
-            ['b', 'FR-751131015'],
-            ['c', '20190823'],
-            ['g', 'AFNOR'],
-            ['h', 'FRBNF457899220000009'],
-            ['2', 'intermrc']]],
-        ['930 __', [
-            ['5', 'FR-751131010:45789922001001'],
-            ['a', '2019-176511'],
-            ['b', '759999999'],
-            ['c', 'Tolbiac - Rez de Jardin - Littérature et art - Magasin'],
-            ['d', 'O']
-        ]]
-    ]
+    assert data[0][0] == 'leader'
+
+    res = client.get(url_for(
+        'api_imports.imports_search',
+        q=''
+    ))
+    assert res.status_code == 200
+    assert get_json(res) == {
+        'aggregations': {},
+        'hits': {
+            'hits': [],
+            'remote_total': 0,
+            'total': 0
+        }
+    }
+
+    res = client.get(url_for(
+        'api_imports.imports_search',
+        q='peter'
+    ))
+    assert res.status_code == 200
+    unfiltered_total = get_json(res)['hits']['remote_total']
+    assert get_json(res)
+
+    res = client.get(url_for(
+        'api_imports.imports_search',
+        q='peter',
+        year=2000,
+        format='rerojson'
+    ))
+    assert res.status_code == 200
+    get_json(res)['hits']['remote_total'] < unfiltered_total
+
+    res = client.get(url_for(
+        'api_imports.imports_search',
+        q='peter',
+        author='Peter Owen',
+        format='rerojson'
+    ))
+    assert res.status_code == 200
+    get_json(res)['hits']['remote_total'] < unfiltered_total
+
+    res = client.get(url_for(
+        'api_imports.imports_search',
+        q='peter',
+        type='book',
+        format='rerojson'
+    ))
+    assert res.status_code == 200
+    get_json(res)['hits']['remote_total'] < unfiltered_total
+
+    res = client.get(url_for(
+        'api_imports.imports_record',
+        id='FRBNF370903960000006'
+    ))
+    assert res.status_code == 200
+    assert get_json(res).get('metadata', {}).get('identifiedBy')
+
+    res = client.get(url_for(
+        'api_imports.imports_record',
+        id='FRBNF370903960000006',
+        format='rerojson'
+    ))
+    assert res.status_code == 200
+    assert get_json(res).get('metadata', {}).get('ui_title_text')
+
+    res = client.get(url_for(
+        'api_imports.imports_record',
+        id='FRBNF370903960000006',
+        format='marc'
+    ))
+    assert res.status_code == 200
+    assert get_json(res)[1][1] == 'FRBNF370903960000006'


### PR DESCRIPTION
* Splits the document dumps function to be usable to the serializers.
* Renames `/api/import/bnf` to `/api/import_bnf` to be usable by the UI.
* Fixes year aggregation filter by forcing the terms to be a string.
* Returns empty result for empty query.
* Sorts aggregations by term counts.
* Creates a post_process function in JSON serializers.
* Creates two serializers: one without extra data for the editor one
  with extra data for the document views.
* Adds a new not found result error handler.
* Makes the tests more robust to BNF changes.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/us/1274

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#286
* rero/ng-core#194

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
