### PR TITLE
editor: fix edition statement saving problem.

### DIFF
--- a/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
+++ b/rero_ils/modules/documents/jsonschemas/documents/document-v0.0.1.json
@@ -524,9 +524,15 @@
             "items": {
               "title": "Responsibility",
               "$ref": "#/definitions/language_script"
+            },
+            "form": {
+              "hide": true
             }
           }
-        }
+        },
+        "required": [
+          "editionDesignation"
+        ]
       },
       "form": {
         "hide": true,


### PR DESCRIPTION
According to PO, the 'responsibilities' field from document 'edition
statement' should be optional in the editor form. This commit hides this
field (if it's empty) so, now, the user must choose to add this field
(and fill a value). Editing a document without 'responsibilities' is now
allowed by default.

* Closes rero/rero-ils#906

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Try to edit a document without edition designation (`documents/249`)
- The 'responsibilities' field from 'edition statements' array is now hide by default --> you can save without fill any value.
- Try to edit again the save document. Add a 'responsibilities' and save the document.
- Try to edit again, the 'responsibilities' field is well displayed and filled with correct data. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
