### PR TITLE
circulation: ensure the cancel item request action for frontend calls

### DIFF
--- a/doc/circulation/actions.md
+++ b/doc/circulation/actions.md
@@ -2,6 +2,13 @@
 
 ## Add a request
 
+#### required_parameters:
+    item_pid_value,
+    pickup_location_pid,
+    patron_pid,
+    transaction_location_pid or transaction_library_pid,
+    transaction_user_pid
+
 1. :100: __ADD_REQUEST_1__: item on_shelf (no current loan)
     1. :white_check_mark: :white_check_mark: :white_check_mark: :white_check_mark: __ADD_REQUEST_1_1__: PENDING loan does not exist →  (add loan PENDING)
     1. __ADD_REQUEST_1_2__: PENDING loan exists
@@ -25,6 +32,46 @@
     1. __ADD_REQUEST_5_2__: PENDING loan exists
         1. __ADD_REQUEST_5_2_1__: request patron = current loan patron → request denied
         1. __ADD_REQUEST_5_2_2__: request patron != current loan patron →  (add loan PENDING)
+
+
+## Cancel request
+
+#### required_parameters:
+    pid (loan pid)
+    transaction_location_pid or transaction_library_pid,
+    transaction_user_pid
+
+1. :100: __CANCEL_REQUEST_1__: item on_shelf (no current loan)
+	1. __CANCEL_REQUEST_1_1__: PENDING loan does not exist → (cancel not possible)
+	1. __CANCEL_REQUEST_1_2__: PENDING loan exists → (cancel loan, item is: on_shelf)
+
+1. :100: __CANCEL_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK)
+	1. __CANCEL_REQUEST_2_1__: loan to cancel = current loan
+		1. __CANCEL_REQUEST_2_1_1__: PENDING loan does not exist Make it impossible to cancel loan from public interface. Future: make it possible and give an alert to the library that the item should not stayed at desk
+			1. __CANCEL_REQUEST_2_1_1_1__: item library != pickup location of current loan → (update loan to IN_TRANSIT_TO_HOUSE, item is: in_transit)
+			1. __CANCEL_REQUEST_2_1_1_2__: item library = pickup location of current loan → (cancel loan, item is: on_shelf)
+		1. __CANCEL_REQUEST_2_1_2__: PENDING loan exists
+			1. __CANCEL_REQUEST_2_1_2_1__: pickup location of 1st pending loan != pickup location of current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
+			1. __CANCEL_REQUEST_2_1_2_2__: pickup location of 1st pending loan = pickup location of current loan → (cancel loan, item is: at_desk (ITEM_AT_DESK))[automatic validate next PENDING loan]
+	1. __CANCEL_REQUEST_2_2__: loan to cancel != current loan → (cancel loan, item is: at desk)
+
+1. :100: __CANCEL_REQUEST_3__: item on_loan (ITEM_ON_LOAN)
+	1. __CANCEL_REQUEST_3_1__: loan to cancel = current loan → (cancel not possible)
+	1. __CANCEL_REQUEST_3_2__: loan to cancel != current loan → (cancel loan, item is: on_loan (ITEM_ON_LOAN))
+
+1. :100: __CANCEL_REQUEST_4__: item in_transit (IN_TRANSIT_FOR_PICKUP)
+	1. __CANCEL_REQUEST_4_1__: loan to cancel = current loan
+		1. __CANCEL_REQUEST_4_1_1__: PENDING loan does not exist → (update loan, item is: in_transit (IN_TRANSIT_TO_HOUSE))
+		1. __CANCEL_REQUEST_4_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate logic is applied next PENDING loan] 
+		
+	1. __CANCEL_REQUEST_4_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))
+
+1. :100: __CANCEL_REQUEST_5__: item in_transit (IN_TRANSIT_TO_HOUSE)
+	1. __CANCEL_REQUEST_5_1__: loan to cancel = current loan
+		1. __CANCEL_REQUEST_5_1_1__: PENDING loan does not exist → (checkin the IN_TRANSIT_TO_HOUSE loan, item will  go on shelf  and the loan is cancelled).
+		1. __CANCEL_REQUEST_5_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
+	1. __CANCEL_REQUEST_5_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_TO_HOUSE)) This use case should in principle never happen.
+
 
 ## Checkout form
 
@@ -108,39 +155,6 @@
 1. :100: __EXTEND_4__: item in_transit (IN_TRANSIT_FOR_PICKUP) →  (extend not possible)
 1. :100: __EXTEND_5__: item in_transit (IN_TRANSIT_TO_HOUSE) →  (extend not possible)
 
-## Cancel request
-
-
-1. :100: __CANCEL_REQUEST_1__: item on_shelf (no current loan)
-	1. __CANCEL_REQUEST_1_1__: PENDING loan does not exist → (cancel not possible)
-	1. __CANCEL_REQUEST_1_2__: PENDING loan exists → (cancel loan, item is: on_shelf)
-
-1. :100: __CANCEL_REQUEST_2__: item at_desk, requested (ITEM_AT_DESK)
-	1. __CANCEL_REQUEST_2_1__: loan to cancel = current loan
-		1. __CANCEL_REQUEST_2_1_1__: PENDING loan does not exist Make it impossible to cancel loan from public interface. Future: make it possible and give an alert to the library that the item should not stayed at desk
-			1. __CANCEL_REQUEST_2_1_1_1__: item library != pickup location of current loan → (update loan to IN_TRANSIT_TO_HOUSE, item is: in_transit)
-			1. __CANCEL_REQUEST_2_1_1_2__: item library = pickup location of current loan → (cancel loan, item is: on_shelf)
-		1. __CANCEL_REQUEST_2_1_2__: PENDING loan exists
-			1. __CANCEL_REQUEST_2_1_2_1__: pickup location of 1st pending loan != pickup location of current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
-			1. __CANCEL_REQUEST_2_1_2_2__: pickup location of 1st pending loan = pickup location of current loan → (cancel loan, item is: at_desk (ITEM_AT_DESK))[automatic validate next PENDING loan]
-	1. __CANCEL_REQUEST_2_2__: loan to cancel != current loan → (cancel loan, item is: at desk)
-
-1. :100: __CANCEL_REQUEST_3__: item on_loan (ITEM_ON_LOAN)
-	1. __CANCEL_REQUEST_3_1__: loan to cancel = current loan → (cancel not possible)
-	1. __CANCEL_REQUEST_3_2__: loan to cancel != current loan → (cancel loan, item is: on_loan (ITEM_ON_LOAN))
-
-1. :100: __CANCEL_REQUEST_4__: item in_transit (IN_TRANSIT_FOR_PICKUP)
-	1. __CANCEL_REQUEST_4_1__: loan to cancel = current loan
-		1. __CANCEL_REQUEST_4_1_1__: PENDING loan does not exist → (update loan, item is: in_transit (IN_TRANSIT_TO_HOUSE))
-		1. __CANCEL_REQUEST_4_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate logic is applied next PENDING loan] 
-		
-	1. __CANCEL_REQUEST_4_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))
-
-1. :100: __CANCEL_REQUEST_5__: item in_transit (IN_TRANSIT_TO_HOUSE)
-	1. __CANCEL_REQUEST_5_1__: loan to cancel = current loan
-		1. __CANCEL_REQUEST_5_1_1__: PENDING loan does not exist → (checkin the IN_TRANSIT_TO_HOUSE loan, item will  go on shelf  and the loan is cancelled).
-		1. __CANCEL_REQUEST_5_1_2__: PENDING loan exists → (cancel loan, item is: in_transit (IN_TRANSIT_FOR_PICKUP))[automatic validate next PENDING loan]
-	1. __CANCEL_REQUEST_5_2__: loan to cancel != current loan → (cancel loan, item is: in_transit (IN_TRANSIT_TO_HOUSE)) This use case should in principle never happen.
 
 
 ## Change request pickup location

--- a/rero_ils/modules/loans/api.py
+++ b/rero_ils/modules/loans/api.py
@@ -122,6 +122,11 @@ class Loan(IlsRecord):
                 'transaction_location_pid',
                 'transaction_user_pid',
                 'pid'
+            ],
+            'cancel_loan': [
+                'transaction_location_pid',
+                'transaction_user_pid',
+                'pid'
             ]
         }
         return params.get(action)

--- a/rero_ils/modules/patrons/views.py
+++ b/rero_ils/modules/patrons/views.py
@@ -157,9 +157,13 @@ def profile(viewcode):
         item = Item.get_record_by_pid(loan.get('item_pid', {}).get('value'))
         if request.form.get('type') == 'cancel':
             tab = 'pendings'
-            data = loan
+            cancel_params = {
+                'pid': loan.pid,
+                'transaction_location_pid': item.location_pid,
+                'transaction_user_pid': patron.pid
+            }
             try:
-                item.cancel_loan(**data)
+                item.cancel_item_request(**cancel_params)
                 flash(_('The request for item %(item_id)s has been canceled.',
                         item_id=item.pid), 'success')
             except Exception:

--- a/tests/api/circulation/test_actions_views_add_request.py
+++ b/tests/api/circulation/test_actions_views_add_request.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests REST API methods in the item api_views."""
+"""Tests REST librarian request API methods in the item api_views."""
 
 
 from invenio_accounts.testutils import login_user_via_session

--- a/tests/api/circulation/test_actions_views_cancel_request.py
+++ b/tests/api/circulation/test_actions_views_cancel_request.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# RERO ILS
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests REST cancel item request API methods in the item api_views."""
+
+
+from invenio_accounts.testutils import login_user_via_session
+from utils import postdata
+
+from rero_ils.modules.loans.api import Loan, LoanAction, LoanState, \
+    get_last_transaction_loc_for_item, get_loans_by_patron_pid
+
+
+def test_cancel_an_item_request(
+        client, librarian_martigny_no_email, lib_martigny,
+        item_at_desk_martigny_patron_and_loan_at_desk,
+        item_on_shelf_martigny_patron_and_loan_pending, loc_public_martigny,
+        circulation_policies):
+    """Test the frontend cancel an item request action."""
+    # test passes when all required parameters are given
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item, patron, loan = item_on_shelf_martigny_patron_and_loan_pending
+
+    # test fails when there is a missing required parameter
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            pid=loan.pid
+        )
+    )
+    assert res.status_code == 400
+
+    # test fails when there is a missing required parameter
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            pid=loan.pid,
+            transaction_location_pid=loc_public_martigny.pid
+        )
+    )
+    assert res.status_code == 400
+
+    # test fails when there is a missing required parameter
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 400
+
+    # test passes when the transaction location pid is given
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            pid=loan.pid,
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 200
+
+    # test passes when the transaction library pid is given
+    login_user_via_session(client, librarian_martigny_no_email.user)
+    item, patron, loan = item_at_desk_martigny_patron_and_loan_at_desk
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            pid=loan.pid,
+            transaction_library_pid=lib_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 200

--- a/tests/api/test_circ_bug.py
+++ b/tests/api/test_circ_bug.py
@@ -76,13 +76,13 @@ def test_document_with_one_item_attached_bug(
     assert res.status_code == 200
 
     assert item_lib_martigny.number_of_requests() == 1
-
     res, data = postdata(
         client,
-        'api_item.cancel_loan',
+        'api_item.cancel_item_request',
         dict(
-            item_pid=item_lib_martigny.pid,
-            pid=loan2_pid
+            pid=loan2_pid,
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
         )
     )
     assert res.status_code == 200

--- a/tests/api/test_items_in_transit.py
+++ b/tests/api/test_items_in_transit.py
@@ -170,8 +170,18 @@ def test_auto_checkin_else(client, librarian_martigny_no_email,
     assert 'no' in actions
     assert actions['no']['pid'] == loan_pid
 
-    item.cancel_loan(pid=loan_pid)
-    assert item.status == ItemStatus.ON_SHELF
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            pid=loan_pid,
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 200
+    # TODO check this when automatic_checkin is replaced by checkin
+    assert item.status == ItemStatus.IN_TRANSIT
 
 
 def test_checkout_in_transit_return_same_library(

--- a/tests/api/test_patrons_views.py
+++ b/tests/api/test_patrons_views.py
@@ -65,7 +65,16 @@ def test_patron_can_delete(client, librarian_martigny_no_email,
     reasons = patron_martigny_no_email.reasons_not_to_delete()
     assert 'links' in reasons
 
-    item.cancel_loan(pid=loan_pid)
+    res, data = postdata(
+        client,
+        'api_item.cancel_item_request',
+        dict(
+            pid=loan_pid,
+            transaction_location_pid=loc_public_martigny.pid,
+            transaction_user_pid=librarian_martigny_no_email.pid
+        )
+    )
+    assert res.status_code == 200
     assert item.status == ItemStatus.ON_SHELF
 
 


### PR DESCRIPTION
Replaces the cancel_loan method by cancel_item_request

Users have now the choice to give one of the transaction_location_pid
or transaction_library_pid when placing a request.

The cancel item request action is now possible from the item views
and api views. The list of required parameters are clearly
noted for frontend calls in the actions.md and api_views.

* Creates additional units testing for frontend calls.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on the following `rero-ils-ui`'s PR(s):

* rero/rero-ils-ui#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
