### PR TITLE
circulation: ensure the add request action for frontend calls

### DIFF
--- a/rero_ils/modules/items/views.py
+++ b/rero_ils/modules/items/views.py
@@ -33,6 +33,7 @@ from ..documents.api import Document
 from ..item_types.api import ItemType
 from ..libraries.api import Library
 from ..locations.api import Location
+from ..patrons.api import current_patron
 from ...permissions import request_item_permission
 
 
@@ -106,7 +107,10 @@ def patron_request(viewcode, item_pid=None, pickup_location_pid=None):
     """
     data = {
         'item_pid': item_pid,
-        'pickup_location_pid': pickup_location_pid
+        'pickup_location_pid': pickup_location_pid,
+        'patron_pid': current_patron.pid,
+        'transaction_location_pid': pickup_location_pid,
+        'transaction_user_pid': current_patron.pid
     }
     item = Item.get_record_by_pid(data.get('item_pid'))
     item_data, action_applied = item.request(**data)

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -209,8 +209,10 @@ def test_item_holding_document_availability(
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
+            patron_pid=patron_martigny_no_email.pid,
             pickup_location_pid=loc_public_saxon.pid,
-            patron_pid=patron_martigny_no_email.pid
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200
@@ -346,8 +348,10 @@ def test_item_holding_document_availability(
         'api_item.librarian_request',
         dict(
             item_pid=item2_lib_martigny.pid,
+            patron_pid=patron2_martigny_no_email.pid,
             pickup_location_pid=loc_public_saxon.pid,
-            patron_pid=patron2_martigny_no_email.pid
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/test_circ_bug.py
+++ b/tests/api/test_circ_bug.py
@@ -54,7 +54,9 @@ def test_document_with_one_item_attached_bug(
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid
+            patron_pid=patron2_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200
@@ -134,7 +136,9 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid
+            patron_pid=patron2_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200
@@ -146,7 +150,9 @@ def test_document_with_items_attached_bug(client, librarian_martigny_no_email,
         dict(
             item_pid=item2_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid
+            patron_pid=patron2_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/test_items_in_transit.py
+++ b/tests/api/test_items_in_transit.py
@@ -67,7 +67,7 @@ def test_items_in_transit_between_libraries(
     assert item.get('status') == ItemStatus.ON_SHELF
 
 
-def test_item_multiple_transit(client, item_lib_martigny,
+def test_item_multiple_transit(client, item_lib_martigny, lib_martigny,
                                librarian_martigny_no_email,
                                patron_martigny_no_email, loc_public_martigny,
                                loc_public_saxon, loc_public_fully,
@@ -84,7 +84,9 @@ def test_item_multiple_transit(client, item_lib_martigny,
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_fully.pid,
-            patron_pid=patron2_martigny_no_email.pid
+            patron_pid=patron2_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200
@@ -125,7 +127,7 @@ def test_item_multiple_transit(client, item_lib_martigny,
 
 def test_auto_checkin_else(client, librarian_martigny_no_email,
                            patron_martigny_no_email, loc_public_martigny,
-                           item3_lib_martigny, json_header,
+                           item3_lib_martigny, json_header, lib_martigny,
                            loc_public_saxon):
     """Test item automatic checkin other scenarios."""
     login_user_via_session(client, librarian_martigny_no_email.user)
@@ -139,7 +141,9 @@ def test_auto_checkin_else(client, librarian_martigny_no_email,
         dict(
             item_pid=item3_lib_martigny.pid,
             pickup_location_pid=loc_public_saxon.pid,
-            patron_pid=patron_martigny_no_email.pid
+            patron_pid=patron_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         ),
     )
     assert res.status_code == 200

--- a/tests/api/test_loans_rest.py
+++ b/tests/api/test_loans_rest.py
@@ -223,7 +223,7 @@ def test_checkout_item_transit(client, item2_lib_martigny,
                                librarian_martigny_no_email,
                                librarian_saxon_no_email,
                                patron_martigny_no_email,
-                               loc_public_saxon,
+                               loc_public_saxon, lib_martigny,
                                loc_public_martigny,
                                circulation_policies):
     """Test checkout of an item in transit."""
@@ -245,7 +245,9 @@ def test_checkout_item_transit(client, item2_lib_martigny,
         dict(
             item_pid=item2_lib_martigny.pid,
             pickup_location_pid=loc_public_saxon.pid,
-            patron_pid=patron_martigny_no_email.pid
+            patron_pid=patron_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200
@@ -498,8 +500,8 @@ It should be the same date, even if timezone changed."
 
 
 def test_librarian_request_on_blocked_user(
-        client, item_lib_martigny,
-        librarian_martigny_no_email,
+        client, item_lib_martigny, lib_martigny,
+        librarian_martigny_no_email, loc_public_martigny,
         patron3_martigny_blocked_no_email,
         circulation_policies):
     """Librarian request on blocked user returns a specific 403 message."""
@@ -513,7 +515,10 @@ def test_librarian_request_on_blocked_user(
         'api_item.librarian_request',
         dict(
             item_pid=item_lib_martigny.pid,
-            patron_pid=patron3_martigny_blocked_no_email.pid
+            patron_pid=patron3_martigny_blocked_no_email.pid,
+            pickup_location_pid=loc_public_martigny,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 403

--- a/tests/api/test_notifications_rest.py
+++ b/tests/api/test_notifications_rest.py
@@ -306,7 +306,7 @@ def test_notifications_post_put_delete(
     notif.delete(dbcommit=True, delindex=True)
 
 
-def test_recall_notification(client, patron_martigny_no_email,
+def test_recall_notification(client, patron_martigny_no_email, lib_martigny,
                              json_header, patron2_martigny_no_email,
                              item_lib_martigny, librarian_martigny_no_email,
                              circulation_policies, loc_public_martigny):
@@ -335,7 +335,9 @@ def test_recall_notification(client, patron_martigny_no_email,
         dict(
             item_pid=item_lib_martigny.pid,
             pickup_location_pid=loc_public_martigny.pid,
-            patron_pid=patron2_martigny_no_email.pid
+            patron_pid=patron2_martigny_no_email.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/test_patrons_views.py
+++ b/tests/api/test_patrons_views.py
@@ -30,7 +30,7 @@ from rero_ils.modules.patrons.utils import user_has_patron
 
 def test_patron_can_delete(client, librarian_martigny_no_email,
                            patron_martigny_no_email, loc_public_martigny,
-                           item_lib_martigny, json_header,
+                           item_lib_martigny, json_header, lib_martigny,
                            circulation_policies):
     """Test patron can delete."""
     login_user_via_session(client, librarian_martigny_no_email.user)
@@ -49,7 +49,9 @@ def test_patron_can_delete(client, librarian_martigny_no_email,
         dict(
             item_pid=item.pid,
             pickup_location_pid=location.pid,
-            patron_pid=patron.pid
+            patron_pid=patron.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200

--- a/tests/ui/items/test_items_ui.py
+++ b/tests/ui/items/test_items_ui.py
@@ -29,7 +29,7 @@ def test_items_ui_permissions(client, item_lib_martigny,
                               loc_public_martigny,
                               patron_martigny_no_email, json_header,
                               circulation_policies):
-    """Test record retrieval."""
+    """Test patron request ui permissions."""
     item_pid = item_lib_martigny.pid
     pickup_location_pid = loc_public_martigny.pid
     request_url = url_for(

--- a/tests/ui/patrons/test_patrons_ui.py
+++ b/tests/ui/patrons/test_patrons_ui.py
@@ -30,7 +30,7 @@ from rero_ils.modules.loans.api import Loan, LoanState
 
 def test_patrons_profile(
         client, librarian_martigny_no_email, loan_pending_martigny,
-        lib_martigny, patron_martigny_no_email, loc_public_martigny,
+        patron_martigny_no_email, loc_public_martigny,
         item_type_standard_martigny, item_lib_martigny, json_header,
         circ_policy_short_martigny):
     """Test patron profile."""
@@ -49,7 +49,9 @@ def test_patrons_profile(
     data = {
         'patron_pid': patron_martigny_no_email.pid,
         'item_pid': item_lib_martigny.pid,
-        'pickup_location_pid': loc_public_martigny.pid
+        'pickup_location_pid': loc_public_martigny.pid,
+        'transaction_location_pid': loc_public_martigny.pid,
+        'transaction_user_pid': librarian_martigny_no_email.pid
     }
     loan = item_lib_martigny.request(**data)
     loan_pid = loan[1].get('request').get('pid')


### PR DESCRIPTION
Users have now the choice to give one of the transaction_location_pid
or transaction_library_pid when placing a request.

The add request action is now possible from the item views
and api views. The list of required parameters are clearly
noted for frontend calls.

This pull request starts the work of the refactoring of the
all circulation actions decorator add_loans_parameters_and_flush_indexes.

* Creates additional units testing for frontend calls.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
