### PR TITLE
documentation: add an issue template for dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/developers.md
+++ b/.github/ISSUE_TEMPLATE/developers.md
@@ -1,0 +1,19 @@
+---
+name: Developers issue report
+about: Create a report to help us improve
+title: 'Write a full sentence: This library should be used with this function.'
+labels: developers, triage
+assignees: ''
+
+---
+
+**Please, fill the bug report as precisely as possible, and remove unused
+sections. Thanks a lot for helping us!**
+
+**Describe the issue**
+
+A clear and concise description of what the issue is.
+
+**What should be done**
+
+A clear and concise description of what you think has to be done.


### PR DESCRIPTION
## Why are you opening this PR?

An issue template specific for dev is missing in 60c8b97. It allows developers
to open a purely technical issue.

## How to test?

Check the new file.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?

